### PR TITLE
adds implementation of TypeCache

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
 use crate::result::{invalid_schema_error_raw, IonSchemaResult};
-use crate::system::SharedTypeCache;
-use crate::types::{Type, TypeRef};
+use crate::system::{SharedTypeCache, TypeId};
+use crate::types::TypeRef;
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, Sequence};
@@ -26,11 +26,11 @@ pub enum Constraint {
 /// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#all_of
 #[derive(Debug, Clone)]
 pub struct AllOfConstraint {
-    type_references: Vec<Type>,
+    type_references: Vec<TypeId>,
 }
 
 impl AllOfConstraint {
-    pub fn new(types: Vec<Type>) -> Self {
+    pub fn new(types: Vec<TypeId>) -> Self {
         Self {
             type_references: types,
         }
@@ -54,10 +54,10 @@ impl AllOfConstraint {
             .map(|e| TypeRef::parse_from_ion_element(e, type_cache))
             .collect::<IonSchemaResult<Vec<TypeRef>>>()?;
 
-        let resolved_types: Vec<Type> = types
+        let resolved_types: Vec<TypeId> = types
             .iter()
             .map(|t| TypeRef::resolve_type_reference(t, type_cache))
-            .collect::<IonSchemaResult<Vec<Type>>>()?;
+            .collect::<IonSchemaResult<Vec<TypeId>>>()?;
         Ok(AllOfConstraint::new(resolved_types.to_owned()))
     }
 }
@@ -72,11 +72,11 @@ impl ConstraintValidator for AllOfConstraint {
 /// [type]: https://amzn.github.io/ion-schema/docs/spec.html#type
 #[derive(Debug, Clone)]
 pub struct TypeConstraint {
-    type_reference: Type,
+    type_reference: TypeId,
 }
 
 impl TypeConstraint {
-    pub fn new(type_reference: Type) -> Self {
+    pub fn new(type_reference: TypeId) -> Self {
         Self { type_reference }
     }
 
@@ -92,8 +92,8 @@ impl TypeConstraint {
             )));
         }
         let type_reference: TypeRef = TypeRef::parse_from_ion_element(ion, type_cache)?;
-        let type_def = TypeRef::resolve_type_reference(&type_reference, type_cache)?;
-        Ok(TypeConstraint::new(type_def))
+        let type_id = TypeRef::resolve_type_reference(&type_reference, type_cache)?;
+        Ok(TypeConstraint::new(type_id))
     }
 }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,5 +1,5 @@
 use crate::result::{invalid_schema_error_raw, IonSchemaResult};
-use crate::system::{SharedTypeCache, TypeId};
+use crate::system::{SharedTypeStore, TypeId};
 use crate::types::TypeRef;
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
@@ -26,20 +26,18 @@ pub enum Constraint {
 /// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#all_of
 #[derive(Debug, Clone)]
 pub struct AllOfConstraint {
-    type_references: Vec<TypeId>,
+    type_ids: Vec<TypeId>,
 }
 
 impl AllOfConstraint {
-    pub fn new(types: Vec<TypeId>) -> Self {
-        Self {
-            type_references: types,
-        }
+    pub fn new(type_ids: Vec<TypeId>) -> Self {
+        Self { type_ids }
     }
 
     /// Tries to create an [AllOf] constraint from the given OwnedElement
     pub fn parse_from_ion_element(
         ion: &OwnedElement,
-        type_cache: &SharedTypeCache,
+        type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
         if ion.ion_type() != IonType::List {
             return Err(invalid_schema_error_raw(format!(
@@ -51,12 +49,12 @@ impl AllOfConstraint {
             .as_sequence()
             .unwrap()
             .iter()
-            .map(|e| TypeRef::parse_from_ion_element(e, type_cache))
+            .map(|e| TypeRef::parse_from_ion_element(e, type_store))
             .collect::<IonSchemaResult<Vec<TypeRef>>>()?;
 
         let resolved_types: Vec<TypeId> = types
             .iter()
-            .map(|t| TypeRef::resolve_type_reference(t, type_cache))
+            .map(|t| TypeRef::resolve_type_reference(t, type_store))
             .collect::<IonSchemaResult<Vec<TypeId>>>()?;
         Ok(AllOfConstraint::new(resolved_types.to_owned()))
     }
@@ -72,18 +70,18 @@ impl ConstraintValidator for AllOfConstraint {
 /// [type]: https://amzn.github.io/ion-schema/docs/spec.html#type
 #[derive(Debug, Clone)]
 pub struct TypeConstraint {
-    type_reference: TypeId,
+    type_id: TypeId,
 }
 
 impl TypeConstraint {
-    pub fn new(type_reference: TypeId) -> Self {
-        Self { type_reference }
+    pub fn new(type_id: TypeId) -> Self {
+        Self { type_id }
     }
 
     /// Tries to create a [Type] constraint from the given OwnedElement
     pub fn parse_from_ion_element(
         ion: &OwnedElement,
-        type_cache: &SharedTypeCache,
+        type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
         if ion.ion_type() != IonType::Symbol && ion.ion_type() != IonType::Struct {
             return Err(invalid_schema_error_raw(format!(
@@ -91,8 +89,8 @@ impl TypeConstraint {
                 ion.ion_type()
             )));
         }
-        let type_reference: TypeRef = TypeRef::parse_from_ion_element(ion, type_cache)?;
-        let type_id = TypeRef::resolve_type_reference(&type_reference, type_cache)?;
+        let type_reference: TypeRef = TypeRef::parse_from_ion_element(ion, type_store)?;
+        let type_id = TypeRef::resolve_type_reference(&type_reference, type_store)?;
         Ok(TypeConstraint::new(type_id))
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,5 @@
 use crate::import::Import;
-use crate::system::TypeCache;
+use crate::system::TypeStore;
 use crate::types::Type;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -13,11 +13,11 @@ use std::rc::Rc;
 pub struct Schema {
     id: String,
     imports: Vec<Rc<Schema>>, //TODO: Use HashMap for imports
-    types: TypeCache,
+    types: Rc<TypeStore>,
 }
 
 impl Schema {
-    pub fn new<A: AsRef<str>>(id: A, types: TypeCache) -> Self {
+    pub(crate) fn new<A: AsRef<str>>(id: A, types: Rc<TypeStore>) -> Self {
         Self {
             id: id.as_ref().to_owned(),
             imports: vec![],
@@ -46,8 +46,8 @@ impl Schema {
 
     /// Returns the requested type, if present in this schema;
     /// otherwise returns None.
-    fn get_type(&self, name: String) -> Option<&Type> {
-        self.types.get_type_by_name(&name)
+    fn get_type<A: AsRef<str>>(&self, name: A) -> Option<&Type> {
+        self.types.get_type_by_name(name.as_ref())
     }
 
     //TODO: change get_types() return type to SchemaTypeIterator and define SchemaTypeIterator

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::import::Import;
+use crate::system::TypeCache;
 use crate::types::Type;
-use std::collections::hash_map::IntoIter;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -13,15 +13,15 @@ use std::rc::Rc;
 pub struct Schema {
     id: String,
     imports: Vec<Rc<Schema>>, //TODO: Use HashMap for imports
-    types: HashMap<String, Type>,
+    types: TypeCache,
 }
 
 impl Schema {
-    pub fn new<A: AsRef<str>>(id: A, types: IntoIter<String, Type>) -> Self {
+    pub fn new<A: AsRef<str>>(id: A, types: TypeCache) -> Self {
         Self {
             id: id.as_ref().to_owned(),
             imports: vec![],
-            types: types.collect(),
+            types,
         }
     }
 
@@ -47,13 +47,13 @@ impl Schema {
     /// Returns the requested type, if present in this schema;
     /// otherwise returns None.
     fn get_type(&self, name: String) -> Option<&Type> {
-        self.types.get(&name)
+        self.types.get_type_by_name(&name)
     }
 
     //TODO: change get_types() return type to SchemaTypeIterator and define SchemaTypeIterator
     /// Returns an iterator over the types in this schema.
     pub(crate) fn get_types(&self) -> &HashMap<String, Type> {
-        &self.types
+        todo!()
     }
 
     /// Returns a new [Schema] instance containing all the types of this

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
 use crate::result::{invalid_schema_error_raw, unresolvable_schema_error, IonSchemaResult};
-use crate::system::{SharedTypeCache, TypeId};
+use crate::system::{SharedTypeStore, TypeId};
 use crate::violation::Violations;
 use ion_rs::value::owned::{OwnedElement, OwnedStruct};
 use ion_rs::value::{Element, Struct, SymbolToken};
@@ -43,7 +43,7 @@ impl Type {
     /// Parse constraints inside an [OwnedStruct] to a schema [Type]
     pub fn parse_from_ion_element(
         ion_struct: &OwnedStruct,
-        type_cache: &SharedTypeCache,
+        type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
 
@@ -71,12 +71,12 @@ impl Type {
             let constraint = match constraint_name {
                 "all_of" => {
                     let all_of: AllOfConstraint =
-                        AllOfConstraint::parse_from_ion_element(value, type_cache)?;
+                        AllOfConstraint::parse_from_ion_element(value, type_store)?;
                     Constraint::AllOf(all_of)
                 }
                 "type" => {
                     let type_constraint: TypeConstraint =
-                        TypeConstraint::parse_from_ion_element(value, type_cache)?;
+                        TypeConstraint::parse_from_ion_element(value, type_store)?;
                     Constraint::Type(type_constraint)
                 }
                 _ => {
@@ -91,11 +91,7 @@ impl Type {
             };
             constraints.push(constraint);
         }
-        let type_def = Type::new(type_name.to_owned(), constraints);
-        type_cache
-            .borrow_mut()
-            .add_named_type(&type_name, type_def.to_owned());
-        Ok(type_def.to_owned())
+        Ok(Type::new(type_name.to_owned(), constraints))
     }
 }
 
@@ -129,7 +125,7 @@ impl TypeRef {
     /// Tries to create a schema type reference from the given OwnedElement
     pub fn parse_from_ion_element(
         value: &OwnedElement,
-        type_cache: &SharedTypeCache,
+        type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
         match value.ion_type() {
             IonType::Symbol => {
@@ -163,30 +159,30 @@ impl TypeRef {
             IonType::Struct =>
                 Ok(TypeRef::AnonymousType(Type::parse_from_ion_element(value
                                            .as_struct()
-                                           .unwrap(), type_cache)?)),
+                                           .unwrap(), type_store)?)),
             _ => Err(invalid_schema_error_raw(
                 "type reference can either be a symbol(For base/alias type reference) or a struct (for anonymous type reference)",
             )),
         }
     }
 
-    /// Resolves a type_reference into a [Type] that can be using the type_cache
+    /// Resolves a type_reference into a [Type] that can be using the type_store
     pub fn resolve_type_reference(
         type_reference: &TypeRef,
-        type_cache: &SharedTypeCache,
+        type_store: &SharedTypeStore,
     ) -> IonSchemaResult<TypeId> {
         match type_reference {
             TypeRef::IslCoreType(ion_type) => {
                 // TODO: create CoreType struct for storing ISLCoreType type definition instead of Type
-                // inserts ISLCoreType as a Type into type_cache
-                Ok(type_cache.borrow_mut().add_named_type(
+                // inserts ISLCoreType as a Type into type_store
+                Ok(type_store.borrow_mut().add_named_type(
                     &format!("{:?}", ion_type),
                     Type::new(format!("{:?}", ion_type), vec![]),
                 ))
             }
             TypeRef::AliasType(alias) => {
-                // verify if the AliasType actually exists in the type_cache or throw an error
-                match type_cache.borrow_mut().get_type_id_by_name(alias) {
+                // verify if the AliasType actually exists in the type_store or throw an error
+                match type_store.borrow_mut().get_type_id_by_name(alias) {
                     Some(type_id) => Ok(type_id.to_owned()),
                     None => unresolvable_schema_error(format!(
                         "Could not resolve type reference: {:?} does not exist",
@@ -194,7 +190,7 @@ impl TypeRef {
                     )),
                 }
             }
-            TypeRef::AnonymousType(type_def) => Ok(type_cache
+            TypeRef::AnonymousType(type_def) => Ok(type_store
                 .borrow_mut()
                 .add_anonymous_type(type_def.to_owned())),
             //TODO: add a check for ImportType type reference here


### PR DESCRIPTION
*Issue #15*

*Description of changes:*
This PR works on implementation of  `TypeCache`.

*Change:*
- creates a struct `TypeCache` which helps with the cycling issue as described in #15.
- creates a type `TypeId` which represents the index/id for Types stores in `TypeCache`.
- modifies the `Constraint`s to store `Vec<TypeId>` instead of `Vec<Type>`.
- modifies `Scehma` struct to store the `TypeCache` that is created while loading the schema instead of a `HashMap<String, Type>`. (This `TypeCache` will help in resolving the `TypeId`s while validation)
- modifies get_types() in Schema as it needs to return an Iterator and not the `HashMap`/ `TypeCache` stored inside `Schema`.(I will work on this on next PR)
