### PR TITLE
adds changes for constructing types/constraints programmatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2018"
 [dependencies]
 ion-rs = "0.6.0"
 thiserror = "1.0"
+
+
+[dev-dependencies]
+rstest = "0.9"

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::IslTypeRef;
 use crate::result::IonSchemaResult;
-use crate::system::{SharedTypeStore, TypeId};
+use crate::system::{SharedContext, SharedTypeStore, TypeId};
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
 
@@ -13,7 +13,7 @@ pub trait ConstraintValidator {
 }
 
 /// Defines schema Constraints
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 // TODO: add other constraints
 pub enum Constraint {
     AllOf(AllOfConstraint),
@@ -36,10 +36,11 @@ impl AllOfConstraint {
     pub fn resolve_from_isl_constraint(
         type_references: &[IslTypeRef],
         type_store: &SharedTypeStore,
+        context: &SharedContext,
     ) -> IonSchemaResult<Self> {
         let resolved_types: Vec<TypeId> = type_references
             .iter()
-            .map(|t| IslTypeRef::resolve_type_reference(t, type_store))
+            .map(|t| IslTypeRef::resolve_type_reference(t, type_store, context))
             .collect::<IonSchemaResult<Vec<TypeId>>>()?;
         Ok(AllOfConstraint::new(resolved_types))
     }
@@ -48,6 +49,12 @@ impl AllOfConstraint {
 impl ConstraintValidator for AllOfConstraint {
     fn validate(&self, value: OwnedElement, issues: &mut Violations) {
         todo!()
+    }
+}
+
+impl PartialEq for AllOfConstraint {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_ids == other.type_ids
     }
 }
 
@@ -67,8 +74,9 @@ impl TypeConstraint {
     pub fn resolve_from_isl_constraint(
         type_reference: &IslTypeRef,
         type_store: &SharedTypeStore,
+        context: &SharedContext,
     ) -> IonSchemaResult<Self> {
-        let type_id = IslTypeRef::resolve_type_reference(type_reference, type_store)?;
+        let type_id = IslTypeRef::resolve_type_reference(type_reference, type_store, context)?;
         Ok(TypeConstraint::new(type_id))
     }
 }
@@ -76,5 +84,11 @@ impl TypeConstraint {
 impl ConstraintValidator for TypeConstraint {
     fn validate(&self, value: OwnedElement, issues: &mut Violations) {
         todo!()
+    }
+}
+
+impl PartialEq for TypeConstraint {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_id == other.type_id
     }
 }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::IslTypeRef;
 use crate::result::IonSchemaResult;
-use crate::system::{SharedContext, SharedTypeStore, TypeId};
+use crate::system::{SharedPendingTypes, SharedTypeStore, TypeId};
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
 
@@ -36,7 +36,7 @@ impl AllOfConstraint {
     pub fn resolve_from_isl_constraint(
         type_references: &[IslTypeRef],
         type_store: &SharedTypeStore,
-        context: &SharedContext,
+        context: &SharedPendingTypes,
     ) -> IonSchemaResult<Self> {
         let resolved_types: Vec<TypeId> = type_references
             .iter()
@@ -74,7 +74,7 @@ impl TypeConstraint {
     pub fn resolve_from_isl_constraint(
         type_reference: &IslTypeRef,
         type_store: &SharedTypeStore,
-        context: &SharedContext,
+        context: &SharedPendingTypes,
     ) -> IonSchemaResult<Self> {
         let type_id = IslTypeRef::resolve_type_reference(type_reference, type_store, context)?;
         Ok(TypeConstraint::new(type_id))

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -33,7 +33,7 @@ impl AllOfConstraint {
     }
 
     /// Tries to create an [AllOf] constraint from the given OwnedElement
-    pub fn parse_from_isl_constraint(
+    pub fn resolve_from_isl_constraint(
         type_references: &[IslTypeRef],
         type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
@@ -41,7 +41,7 @@ impl AllOfConstraint {
             .iter()
             .map(|t| IslTypeRef::resolve_type_reference(t, type_store))
             .collect::<IonSchemaResult<Vec<TypeId>>>()?;
-        Ok(AllOfConstraint::new(resolved_types.to_owned()))
+        Ok(AllOfConstraint::new(resolved_types))
     }
 }
 
@@ -64,7 +64,7 @@ impl TypeConstraint {
     }
 
     /// Tries to create a [Type] constraint from the given OwnedElement
-    pub fn parse_from_isl_constraint(
+    pub fn resolve_from_isl_constraint(
         type_reference: &IslTypeRef,
         type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {

--- a/src/isl.rs
+++ b/src/isl.rs
@@ -201,7 +201,9 @@ impl IslTypeRef {
                 }
             }
             IslTypeRef::AnonymousType(isl_type) => {
-                let type_def = TypeDefinition::parse_from_isl_type(isl_type, type_store)?;
+                let type_def = TypeDefinition::parse_from_isl_type_and_update_type_store(
+                    isl_type, type_store,
+                )?;
                 Ok(type_store.borrow_mut().add_anonymous_type(type_def))
             } //TODO: add a check for ImportType type reference here
         }

--- a/src/isl.rs
+++ b/src/isl.rs
@@ -1,0 +1,209 @@
+use crate::result::{
+    invalid_schema_error_raw, unresolvable_schema_error, IonSchemaError, IonSchemaResult,
+};
+use crate::system::{SharedTypeStore, TypeId};
+use crate::types::TypeDefinition;
+use ion_rs::value::owned::{OwnedElement, OwnedStruct};
+use ion_rs::value::{Element, Sequence, Struct, SymbolToken};
+use ion_rs::IonType;
+use std::convert::{TryFrom, TryInto};
+
+/// Represents a public facing API for schema constraints [IslConstraint] which stores IslTypeRef
+#[derive(Debug, Clone)]
+pub enum IslConstraint {
+    AllOf(Vec<IslTypeRef>),
+    Type(IslTypeRef),
+}
+
+/// Represents a public facing schema type [IslType] which can be converted to a solid TypeRef using TypeStore
+#[derive(Debug, Clone)]
+pub struct IslType {
+    name: Option<String>,
+    constraints: Vec<IslConstraint>,
+}
+
+impl IslType {
+    pub fn new(name: Option<String>, constraints: Vec<IslConstraint>) -> Self {
+        Self { name, constraints }
+    }
+
+    pub fn name(&self) -> &Option<String> {
+        &self.name
+    }
+
+    pub fn constraints(&self) -> &[IslConstraint] {
+        &self.constraints
+    }
+}
+
+/// Parse constraints inside an [OwnedStruct] to an [IslType]
+impl TryFrom<&OwnedStruct> for IslType {
+    type Error = IonSchemaError;
+
+    fn try_from(ion_struct: &OwnedStruct) -> Result<Self, Self::Error> {
+        let mut constraints = vec![];
+
+        // parses the name of the type specified by schema
+        let type_name: Option<String>=  match ion_struct.get("name") {
+            Some(name_element) => match name_element.as_str() {
+                Some(name) => Some(name.to_owned()),
+                None => { return Err(invalid_schema_error_raw("A type name is not string/symbol, if the value is any null, or the text of the symbol is not defined.")) }
+            },
+            None => None // If the type is UNNAMED_TYPE_DEFINITION/ AnonymousType then set name as None
+        };
+
+        // parses all the constraints inside a Type
+        for (field_name, value) in ion_struct.iter() {
+            let constraint_name = match field_name.text() {
+                Some("name") => continue, // if the field_name is "name" then it's the type name not a constraint
+                Some(name) => name,
+                None => {
+                    return Err(invalid_schema_error_raw(
+                        "A type name symbol token does not have any text",
+                    ))
+                }
+            };
+            // TODO: add more constraints to match below
+            let constraint = match constraint_name {
+                "all_of" => {
+                    if value.ion_type() != IonType::List {
+                        return Err(invalid_schema_error_raw(format!(
+                            "all_of constraint was a {:?} instead of a list",
+                            value.ion_type()
+                        )));
+                    }
+                    let types: Vec<IslTypeRef> = value
+                        .as_sequence()
+                        .unwrap()
+                        .iter()
+                        .map(|e| IslTypeRef::parse_from_ion_element(e))
+                        .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?;
+                    IslConstraint::AllOf(types)
+                }
+                "type" => {
+                    if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
+                        return Err(invalid_schema_error_raw(format!(
+                            "type constraint was a {:?} instead of a symbol/struct",
+                            value.ion_type()
+                        )));
+                    }
+                    let type_reference: IslTypeRef = IslTypeRef::parse_from_ion_element(value)?;
+                    IslConstraint::Type(type_reference)
+                }
+                _ => {
+                    return Err(invalid_schema_error_raw(
+                        "Type: ".to_owned()
+                            + &type_name.unwrap()
+                            + " can not be built as constraint: "
+                            + constraint_name
+                            + " does not exist",
+                    ))
+                }
+            };
+            constraints.push(constraint);
+        }
+        Ok(IslType::new(type_name.to_owned(), constraints))
+    }
+}
+
+/// Provides an internal representation of schema type reference.
+/// Type reference grammar is defined in [Ion Schema Spec]
+/// [Ion Schema spec]: https://amzn.github.io/ion-schema/docs/spec.html#grammar
+#[derive(Debug, Clone)]
+pub enum IslTypeRef {
+    /// represents core ion type reference
+    IslCoreType(IonType),
+    /// represents a type reference which represents a type imported from another schema
+    AliasType(String),
+    /// represents a type reference defined as an inlined import type from another schema
+    // TODO: add ImportType(Import) where ImportType could either point to a schema represented by an id with all the types or a single type from inside it
+    /// represents an unnamed type definition reference
+    AnonymousType(IslType),
+}
+
+// TODO: add a check for nullable type reference
+impl IslTypeRef {
+    /// Tries to create an [IslTypeRef] from the given OwnedElement
+    pub fn parse_from_ion_element(value: &OwnedElement) -> IonSchemaResult<Self> {
+        match value.ion_type() {
+            IonType::Symbol => {
+                value.as_sym().unwrap()
+                    .text()
+                    .ok_or_else(|| {
+                        invalid_schema_error_raw(
+                            "a base or alias type reference symbol doesn't have text",
+                        )
+                    })
+                    .and_then(|type_reference| {
+                        let ion_type = match type_reference {
+                            "int" => IslTypeRef::IslCoreType(IonType::Integer),
+                            "float" => IslTypeRef::IslCoreType(IonType::Float),
+                            "decimal" => IslTypeRef::IslCoreType(IonType::Decimal),
+                            "timestamp" => IslTypeRef::IslCoreType(IonType::Timestamp),
+                            "string" => IslTypeRef::IslCoreType(IonType::String),
+                            "symbol" => IslTypeRef::IslCoreType(IonType::Symbol),
+                            "bool" => IslTypeRef::IslCoreType(IonType::Boolean),
+                            "blob" => IslTypeRef::IslCoreType(IonType::Blob),
+                            "clob" => IslTypeRef::IslCoreType(IonType::Clob),
+                            "sexp" => IslTypeRef::IslCoreType(IonType::SExpression),
+                            "list" => IslTypeRef::IslCoreType(IonType::List),
+                            "struct" => IslTypeRef::IslCoreType(IonType::Struct),
+                            // TODO: add a match for other core types like: lob, text, number, document, any
+                            _ => IslTypeRef::AliasType(type_reference.to_owned()),
+                        };
+                        Ok(ion_type)
+                    })
+            }
+            IonType::Struct =>
+                Ok(IslTypeRef::AnonymousType(value.as_struct().unwrap().try_into()?)),
+            _ => Err(invalid_schema_error_raw(
+                "type reference can either be a symbol(For base/alias type reference) or a struct (for anonymous type reference)",
+            )),
+        }
+    }
+
+    /// Resolves a type_reference into a [TypeId] using the type_store
+    pub fn resolve_type_reference(
+        type_reference: &IslTypeRef,
+        type_store: &SharedTypeStore,
+    ) -> IonSchemaResult<TypeId> {
+        match type_reference {
+            IslTypeRef::IslCoreType(ion_type) => {
+                // TODO: create CoreType struct for storing ISLCoreType type definition instead of Type
+                // inserts ISLCoreType as a Type into type_store
+                Ok(type_store.borrow_mut().add_named_type(
+                    &format!("{:?}", ion_type),
+                    TypeDefinition::new(Some(format!("{:?}", ion_type)), vec![]),
+                ))
+            }
+            IslTypeRef::AliasType(alias) => {
+                let borrow_type_store = type_store.borrow_mut();
+                // verify if the AliasType actually exists in the type_store or throw an error
+                match borrow_type_store.get_type_id_by_name(alias) {
+                    Some(type_id) => Ok(type_id.to_owned()),
+                    None => match borrow_type_store.get_parent() {
+                        Some(parent) => {
+                            // if it is a self referencing type resolve it using parent information from type_store
+                            if parent.0.eq(alias) {
+                                Ok(parent.1)
+                            } else {
+                                unresolvable_schema_error(format!(
+                                    "Could not resolve type reference: {:?} does not exist",
+                                    alias
+                                ))
+                            }
+                        }
+                        None => unresolvable_schema_error(format!(
+                            "Could not resolve type reference: {:?} does not exist",
+                            alias
+                        )),
+                    },
+                }
+            }
+            IslTypeRef::AnonymousType(isl_type) => {
+                let type_def = TypeDefinition::parse_from_isl_type(isl_type, type_store)?;
+                Ok(type_store.borrow_mut().add_anonymous_type(type_def))
+            } //TODO: add a check for ImportType type reference here
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ macro_rules! try_to {
 mod authority;
 mod constraint;
 mod import;
+mod isl;
 mod result;
 mod schema;
 mod system;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::import::Import;
 use crate::system::TypeStore;
-use crate::types::Type;
+use crate::types::TypeDefinition;
 use std::rc::Rc;
 use std::slice::Iter;
 
@@ -46,7 +46,7 @@ impl Schema {
 
     /// Returns the requested type, if present in this schema;
     /// otherwise returns None.
-    fn get_type<A: AsRef<str>>(&self, name: A) -> Option<&Type> {
+    fn get_type<A: AsRef<str>>(&self, name: A) -> Option<&TypeDefinition> {
         self.types.get_type_by_name(name.as_ref())
     }
 
@@ -61,18 +61,18 @@ impl Schema {
     /// instance plus the provided type.  Note that the added type
     /// in the returned instance will hide a type of the same name
     /// from this instance.
-    fn plus_type(&self, schema_type: Type) -> Self {
+    fn plus_type(&self, schema_type: TypeDefinition) -> Self {
         todo!()
     }
 }
 
 /// Provides an Iterator which returns [Type]s inside a [Schema]
 pub struct SchemaTypeIterator<'a> {
-    types: Iter<'a, Type>,
+    types: Iter<'a, TypeDefinition>,
 }
 
 impl<'a> Iterator for SchemaTypeIterator<'a> {
-    type Item = &'a Type;
+    type Item = &'a TypeDefinition;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.types.next()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,8 +1,7 @@
 use crate::import::Import;
 use crate::system::TypeStore;
-use crate::types::TypeDefinition;
+use crate::types::{TypeDefinition, TypeRef};
 use std::rc::Rc;
-use std::slice::Iter;
 
 /// A Schema is a collection of zero or more [Type]s.
 ///
@@ -52,9 +51,14 @@ impl Schema {
 
     /// Returns an iterator over the types in this schema.
     pub(crate) fn get_types(&self) -> SchemaTypeIterator {
-        SchemaTypeIterator {
-            types: self.types.get_types().iter(),
-        }
+        SchemaTypeIterator::new(
+            self.types
+                .get_types()
+                .iter()
+                .enumerate()
+                .map(|(i, t)| TypeRef::new(i, Rc::clone(&self.types)))
+                .collect(),
+        )
     }
 
     /// Returns a new [Schema] instance containing all the types of this
@@ -67,14 +71,115 @@ impl Schema {
 }
 
 /// Provides an Iterator which returns [Type]s inside a [Schema]
-pub struct SchemaTypeIterator<'a> {
-    types: Iter<'a, TypeDefinition>,
+pub struct SchemaTypeIterator {
+    types: Vec<TypeRef>,
+    index: usize,
 }
 
-impl<'a> Iterator for SchemaTypeIterator<'a> {
-    type Item = &'a TypeDefinition;
+impl SchemaTypeIterator {
+    fn new(types: Vec<TypeRef>) -> Self {
+        Self { types, index: 0 }
+    }
+}
+
+impl Iterator for SchemaTypeIterator {
+    type Item = TypeRef;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.types.next()
+        if self.index >= self.types.len() {
+            return None;
+        }
+        self.index = self.index + 1;
+        Some(self.types[self.index - 1].to_owned())
+    }
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+    use crate::system::Resolver;
+    use ion_rs::value::owned::{text_token, OwnedElement};
+    use ion_rs::value::{Builder, Element};
+    use rstest::*;
+    use std::cell::RefCell;
+
+    #[rstest(
+    owned_elements, total_types,
+    case::type_constraint_with_anonymous_type(
+        /* For a schema with single anonymous type as below: 
+            type:: { type: int }
+         */
+        vec![OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("int")))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        2 // this includes the core type int and the anonymous type
+    ),
+    case::type_constraint_with_named_type(
+        /* For a schema with named type as below: 
+            type:: { name: my_int, type: int }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))),("type", OwnedElement::from(text_token("int")))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        2 // this includes the core type int and the anonymous type
+    ),
+    case::type_constraint_with_self_reference_type(
+        /* For a schema with self reference type as below: 
+            type:: { name: my_int, type: my_int }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))),("type", OwnedElement::from(text_token("my_int")))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        1 // this includes only my_int type
+    ),
+    case::type_constraint_with_nested_self_reference_type(
+        /* For a schema with nested self reference type as below:
+            type:: { name: my_int, type: { type: my_int } }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))), ("type", OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("my_int")))].into_iter()))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        2 // this includes my_int type and the anonymous type that uses my_int
+    ),
+    case::type_constraint_with_nested_type(
+        /* For a schema with nested types as below:
+            type:: { name: my_int, type: { type: int } }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))), ("type", OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("int")))].into_iter()))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        3 // this includes my_int type, the anonymous type that uses int and core type int
+    ),
+    case::type_constraint_with_nested_multiple_types(
+        /* For a schema with nested multiple types as below: 
+            { name: my_int, type: { type: int }, type: { type: my_int } }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))), ("type", OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("int")))].into_iter())), ("type", OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("my_int")))].into_iter()))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        4 //  this includes my_int type, the anonymous type that uses int, core type int and the anonymous type that uses my_int type
+    ),
+    case::type_constraint_wiht_multiple_types(
+        /* For a schema with multiple type as below:
+             type:: { name: my_int, type: int }
+             type:: { name: my_bool, type: bool }
+             type:: { type: string }
+         */
+        vec![OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_int"))),("type", OwnedElement::from(text_token("int")))].into_iter()).with_annotations(vec![text_token("type")]),
+        OwnedElement::new_struct(vec![("name", OwnedElement::from(text_token("my_bool"))),("type", OwnedElement::from(text_token("bool")))].into_iter()).with_annotations(vec![text_token("type")]),
+        OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("string")))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        6
+    ),
+    case::all_of_constraint(
+        /* For a schema with all_of type as below: 
+            type:: { all_of: [{ type: int }] }
+        */
+        vec![OwnedElement::new_struct(vec![("all_of", OwnedElement::new_list(vec![OwnedElement::new_struct(vec![("type", OwnedElement::from(text_token("int")))].into_iter())]))].into_iter()).with_annotations(vec![text_token("type")])].into_iter(),
+        3
+    ),
+    )]
+    fn owned_elements_to_schema<'a, I: Iterator<Item = OwnedElement>>(
+        owned_elements: I,
+        total_types: usize,
+    ) {
+        // create a type_store and resolver instance to be used for loading OwnedElements as schema
+        let type_store = &Rc::new(RefCell::new(TypeStore::new()));
+        let mut resolver = Resolver::new(vec![]);
+
+        // create a schema from owned_elements and verifies if the result is `ok`
+        let schema = resolver.schema_from_elements(owned_elements, "my_schema.isl", type_store);
+        assert_eq!(schema.is_ok(), true);
+
+        // check if the types of the created schema matches with the actual types specified by test case
+        let types: Vec<TypeRef> = schema.unwrap().get_types().collect();
+        assert_eq!(types.len(), total_types);
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -135,11 +135,10 @@ impl Resolver {
                 // convert OwnedElement to IslType and then IslType to TypeDefinition
                 let isl_type: IslType = try_to!(value.as_struct()).try_into()?;
                 let type_def: TypeDefinition =
-                    TypeDefinition::parse_from_isl_type(&isl_type, type_store)?;
-                // add the resolved type_def into type_store
-                type_store
-                    .borrow_mut()
-                    .add_named_type(type_def.to_owned().name().as_ref().unwrap(), type_def);
+                    TypeDefinition::parse_from_isl_type_and_update_type_store(
+                        &isl_type, type_store,
+                    )?;
+
                 // clear parent information from type_store as the type is already added in the type_store now
                 type_store.borrow_mut().clear_parent();
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
 use crate::isl::{IslConstraint, IslType};
 use crate::result::IonSchemaResult;
-use crate::system::{SharedTypeStore, TypeId, TypeStore};
+use crate::system::{SharedContext, SharedTypeStore, TypeId, TypeStore};
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
 use std::rc::Rc;
@@ -20,9 +20,16 @@ pub trait TypeValidator {
 
 // Provides a public facing schema type which has a reference to TypeStore
 // to get the underlying TypeDefinition from TypeStore
+#[derive(Debug, Clone)]
 pub struct TypeRef {
     id: TypeId,
     type_store: Rc<TypeStore>,
+}
+
+impl TypeRef {
+    pub fn new(id: TypeId, type_store: Rc<TypeStore>) -> Self {
+        Self { id, type_store }
+    }
 }
 
 /// A Type consists of an optional name and zero or more constraints.
@@ -51,6 +58,7 @@ impl TypeDefinition {
     pub fn parse_from_isl_type_and_update_type_store(
         isl_type: &IslType,
         type_store: &SharedTypeStore,
+        context: &SharedContext,
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
 
@@ -59,38 +67,66 @@ impl TypeDefinition {
 
         // add parent information for named type
         if type_name.is_some() {
-            type_store
+            context
                 .borrow_mut()
                 .add_parent(type_name.to_owned().unwrap())
         }
+
+        // add this unresolved type to context for type_id
+        let type_id = context.borrow_mut().add_type();
 
         // convert IslConstraint to Constraint
         for isl_constraint in isl_type.constraints() {
             let constraint = match isl_constraint {
                 IslConstraint::AllOf(type_references) => {
-                    let all_of: AllOfConstraint =
-                        AllOfConstraint::resolve_from_isl_constraint(type_references, type_store)?;
+                    let all_of: AllOfConstraint = AllOfConstraint::resolve_from_isl_constraint(
+                        type_references,
+                        type_store,
+                        context,
+                    )?;
                     Constraint::AllOf(all_of)
                 }
                 IslConstraint::Type(type_reference) => {
                     let type_constraint: TypeConstraint =
-                        TypeConstraint::resolve_from_isl_constraint(type_reference, type_store)?;
+                        TypeConstraint::resolve_from_isl_constraint(
+                            type_reference,
+                            type_store,
+                            context,
+                        )?;
                     Constraint::Type(type_constraint)
                 }
             };
             constraints.push(constraint);
         }
-        // add the resolved type_def into type_store
+
         let type_def = TypeDefinition::new(type_name.to_owned(), constraints);
+
+        // update with this resolved type_def to context for type_id
+        let type_name = type_def.name();
         match type_name {
-            Some(name) => type_store
+            Some(name) => context.borrow_mut().update_named_type(
+                type_id,
+                name,
+                type_def.to_owned(),
+                type_store,
+            ),
+            None => context
                 .borrow_mut()
-                .add_named_type(name, type_def.to_owned()),
-            None => type_store
-                .borrow_mut()
-                .add_anonymous_type(type_def.to_owned()),
+                .update_anonymous_type(type_id, type_def.to_owned()),
         };
+
+        // clear parent information from type_store as the type is already added in the type_store now
+        if type_name.is_some() {
+            context.borrow_mut().clear_parent();
+        }
+
         Ok(type_def)
+    }
+}
+
+impl PartialEq for TypeDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name() && self.constraints == other.constraints()
     }
 }
 
@@ -101,5 +137,82 @@ impl TypeValidator for TypeDefinition {
 
     fn validate(&self, value: &OwnedElement, issues: &mut Violations) {
         todo!()
+    }
+}
+
+#[cfg(test)]
+mod type_definition_tests {
+    use super::*;
+    use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
+    use crate::isl::{IslConstraint, IslType, IslTypeRef};
+    use crate::system::Context;
+    use ion_rs::IonType;
+    use rstest::*;
+    use std::cell::RefCell;
+
+    #[rstest(
+    isl_type, type_def,
+    case::type_constraint_with_anonymous_type(
+        /* For a schema with single anonymous type as below: 
+            { type: int }
+         */
+        IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]),
+        TypeDefinition::new(None, vec![Constraint::Type(TypeConstraint::new(1))])
+    ),
+    case::type_constraint_with_named_type(
+        /* For a schema with named type as below: 
+            { name: my_int, type: int }
+         */
+        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]),
+        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+    ),
+    case::type_constraint_with_self_reference_type(
+        /* For a schema with self reference type as below: 
+            { name: my_int, type: my_int }
+         */
+        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))]),
+        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(0))])
+    ),
+    case::type_constraint_with_nested_self_reference_type(
+        /* For a schema with nested self reference type as below: 
+            { name: my_int, type: { type: my_int } }
+         */
+        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]),
+        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+    ),
+    case::type_constraint_with_nested_type(
+        /* For a schema with nested types as below: 
+            { name: my_int, type: { type: int } }
+         */
+        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])))]),
+        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+    ),
+    case::type_constraint_with_nested_multiple_types(
+        /* For a schema with nested multiple types as below: 
+            { name: my_int, type: { type: int }, type: { type: my_int } }
+         */
+        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))), IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]),
+        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1)), Constraint::Type(TypeConstraint::new(3))])
+    ),
+    case::all_of_constraint(
+        /* For a schema with all_of type as below: 
+            { all_of: [{ type: int }] }
+        */
+        IslType::new(None, vec![IslConstraint::AllOf(vec![IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))])]),
+        TypeDefinition::new(None, vec![Constraint::AllOf(AllOfConstraint::new(vec![1]))])
+    ),
+    )]
+    fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
+        // assert if both the IslType are same in terms of constraints and name
+        let type_store = Rc::new(RefCell::new(TypeStore::new()));
+        let context = &Rc::new(RefCell::new(Context::new()));
+        let this_type_def = TypeDefinition::parse_from_isl_type_and_update_type_store(
+            &isl_type,
+            &type_store,
+            context,
+        )
+        .unwrap();
+        let t = context.borrow().to_owned();
+        assert_eq!(this_type_def, type_def);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
 use crate::isl::{IslConstraint, IslType};
 use crate::result::IonSchemaResult;
-use crate::system::{SharedContext, SharedTypeStore, TypeId, TypeStore};
+use crate::system::{SharedPendingTypes, SharedTypeStore, TypeId, TypeStore};
 use crate::violation::Violations;
 use ion_rs::value::owned::OwnedElement;
 use std::rc::Rc;
@@ -58,7 +58,7 @@ impl TypeDefinition {
     pub fn parse_from_isl_type_and_update_type_store(
         isl_type: &IslType,
         type_store: &SharedTypeStore,
-        context: &SharedContext,
+        context: &SharedPendingTypes,
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
 
@@ -145,7 +145,7 @@ mod type_definition_tests {
     use super::*;
     use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
     use crate::isl::{IslConstraint, IslType, IslTypeRef};
-    use crate::system::Context;
+    use crate::system::PendingTypes;
     use ion_rs::IonType;
     use rstest::*;
     use std::cell::RefCell;
@@ -205,7 +205,7 @@ mod type_definition_tests {
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the IslType are same in terms of constraints and name
         let type_store = Rc::new(RefCell::new(TypeStore::new()));
-        let context = &Rc::new(RefCell::new(Context::new()));
+        let context = &Rc::new(RefCell::new(PendingTypes::new()));
         let this_type_def = TypeDefinition::parse_from_isl_type_and_update_type_store(
             &isl_type,
             &type_store,

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,9 +18,9 @@ pub trait TypeValidator {
     fn validate(&self, value: &OwnedElement, issues: &mut Violations);
 }
 
-/// Provides a public facing schema type which has a reference to TypeStore
-/// to get the underlying TypeDefinition from TypeStore
-struct TypeRef {
+// Provides a public facing schema type which has a reference to TypeStore
+// to get the underlying TypeDefinition from TypeStore
+pub struct TypeRef {
     id: TypeId,
     type_store: Rc<TypeStore>,
 }
@@ -69,12 +69,12 @@ impl TypeDefinition {
             let constraint = match isl_constraint {
                 IslConstraint::AllOf(type_references) => {
                     let all_of: AllOfConstraint =
-                        AllOfConstraint::parse_from_isl_constraint(type_references, type_store)?;
+                        AllOfConstraint::resolve_from_isl_constraint(type_references, type_store)?;
                     Constraint::AllOf(all_of)
                 }
                 IslConstraint::Type(type_reference) => {
                     let type_constraint: TypeConstraint =
-                        TypeConstraint::parse_from_isl_constraint(type_reference, type_store)?;
+                        TypeConstraint::resolve_from_isl_constraint(type_reference, type_store)?;
                     Constraint::Type(type_constraint)
                 }
             };

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,7 +48,7 @@ impl TypeDefinition {
     }
 
     /// Parse constraints inside an [OwnedStruct] to a schema [Type]
-    pub fn parse_from_isl_type(
+    pub fn parse_from_isl_type_and_update_type_store(
         isl_type: &IslType,
         type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
@@ -80,7 +80,17 @@ impl TypeDefinition {
             };
             constraints.push(constraint);
         }
-        Ok(TypeDefinition::new(type_name.to_owned(), constraints))
+        // add the resolved type_def into type_store
+        let type_def = TypeDefinition::new(type_name.to_owned(), constraints);
+        match type_name {
+            Some(name) => type_store
+                .borrow_mut()
+                .add_named_type(name, type_def.to_owned()),
+            None => type_store
+                .borrow_mut()
+                .add_anonymous_type(type_def.to_owned()),
+        };
+        Ok(type_def)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,10 @@
 use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
-use crate::result::{invalid_schema_error_raw, unresolvable_schema_error, IonSchemaResult};
-use crate::system::{SharedTypeStore, TypeId};
+use crate::isl::{IslConstraint, IslType};
+use crate::result::IonSchemaResult;
+use crate::system::{SharedTypeStore, TypeId, TypeStore};
 use crate::violation::Violations;
-use ion_rs::value::owned::{OwnedElement, OwnedStruct};
-use ion_rs::value::{Element, Struct, SymbolToken};
-use ion_rs::IonType;
+use ion_rs::value::owned::OwnedElement;
+use std::rc::Rc;
 
 /// Provides validation for Type
 pub trait TypeValidator {
@@ -18,21 +18,28 @@ pub trait TypeValidator {
     fn validate(&self, value: &OwnedElement, issues: &mut Violations);
 }
 
+/// Provides a public facing schema type which has a reference to TypeStore
+/// to get the underlying TypeDefinition from TypeStore
+struct TypeRef {
+    id: TypeId,
+    type_store: Rc<TypeStore>,
+}
+
 /// A Type consists of an optional name and zero or more constraints.
 ///
 /// Unless otherwise specified, the constraint `type: any` is automatically applied.
 #[derive(Debug, Clone)]
-pub struct Type {
-    name: String,
+pub struct TypeDefinition {
+    name: Option<String>,
     constraints: Vec<Constraint>,
 }
 
-impl Type {
-    pub fn new(name: String, constraints: Vec<Constraint>) -> Self {
+impl TypeDefinition {
+    pub fn new(name: Option<String>, constraints: Vec<Constraint>) -> Self {
         Self { name, constraints }
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &Option<String> {
         &self.name
     }
 
@@ -41,159 +48,48 @@ impl Type {
     }
 
     /// Parse constraints inside an [OwnedStruct] to a schema [Type]
-    pub fn parse_from_ion_element(
-        ion_struct: &OwnedStruct,
+    pub fn parse_from_isl_type(
+        isl_type: &IslType,
         type_store: &SharedTypeStore,
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
 
-        // parses the name of the type specified by schema
-        let type_name=  match ion_struct.get("name") {
-            Some(name_element) => match name_element.as_str() {
-                Some(name) => name.to_owned(),
-                None => { return Err(invalid_schema_error_raw("A type name is not string/symbol, if the value is any null, or the text of the symbol is not defined.")) }
-            },
-            None => format!("{:?}", ion_struct) // If the type is UNNAMED_TYPE_DEFINITION/ AnonymousType then add the entire struct as the name of type
-        };
+        // parses an isl_type to a TypeDefinition
+        let type_name = isl_type.name();
 
-        // parses all the constraints inside a Type
-        for (field_name, value) in ion_struct.iter() {
-            let constraint_name = match field_name.text() {
-                Some("name") => continue, // if the field_name is "name" then it's the type name not a constraint
-                Some(name) => name,
-                None => {
-                    return Err(invalid_schema_error_raw(
-                        "A type name symbol token does not have any text",
-                    ))
-                }
-            };
-            // TODO: add more constraints to match below
-            let constraint = match constraint_name {
-                "all_of" => {
+        // add parent information for named type
+        if type_name.is_some() {
+            type_store
+                .borrow_mut()
+                .add_parent(type_name.to_owned().unwrap())
+        }
+
+        // convert IslConstraint to Constraint
+        for isl_constraint in isl_type.constraints() {
+            let constraint = match isl_constraint {
+                IslConstraint::AllOf(type_references) => {
                     let all_of: AllOfConstraint =
-                        AllOfConstraint::parse_from_ion_element(value, type_store)?;
+                        AllOfConstraint::parse_from_isl_constraint(type_references, type_store)?;
                     Constraint::AllOf(all_of)
                 }
-                "type" => {
+                IslConstraint::Type(type_reference) => {
                     let type_constraint: TypeConstraint =
-                        TypeConstraint::parse_from_ion_element(value, type_store)?;
+                        TypeConstraint::parse_from_isl_constraint(type_reference, type_store)?;
                     Constraint::Type(type_constraint)
-                }
-                _ => {
-                    return Err(invalid_schema_error_raw(
-                        "Type: ".to_owned()
-                            + &type_name
-                            + " can not be built as constraint: "
-                            + constraint_name
-                            + " does not exist",
-                    ))
                 }
             };
             constraints.push(constraint);
         }
-        Ok(Type::new(type_name.to_owned(), constraints))
+        Ok(TypeDefinition::new(type_name.to_owned(), constraints))
     }
 }
 
-impl TypeValidator for Type {
+impl TypeValidator for TypeDefinition {
     fn is_valid(&self, value: &OwnedElement) -> bool {
         todo!()
     }
 
     fn validate(&self, value: &OwnedElement, issues: &mut Violations) {
         todo!()
-    }
-}
-
-/// Provides an internal representation of schema type reference.
-/// Type reference grammar is defined in [Ion Schema Spec]
-/// [Ion Schema spec]: https://amzn.github.io/ion-schema/docs/spec.html#grammar
-#[derive(Debug, Clone)]
-pub enum TypeRef {
-    /// represents core ion type reference
-    IslCoreType(IonType),
-    /// represents a type reference which represents a type imported from another schema
-    AliasType(String),
-    /// represents a type reference defined as an inlined import type from another schema
-    // TODO: add ImportType(Import) where ImportType could either point to a schema represented by an id with all the types or a single type from inside it
-    /// represents an unnamed type definition reference
-    AnonymousType(Type),
-}
-
-// TODO: add a check for nullable type reference
-impl TypeRef {
-    /// Tries to create a schema type reference from the given OwnedElement
-    pub fn parse_from_ion_element(
-        value: &OwnedElement,
-        type_store: &SharedTypeStore,
-    ) -> IonSchemaResult<Self> {
-        match value.ion_type() {
-            IonType::Symbol => {
-                value.as_sym().unwrap()
-                    .text()
-                    .ok_or_else(|| {
-                        invalid_schema_error_raw(
-                            "a base or alias type reference symbol doesn't have text",
-                        )
-                    })
-                    .and_then(|type_reference| {
-                        let ion_type = match type_reference {
-                            "int" => TypeRef::IslCoreType(IonType::Integer),
-                            "float" => TypeRef::IslCoreType(IonType::Float),
-                            "decimal" => TypeRef::IslCoreType(IonType::Decimal),
-                            "timestamp" => TypeRef::IslCoreType(IonType::Timestamp),
-                            "string" => TypeRef::IslCoreType(IonType::String),
-                            "symbol" => TypeRef::IslCoreType(IonType::Symbol),
-                            "bool" => TypeRef::IslCoreType(IonType::Boolean),
-                            "blob" => TypeRef::IslCoreType(IonType::Blob),
-                            "clob" => TypeRef::IslCoreType(IonType::Clob),
-                            "sexp" => TypeRef::IslCoreType(IonType::SExpression),
-                            "list" => TypeRef::IslCoreType(IonType::List),
-                            "struct" => TypeRef::IslCoreType(IonType::Struct),
-                            // TODO: add a match for other core types like: lob, text, number, document, any
-                            _ => TypeRef::AliasType(type_reference.to_owned()),
-                        };
-                        Ok(ion_type)
-                    })
-            }
-            IonType::Struct =>
-                Ok(TypeRef::AnonymousType(Type::parse_from_ion_element(value
-                                           .as_struct()
-                                           .unwrap(), type_store)?)),
-            _ => Err(invalid_schema_error_raw(
-                "type reference can either be a symbol(For base/alias type reference) or a struct (for anonymous type reference)",
-            )),
-        }
-    }
-
-    /// Resolves a type_reference into a [Type] that can be using the type_store
-    pub fn resolve_type_reference(
-        type_reference: &TypeRef,
-        type_store: &SharedTypeStore,
-    ) -> IonSchemaResult<TypeId> {
-        match type_reference {
-            TypeRef::IslCoreType(ion_type) => {
-                // TODO: create CoreType struct for storing ISLCoreType type definition instead of Type
-                // inserts ISLCoreType as a Type into type_store
-                Ok(type_store.borrow_mut().add_named_type(
-                    &format!("{:?}", ion_type),
-                    Type::new(format!("{:?}", ion_type), vec![]),
-                ))
-            }
-            TypeRef::AliasType(alias) => {
-                // verify if the AliasType actually exists in the type_store or throw an error
-                match type_store.borrow_mut().get_type_id_by_name(alias) {
-                    Some(type_id) => Ok(type_id.to_owned()),
-                    None => unresolvable_schema_error(format!(
-                        "Could not resolve type reference: {:?} does not exist",
-                        alias
-                    )),
-                }
-            }
-            TypeRef::AnonymousType(type_def) => Ok(type_store
-                .borrow_mut()
-                .add_anonymous_type(type_def.to_owned())),
-            //TODO: add a check for ImportType type reference here
-        }
     }
 }


### PR DESCRIPTION
*Description of changes:*
This PR works on changes for implementation of a public facing API for constructing types/constraints programmatically.

*Changes:*
- Adds implementation of new public facing API `IslType`, `IslConstraint`, `IslTypeRef` (stored in `isl` module)
- Renames `Type` to `TypeDefinition`
- Renames current `TypeRef` to `IslTypeRef`
- Creates a `TypeRef` which has a `TypeId` and reference to `TypeStore`
- Bug fix for self referencing types using parent information stored in `TypeStore`
- `TypeDefinition` field name is changed to be an `Option` to store both anonymous and named types
- doc comment changes

*Fixes #23*
*Fixes #14*