### PR TITLE
adds SchemaTypeIterator implementation

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,8 +1,8 @@
 use crate::import::Import;
 use crate::system::TypeStore;
 use crate::types::Type;
-use std::collections::HashMap;
 use std::rc::Rc;
+use std::slice::Iter;
 
 /// A Schema is a collection of zero or more [Type]s.
 ///
@@ -50,10 +50,11 @@ impl Schema {
         self.types.get_type_by_name(name.as_ref())
     }
 
-    //TODO: change get_types() return type to SchemaTypeIterator and define SchemaTypeIterator
     /// Returns an iterator over the types in this schema.
-    pub(crate) fn get_types(&self) -> &HashMap<String, Type> {
-        todo!()
+    pub(crate) fn get_types(&self) -> SchemaTypeIterator {
+        SchemaTypeIterator {
+            types: self.types.get_types().iter(),
+        }
     }
 
     /// Returns a new [Schema] instance containing all the types of this
@@ -62,5 +63,18 @@ impl Schema {
     /// from this instance.
     fn plus_type(&self, schema_type: Type) -> Self {
         todo!()
+    }
+}
+
+/// Provides an Iterator which returns [Type]s inside a [Schema]
+pub struct SchemaTypeIterator<'a> {
+    types: Iter<'a, Type>,
+}
+
+impl<'a> Iterator for SchemaTypeIterator<'a> {
+    type Item = &'a Type;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.types.next()
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -31,6 +31,11 @@ impl TypeStore {
         }
     }
 
+    /// Returns [Type]s stored in the [TypeStore] to be used by [SchemaTypeIterator]
+    pub fn get_types(&self) -> &[Type] {
+        &self.types_by_id
+    }
+
     /// Provides the [Type] associated with given name if it exists in the [TypeStore]  
     /// Otherwise returns None
     pub fn get_type_by_name(&self, name: &str) -> Option<&Type> {


### PR DESCRIPTION
*Issue #18*

*Description of changes:*
This PR works on implementation of `SchemaTypeIterator` which can be used by `Schema` to return associated `Type`s.

*Changes:*
- adds a new struct `SchemaTypeIterator` and its `Iterator` implementation.
- adds a new method in `TypeStore` to return all the `Type`s stored inside it.
- changed `get_types` signature to return `SchemaTypeIterator` instead of `HashMap`.
