### PR TITLE
adds changes for anonymous and named `TypeDefinition`s and `Isl*` implementations

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -22,18 +22,18 @@ pub enum Constraint {
 }
 
 impl Constraint {
-    /// Creates a [Constraint::Type] using the [TypeId] referenced inside it
+    /// Creates a [Constraint::Type] referring to the type represented by the provided [TypeId].
     pub fn type_constraint(type_id: TypeId) -> Constraint {
         Constraint::Type(TypeConstraint::new(type_id))
     }
 
-    /// Creates a [Constraint::AllOf] using the [TypeId]s referenced inside it
-    pub fn all_of(type_ids: Vec<TypeId>) -> Constraint {
-        Constraint::AllOf(AllOfConstraint::new(type_ids))
+    /// Creates a [Constraint::AllOf] referring to the type represented by the provided [TypeId].
+    pub fn all_of<A: Into<Vec<TypeId>>>(type_ids: A) -> Constraint {
+        Constraint::AllOf(AllOfConstraint::new(type_ids.into()))
     }
 
     /// Parse an [IslConstraint] to a [Constraint]
-    pub fn parse_from_isl_constraint(
+    pub fn resolve_from_isl_constraint(
         isl_constraint: &IslConstraint,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -1,8 +1,70 @@
 use crate::isl::isl_type_reference::IslTypeRef;
+use crate::result::{invalid_schema_error_raw, IonSchemaResult};
+use ion_rs::value::owned::OwnedElement;
+use ion_rs::value::{Element, Sequence};
+use ion_rs::IonType;
 
 /// Represents a public facing API for schema constraints [IslConstraint] which stores IslTypeRef
 #[derive(Debug, Clone, PartialEq)]
 pub enum IslConstraint {
     AllOf(Vec<IslTypeRef>),
     Type(IslTypeRef),
+}
+
+impl IslConstraint {
+    /// Creates a [IslConstraint::Type] using the [IslTypeRef] referenced inside it
+    pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
+        IslConstraint::Type(isl_type)
+    }
+
+    /// Creates a [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
+    pub fn all_of(isl_types: Vec<IslTypeRef>) -> IslConstraint {
+        IslConstraint::AllOf(isl_types)
+    }
+
+    /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
+    pub fn parse_from_ion_element(
+        constraint_name: &str,
+        value: &OwnedElement,
+        type_name: &str,
+    ) -> IonSchemaResult<IslConstraint> {
+        // TODO: add more constraints to match below
+        match constraint_name {
+            "all_of" => {
+                //TODO: create a method/macro for this ion type check which can be reused
+                if value.ion_type() != IonType::List {
+                    return Err(invalid_schema_error_raw(format!(
+                        "all_of constraint was a {:?} instead of a list",
+                        value.ion_type()
+                    )));
+                }
+                let types: Vec<IslTypeRef> = value
+                    .as_sequence()
+                    .unwrap()
+                    .iter()
+                    .map(|e| IslTypeRef::parse_from_ion_element(e))
+                    .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?;
+                Ok(IslConstraint::AllOf(types))
+            }
+            "type" => {
+                if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
+                    return Err(invalid_schema_error_raw(format!(
+                        "type constraint was a {:?} instead of a symbol/struct",
+                        value.ion_type()
+                    )));
+                }
+                let type_reference: IslTypeRef = IslTypeRef::parse_from_ion_element(value)?;
+                Ok(IslConstraint::Type(type_reference))
+            }
+            _ => {
+                return Err(invalid_schema_error_raw(
+                    "Type: ".to_owned()
+                        + type_name
+                        + " can not be built as constraint: "
+                        + constraint_name
+                        + " does not exist",
+                ))
+            }
+        }
+    }
 }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -13,17 +13,18 @@ pub enum IslConstraint {
 
 impl IslConstraint {
     /// Creates a [IslConstraint::Type] using the [IslTypeRef] referenced inside it
+    // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::Type(isl_type)
     }
 
     /// Creates a [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
-    pub fn all_of(isl_types: Vec<IslTypeRef>) -> IslConstraint {
-        IslConstraint::AllOf(isl_types)
+    pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
+        IslConstraint::AllOf(isl_types.into())
     }
 
     /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
-    pub fn parse_from_ion_element(
+    pub fn from_ion_element(
         constraint_name: &str,
         value: &OwnedElement,
         type_name: &str,

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -80,13 +80,13 @@ impl IslTypeImpl {
                 "Top level types must have a name field in its definition",
             ));
         } else if !contains_annotations && type_name.is_some() {
-            // For named types if it does not have the `type::` annotation throw an error
+            // For named types if it does not have the `type::` annotation return an error
             return Err(invalid_schema_error_raw(
                 "Top level types must have `type::` annotation in their definition",
             ));
         }
 
-        // set the isl type name for any error that is thrown while parsing its constraints
+        // set the isl type name for any error that is returned while parsing its constraints
         let isl_type_name = match type_name.to_owned() {
             Some(name) => name,
             None => format!("{:?}", ion_struct),

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -1,115 +1,50 @@
 use crate::isl::isl_constraint::IslConstraint;
-use crate::isl::isl_type_reference::IslTypeRef;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
-use ion_rs::value::{Element, Sequence, Struct, SymbolToken};
-use ion_rs::IonType;
+use ion_rs::value::{Element, Struct, SymbolToken};
 
-/// Represents the public facing schema [IslType] which converts given ion content in the schema file
-/// into an internal representation of ISL types(not-yet-resolved types).
+/// Represents a type in an ISL schema.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IslType {
-    NamedIslType(NamedIslType),
-    AnonymousIslType(AnonymousIslType),
+    Named(IslTypeImpl),
+    Anonymous(IslTypeImpl),
 }
 
-/// Represents a public facing schema type [AnonymousIslType] which can be converted to a solid [AnonymousTypeDefinition] using TypeStore
-/// anonymous ISL type grammar: `{ <CONSTRAINT>... }`
-#[derive(Debug, Clone)]
-pub struct AnonymousIslType {
-    constraints: Vec<IslConstraint>,
-}
-
-impl AnonymousIslType {
-    pub fn new(constraints: Vec<IslConstraint>) -> Self {
-        Self { constraints }
+impl IslType {
+    /// Creates a [IslType::Named] using the [IslConstraint] defined within it
+    pub fn named(name: String, constraints: Vec<IslConstraint>) -> IslType {
+        IslType::Named(IslTypeImpl::new(Some(name), constraints))
     }
 
+    /// Creates a [IslType::Anonymous] using the [IslConstraint] defined within it
+    pub fn anonymous(constraints: Vec<IslConstraint>) -> IslType {
+        IslType::Anonymous(IslTypeImpl::new(None, constraints))
+    }
+
+    /// Provides the underlying constraints of [IslTypeImpl]
     pub fn constraints(&self) -> &[IslConstraint] {
-        &self.constraints
-    }
-
-    /// Parse constraints inside an [OwnedElement] to an [AnonymousIslType]
-    pub fn parse_from_owned_element(ion: &OwnedElement) -> IonSchemaResult<Self> {
-        let mut constraints = vec![];
-
-        let ion_struct = try_to!(ion.as_struct());
-
-        // parses all the constraints inside a Type
-        for (field_name, value) in ion_struct.iter() {
-            let constraint_name = match field_name.text() {
-                Some("name") => continue, // if the field_name is "name" then it's the type name not a constraint
-                Some(name) => name,
-                None => {
-                    return Err(invalid_schema_error_raw(
-                        "A type name symbol token does not have any text",
-                    ))
-                }
-            };
-            // TODO: add more constraints to match below
-            let constraint = match constraint_name {
-                "all_of" => {
-                    //TODO: create a method/macro for this ion type check which can be reused
-                    if value.ion_type() != IonType::List {
-                        return Err(invalid_schema_error_raw(format!(
-                            "all_of constraint was a {:?} instead of a list",
-                            value.ion_type()
-                        )));
-                    }
-                    let types: Vec<IslTypeRef> = value
-                        .as_sequence()
-                        .unwrap()
-                        .iter()
-                        .map(|e| IslTypeRef::parse_from_ion_element(e))
-                        .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?;
-                    IslConstraint::AllOf(types)
-                }
-                "type" => {
-                    if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
-                        return Err(invalid_schema_error_raw(format!(
-                            "type constraint was a {:?} instead of a symbol/struct",
-                            value.ion_type()
-                        )));
-                    }
-                    let type_reference: IslTypeRef = IslTypeRef::parse_from_ion_element(value)?;
-                    IslConstraint::Type(type_reference)
-                }
-                _ => {
-                    return Err(invalid_schema_error_raw(format!(
-                        "Type: {:?}
-                            can not be built as constraint: {}
-                            does not exist",
-                        ion_struct, constraint_name
-                    )))
-                }
-            };
-            constraints.push(constraint);
+        match &self {
+            IslType::Named(named_type) => named_type.constraints(),
+            IslType::Anonymous(anonymous_type) => anonymous_type.constraints(),
         }
-        Ok(AnonymousIslType::new(constraints))
     }
 }
 
-/// Provides an implementation of PartialEq to compare two IslTypes
-impl PartialEq for AnonymousIslType {
-    fn eq(&self, other: &Self) -> bool {
-        self.constraints.eq(&other.constraints)
-    }
-}
-
-/// Represents a public facing schema type [NamedIslType] which can be converted to a solid [NamedTypeDefinition] using TypeStore
+/// Represents both named and anonymous [IslType] which can be converted to a solid [TypeDefinition] using TypeStore
 /// named ISL type grammar: `type:: { name: <NAME>, <CONSTRAINT>...}`
-#[derive(Debug, Clone)]
-pub struct NamedIslType {
-    name: String,
+/// anonymous ISL type grammar: `{ <CONSTRAINT>... }`
+#[derive(Debug, Clone, PartialEq)]
+pub struct IslTypeImpl {
+    name: Option<String>,
     constraints: Vec<IslConstraint>,
 }
 
-impl NamedIslType {
-    pub fn new(name: String, constraints: Vec<IslConstraint>) -> Self {
+impl IslTypeImpl {
+    pub fn new(name: Option<String>, constraints: Vec<IslConstraint>) -> Self {
         Self { name, constraints }
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &Option<String> {
         &self.name
     }
 
@@ -122,31 +57,34 @@ impl NamedIslType {
         let mut constraints = vec![];
         let annotations: Vec<&OwnedSymbolToken> = ion.annotations().collect();
 
-        // For named types check if it has the `type::` annotation
-        if !annotations.contains(&&text_token("type")) {
-            return Err(invalid_schema_error_raw(
-                "Named types must have `type::` annotation in their definition",
-            ));
-        }
+        let contains_annotations = annotations.contains(&&text_token("type"));
 
         let ion_struct = try_to!(ion.as_struct());
 
         // parses the name of the type specified by schema
-        let type_name: String = match ion_struct.get("name") {
+        let type_name: Option<String> = match ion_struct.get("name") {
             Some(name_element) => match name_element.as_str() {
-                Some(name) => name.to_owned(),
+                Some(name) => Some(name.to_owned()),
                 None => {
                     return Err(invalid_schema_error_raw(
                         "type names must be a string or a symbol with defined text",
                     ))
                 }
             },
-            None => {
-                return Err(invalid_schema_error_raw(
-                    "Named type must have a name field in its definition",
-                ))
-            } // If a named type doesn't have name field throw an error
+            None => None, // If there is no name field then it is an anonymous type
         };
+
+        if contains_annotations && type_name.is_none() {
+            // If a named type doesn't have name field throw an error
+            return Err(invalid_schema_error_raw(
+                "Top level types must have a name field in its definition",
+            ));
+        } else if !contains_annotations && type_name.is_some() {
+            // For named types if it does not have the `type::` annotation throw an error
+            return Err(invalid_schema_error_raw(
+                "Top level types must have `type::` annotation in their definition",
+            ));
+        }
 
         // parses all the constraints inside a Type
         for (field_name, value) in ion_struct.iter() {
@@ -159,53 +97,17 @@ impl NamedIslType {
                     ))
                 }
             };
-            // TODO: add more constraints to match below
-            let constraint = match constraint_name {
-                "all_of" => {
-                    //TODO: create a method/macro for this ion type check which can be reused
-                    if value.ion_type() != IonType::List {
-                        return Err(invalid_schema_error_raw(format!(
-                            "all_of constraint was a {:?} instead of a list",
-                            value.ion_type()
-                        )));
-                    }
-                    let types: Vec<IslTypeRef> = value
-                        .as_sequence()
-                        .unwrap()
-                        .iter()
-                        .map(|e| IslTypeRef::parse_from_ion_element(e))
-                        .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?;
-                    IslConstraint::AllOf(types)
-                }
-                "type" => {
-                    if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
-                        return Err(invalid_schema_error_raw(format!(
-                            "type constraint was a {:?} instead of a symbol/struct",
-                            value.ion_type()
-                        )));
-                    }
-                    let type_reference: IslTypeRef = IslTypeRef::parse_from_ion_element(value)?;
-                    IslConstraint::Type(type_reference)
-                }
-                _ => {
-                    return Err(invalid_schema_error_raw(
-                        "Type: ".to_owned()
-                            + &type_name
-                            + " can not be built as constraint: "
-                            + constraint_name
-                            + " does not exist",
-                    ))
-                }
-            };
+
+            // set the isl type name for any error that is thrown while parsing its constraints
+            let mut isl_type_name = format!("{:?}", ion_struct);
+            if type_name.is_some() {
+                isl_type_name = type_name.to_owned().unwrap();
+            }
+
+            let constraint =
+                IslConstraint::parse_from_ion_element(constraint_name, value, &isl_type_name)?;
             constraints.push(constraint);
         }
-        Ok(NamedIslType::new(type_name, constraints))
-    }
-}
-
-/// Provides an implementation of PartialEq to compare two IslTypes
-impl PartialEq for NamedIslType {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.constraints.eq(&other.constraints)
+        Ok(IslTypeImpl::new(type_name, constraints))
     }
 }

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -1,61 +1,151 @@
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::result::{
-    invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
-};
-use ion_rs::value::owned::OwnedElement;
+use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
+use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
 use ion_rs::value::{Element, Sequence, Struct, SymbolToken};
 use ion_rs::IonType;
-use std::convert::TryFrom;
 
-/// Represents a public facing schema type [IslType] which can be converted to a solid TypeRef using TypeStore
+/// Represents the public facing schema [IslType] which converts given ion content in the schema file
+/// into an internal representation of ISL types(not-yet-resolved types).
+#[derive(Debug, Clone, PartialEq)]
+pub enum IslType {
+    NamedIslType(NamedIslType),
+    AnonymousIslType(AnonymousIslType),
+}
+
+/// Represents a public facing schema type [AnonymousIslType] which can be converted to a solid [AnonymousTypeDefinition] using TypeStore
+/// anonymous ISL type grammar: `{ <CONSTRAINT>... }`
 #[derive(Debug, Clone)]
-pub struct IslType {
-    name: Option<String>,
+pub struct AnonymousIslType {
     constraints: Vec<IslConstraint>,
 }
 
-impl IslType {
-    pub fn new(name: Option<String>, constraints: Vec<IslConstraint>) -> Self {
+impl AnonymousIslType {
+    pub fn new(constraints: Vec<IslConstraint>) -> Self {
+        Self { constraints }
+    }
+
+    pub fn constraints(&self) -> &[IslConstraint] {
+        &self.constraints
+    }
+
+    /// Parse constraints inside an [OwnedElement] to an [AnonymousIslType]
+    pub fn parse_from_owned_element(ion: &OwnedElement) -> IonSchemaResult<Self> {
+        let mut constraints = vec![];
+
+        let ion_struct = try_to!(ion.as_struct());
+
+        // parses all the constraints inside a Type
+        for (field_name, value) in ion_struct.iter() {
+            let constraint_name = match field_name.text() {
+                Some("name") => continue, // if the field_name is "name" then it's the type name not a constraint
+                Some(name) => name,
+                None => {
+                    return Err(invalid_schema_error_raw(
+                        "A type name symbol token does not have any text",
+                    ))
+                }
+            };
+            // TODO: add more constraints to match below
+            let constraint = match constraint_name {
+                "all_of" => {
+                    //TODO: create a method/macro for this ion type check which can be reused
+                    if value.ion_type() != IonType::List {
+                        return Err(invalid_schema_error_raw(format!(
+                            "all_of constraint was a {:?} instead of a list",
+                            value.ion_type()
+                        )));
+                    }
+                    let types: Vec<IslTypeRef> = value
+                        .as_sequence()
+                        .unwrap()
+                        .iter()
+                        .map(|e| IslTypeRef::parse_from_ion_element(e))
+                        .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?;
+                    IslConstraint::AllOf(types)
+                }
+                "type" => {
+                    if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
+                        return Err(invalid_schema_error_raw(format!(
+                            "type constraint was a {:?} instead of a symbol/struct",
+                            value.ion_type()
+                        )));
+                    }
+                    let type_reference: IslTypeRef = IslTypeRef::parse_from_ion_element(value)?;
+                    IslConstraint::Type(type_reference)
+                }
+                _ => {
+                    return Err(invalid_schema_error_raw(format!(
+                        "Type: {:?}
+                            can not be built as constraint: {}
+                            does not exist",
+                        ion_struct, constraint_name
+                    )))
+                }
+            };
+            constraints.push(constraint);
+        }
+        Ok(AnonymousIslType::new(constraints))
+    }
+}
+
+/// Provides an implementation of PartialEq to compare two IslTypes
+impl PartialEq for AnonymousIslType {
+    fn eq(&self, other: &Self) -> bool {
+        self.constraints.eq(&other.constraints)
+    }
+}
+
+/// Represents a public facing schema type [NamedIslType] which can be converted to a solid [NamedTypeDefinition] using TypeStore
+/// named ISL type grammar: `type:: { name: <NAME>, <CONSTRAINT>...}`
+#[derive(Debug, Clone)]
+pub struct NamedIslType {
+    name: String,
+    constraints: Vec<IslConstraint>,
+}
+
+impl NamedIslType {
+    pub fn new(name: String, constraints: Vec<IslConstraint>) -> Self {
         Self { name, constraints }
     }
 
-    pub fn name(&self) -> &Option<String> {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
     pub fn constraints(&self) -> &[IslConstraint] {
         &self.constraints
     }
-}
 
-/// Provides an implementation of PartialEq to compare two IslTypes
-impl PartialEq for IslType {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.constraints.eq(&other.constraints)
-    }
-}
-
-/// Parse constraints inside an [OwnedStruct] to an [IslType]
-impl TryFrom<&OwnedElement> for IslType {
-    type Error = IonSchemaError;
-
-    fn try_from(ion: &OwnedElement) -> Result<Self, Self::Error> {
+    /// Parse constraints inside an [OwnedElement] to an [NamedIslType]
+    pub fn parse_from_owned_element(ion: &OwnedElement) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
+        let annotations: Vec<&OwnedSymbolToken> = ion.annotations().collect();
+
+        // For named types check if it has the `type::` annotation
+        if !annotations.contains(&&text_token("type")) {
+            return Err(invalid_schema_error_raw(
+                "Named types must have `type::` annotation in their definition",
+            ));
+        }
 
         let ion_struct = try_to!(ion.as_struct());
 
         // parses the name of the type specified by schema
-        let type_name: Option<String> = match ion_struct.get("name") {
+        let type_name: String = match ion_struct.get("name") {
             Some(name_element) => match name_element.as_str() {
-                Some(name) => Some(name.to_owned()),
+                Some(name) => name.to_owned(),
                 None => {
                     return Err(invalid_schema_error_raw(
                         "type names must be a string or a symbol with defined text",
                     ))
                 }
             },
-            None => None, // If the type is UNNAMED_TYPE_DEFINITION/ AnonymousType then set name as None
+            None => {
+                return Err(invalid_schema_error_raw(
+                    "Named type must have a name field in its definition",
+                ))
+            } // If a named type doesn't have name field throw an error
         };
 
         // parses all the constraints inside a Type
@@ -100,7 +190,7 @@ impl TryFrom<&OwnedElement> for IslType {
                 _ => {
                     return Err(invalid_schema_error_raw(
                         "Type: ".to_owned()
-                            + &type_name.unwrap()
+                            + &type_name
                             + " can not be built as constraint: "
                             + constraint_name
                             + " does not exist",
@@ -109,6 +199,13 @@ impl TryFrom<&OwnedElement> for IslType {
             };
             constraints.push(constraint);
         }
-        Ok(IslType::new(type_name, constraints))
+        Ok(NamedIslType::new(type_name, constraints))
+    }
+}
+
+/// Provides an implementation of PartialEq to compare two IslTypes
+impl PartialEq for NamedIslType {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.constraints.eq(&other.constraints)
     }
 }

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -1,8 +1,8 @@
-use crate::isl::isl_type::AnonymousIslType;
+use crate::isl::isl_constraint::IslConstraint;
+use crate::isl::isl_type::IslTypeImpl;
 use crate::result::{invalid_schema_error_raw, unresolvable_schema_error, IonSchemaResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
-use crate::types::AnonymousTypeDefinition;
-use crate::types::NamedTypeDefinition;
+use crate::types::TypeDefinitionImpl;
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, SymbolToken};
 use ion_rs::IonType;
@@ -13,17 +13,32 @@ use ion_rs::IonType;
 #[derive(Debug, Clone, PartialEq)]
 pub enum IslTypeRef {
     /// Represents a reference to one of ISL's built-in core types:
-    CoreIslType(IonType),
+    CoreIsl(IonType),
     /// Represents a reference to a named type (including aliases)
-    NamedType(String),
+    Named(String),
     /// Represents a type reference defined as an inlined import type from another schema
     // TODO: add ImportType(Import) where ImportType could either point to a schema represented by an id with all the types or a single type from inside it
     /// represents an unnamed type definition reference
-    AnonymousType(AnonymousIslType),
+    Anonymous(IslTypeImpl),
 }
 
 // TODO: add a check for nullable type reference
 impl IslTypeRef {
+    /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
+    pub fn core_isl(ion_type: IonType) -> IslTypeRef {
+        IslTypeRef::CoreIsl(ion_type)
+    }
+
+    /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
+    pub fn named(name: String) -> IslTypeRef {
+        IslTypeRef::Named(name)
+    }
+
+    /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
+    pub fn anonymous(constraints: Vec<IslConstraint>) -> IslTypeRef {
+        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints))
+    }
+
     /// Tries to create an [IslTypeRef] from the given OwnedElement
     pub fn parse_from_ion_element(value: &OwnedElement) -> IonSchemaResult<Self> {
         match value.ion_type() {
@@ -37,26 +52,26 @@ impl IslTypeRef {
                     })
                     .and_then(|type_name| {
                         let ion_type = match type_name {
-                            "int" => IslTypeRef::CoreIslType(IonType::Integer),
-                            "float" => IslTypeRef::CoreIslType(IonType::Float),
-                            "decimal" => IslTypeRef::CoreIslType(IonType::Decimal),
-                            "timestamp" => IslTypeRef::CoreIslType(IonType::Timestamp),
-                            "string" => IslTypeRef::CoreIslType(IonType::String),
-                            "symbol" => IslTypeRef::CoreIslType(IonType::Symbol),
-                            "bool" => IslTypeRef::CoreIslType(IonType::Boolean),
-                            "blob" => IslTypeRef::CoreIslType(IonType::Blob),
-                            "clob" => IslTypeRef::CoreIslType(IonType::Clob),
-                            "sexp" => IslTypeRef::CoreIslType(IonType::SExpression),
-                            "list" => IslTypeRef::CoreIslType(IonType::List),
-                            "struct" => IslTypeRef::CoreIslType(IonType::Struct),
+                            "int" => IslTypeRef::CoreIsl(IonType::Integer),
+                            "float" => IslTypeRef::CoreIsl(IonType::Float),
+                            "decimal" => IslTypeRef::CoreIsl(IonType::Decimal),
+                            "timestamp" => IslTypeRef::CoreIsl(IonType::Timestamp),
+                            "string" => IslTypeRef::CoreIsl(IonType::String),
+                            "symbol" => IslTypeRef::CoreIsl(IonType::Symbol),
+                            "bool" => IslTypeRef::CoreIsl(IonType::Boolean),
+                            "blob" => IslTypeRef::CoreIsl(IonType::Blob),
+                            "clob" => IslTypeRef::CoreIsl(IonType::Clob),
+                            "sexp" => IslTypeRef::CoreIsl(IonType::SExpression),
+                            "list" => IslTypeRef::CoreIsl(IonType::List),
+                            "struct" => IslTypeRef::CoreIsl(IonType::Struct),
                             // TODO: add a match for other core types like: lob, text, number, document, any
-                            _ => IslTypeRef::NamedType(type_name.to_owned()),
+                            _ => IslTypeRef::Named(type_name.to_owned()),
                         };
                         Ok(ion_type)
                     })
             }
             IonType::Struct =>
-                Ok(IslTypeRef::AnonymousType(AnonymousIslType::parse_from_owned_element(value)?)),
+                Ok(IslTypeRef::Anonymous(IslTypeImpl::parse_from_owned_element(value)?)),
             _ => Err(invalid_schema_error_raw(
                 "type reference can either be a symbol(For base/alias type reference) or a struct (for anonymous type reference)",
             )),
@@ -71,16 +86,16 @@ impl IslTypeRef {
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<TypeId> {
         match type_reference {
-            IslTypeRef::CoreIslType(ion_type) => {
+            IslTypeRef::CoreIsl(ion_type) => {
                 // TODO: create CoreType struct for storing ISLCoreType type definition instead of Type
                 // inserts ISLCoreType as a Type into type_store
                 Ok(pending_types.add_named_type(
                     &format!("{:?}", ion_type),
-                    NamedTypeDefinition::new(format!("{:?}", ion_type), vec![]),
+                    TypeDefinitionImpl::new(Some(format!("{:?}", ion_type)), vec![]),
                     type_store,
                 ))
             }
-            IslTypeRef::NamedType(alias) => {
+            IslTypeRef::Named(alias) => {
                 // verify if the AliasType actually exists in the type_store or throw an error
                 match pending_types.get_type_id_by_name(alias, type_store) {
                     Some(type_id) => Ok(type_id.to_owned()),
@@ -103,9 +118,9 @@ impl IslTypeRef {
                     },
                 }
             }
-            IslTypeRef::AnonymousType(isl_type) => {
+            IslTypeRef::Anonymous(isl_type) => {
                 let type_id = pending_types.get_total_types();
-                let type_def = AnonymousTypeDefinition::parse_from_isl_type_and_update_type_store(
+                let type_def = TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
                     isl_type,
                     type_store,
                     pending_types,

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -25,18 +25,18 @@ pub enum IslTypeRef {
 // TODO: add a check for nullable type reference
 impl IslTypeRef {
     /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
-    pub fn core_isl(ion_type: IonType) -> IslTypeRef {
+    pub fn core(ion_type: IonType) -> IslTypeRef {
         IslTypeRef::CoreIsl(ion_type)
     }
 
     /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
-    pub fn named(name: String) -> IslTypeRef {
-        IslTypeRef::Named(name)
+    pub fn named<A: Into<String>>(name: A) -> IslTypeRef {
+        IslTypeRef::Named(name.into())
     }
 
     /// Creates a [IslTypeRef::CoreIsl] using the [IonType] referenced inside it
-    pub fn anonymous(constraints: Vec<IslConstraint>) -> IslTypeRef {
-        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints))
+    pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
+        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints.into()))
     }
 
     /// Tries to create an [IslTypeRef] from the given OwnedElement

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -1,41 +1,39 @@
-//! Provides a way to construct ISL types/constraints programmatically into an internal representation.
+//! Provides a way to construct ISL types/constraints programmatically.
 //!
-//! This module consists of three submodules that implement public facing API for constructing ISL types/constraint:
+//! This module consists of three submodules that help constructing ISL types/constraint:
 //!
-//! * `isl_type` module represents a public facing schema type [IslType] which converts given ion content in the schema file
-//! into an internal representation of ISL types(not-yet-resolved types). It stores [IslConstraint]s defined within the given type.
-//! Also, this eventually gets converted to a solid [TypeRef](which contains a unique TypeId for the given type
-//! and a resolved type TypeDefinition) using [TypeStore].
+//! * `isl_type` module represents a schema type [IslType] which converts given ion content in the schema file
+//! into an ISL types(not-yet-resolved types). It stores [IslConstraint]s defined within the given type.
 //!
-//! * `isl_constraint` module represents a public facing API for schema constraints [IslConstraint]
-//! which converts given ion content in the schema file into an internal representation of ISL constraint(not-yet-resolved constraints).
+//! * `isl_constraint` module represents schema constraints [IslConstraint]
+//! which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
 //! This stores [IslTypeRef]s for the given ISL constraint.
 //!
-//! * `isl_type_reference` module provides an internal representation of a schema type reference.
+//! * `isl_type_reference` module provides a schema type reference.
 //! The type reference grammar is defined in the [Ion Schema Spec]: https://amzn.github.io/ion-schema/docs/spec.html#grammar
 //!
 //! ## Example usage of `isl` module to create an [IslType]:
 //! ```
 //! use ion_rs::IonType;
 //! use ion_schema_rust::isl::{isl_type::*, isl_constraint::*, isl_type_reference::*};
+//! use ion_schema_rust::schema::Schema;
 //!
 //! fn main() {
 //!     // below code represents an ISL type:
-//!     // `type:: {
+//!     // type:: {
 //!     //      name:my_type_name,
 //!     //      type: int,
 //!     //      all_of: [
 //!     //          { type: bool }
 //!     //      ]
 //!     //  }
-//!     // `
 //!     let isl_type = IslType::named(
 //!         // represents the `name` of the defined type
 //!         "my_type_name".to_owned(),
 //!         vec![
 //!             // represents the `type: int` constraint
 //!             IslConstraint::type_constraint(
-//!                 IslTypeRef::core_isl(IonType::Integer)
+//!                 IslTypeRef::core(IonType::Integer)
 //!             ),
 //!             // represents `all_of` with anonymous type `{ type: bool }` constraint
 //!             IslConstraint::all_of(
@@ -43,7 +41,7 @@
 //!                     IslTypeRef::anonymous(
 //!                         vec![
 //!                             IslConstraint::type_constraint(
-//!                                 IslTypeRef::core_isl(IonType::Boolean)
+//!                                 IslTypeRef::core(IonType::Boolean)
 //!                             )
 //!                         ]
 //!                     )
@@ -51,17 +49,23 @@
 //!             )
 //!         ]
 //!     );
-//!     assert_eq!(isl_type.constraints().len(), 2);
+//!
+//!     // create a schema from given IslType
+//!     let schema = Schema::try_from_isl_types("my_schema", [isl_type.to_owned()]);
+//!
+//!     // TODO: add an assert statement for get_types method of this schema
+//!     assert_eq!(schema.is_ok(), true);
 //! }
 //! ```
-//! The given schema is loaded with a two phase approach:
-//! 1. Phase 1: Constructing an internal representation of ISL types/constraints from given schema file.
-//!             This phase creates all [IslType],  [IslConstraint], [IslTypeRef] structs from the ion content in schema file.
-//! 2. Phase 2: Constructing resolved types/constraints from internal representation of ISL types/constraints(not-yet-resolved types/constraints).
-//!             This is done by loading all types into [Schema] as below:
-//!                 a. Convert all [IslType] → [TypeDefinition], [IslConstraint] → [Constraint], [IslTypeRef] → [TypeDefinition]
-//!                 b. While doing (a) store all [TypeDefinition] in the [TypeStore](which could help
-//!                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
+
+// The given schema is loaded with a two phase approach:
+// 1. Phase 1: Constructing an internal representation of ISL types/constraints from given schema file.
+//             This phase creates all [IslType],  [IslConstraint], [IslTypeRef] structs from the ion content in schema file.
+// 2. Phase 2: Constructing resolved types/constraints from internal representation of ISL types/constraints(not-yet-resolved types/constraints).
+//             This is done by loading all types into [Schema] as below:
+//                 a. Convert all [IslType] → [TypeDefinition], [IslConstraint] → [Constraint], [IslTypeRef] → [TypeDefinition]
+//                 b. While doing (a) store all [TypeDefinition] in the [TypeStore](which could help
+//                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
 
 pub mod isl_constraint;
 pub mod isl_type;
@@ -107,43 +111,43 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with single anonymous type
                 {type: int}
             "#),
-        IslType::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])
+        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }
             "#),
-        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])
     ),
     case::type_constraint_with_self_reference_type(
         load_named_type(r#" // For a schema with self reference type
                 type:: { name: my_int, type: my_int }
             "#),
-        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("my_int"))])
     ),
     case::type_constraint_with_nested_self_reference_type(
         load_named_type(r#" // For a schema with nested self reference type
                 type:: { name: my_int, type: { type: my_int } }
             "#),
-        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))]))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))])
     ),
     case::type_constraint_with_nested_type(
         load_named_type(r#" // For a schema with nested types
                 type:: { name: my_int, type: { type: int } }
             "#),
-        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))]))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))]))])
     ),
     case::type_constraint_with_nested_multiple_types(
         load_named_type(r#" // For a schema with nested multiple types
                 type:: { name: my_int, type: { type: int }, type: { type: my_int } }
             "#),
-        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])), IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::Type(IslTypeRef::named("my_int".to_owned()))]))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::Type(IslTypeRef::named("my_int"))]))])
     ),
     case::all_of_constraint(
         load_anonymous_type(r#" // For a schema with all_of type as below:
                 { all_of: [{ type: int }] }
             "#),
-        IslType::anonymous(vec![IslConstraint::all_of(vec![IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::CoreIsl(IonType::Integer))])])])
+        IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])])])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -1,36 +1,76 @@
+//! Provides a way to construct ISL types/constraints programmatically into an internal representation.
+//!
+//! This module consists of three submodules that implement public facing API for constructing ISL types/constraint:
+//!
+//! * `isl_type` module represents a public facing schema type [IslType] which converts given ion content in the schema file
+//! into an internal representation of ISL types(not-yet-resolved types). It stores [IslConstraint]s defined within the given type.
+//! Also, this eventually gets converted to a solid [TypeRef](which contains a unique TypeId for the given type
+//! and a resolved type TypeDefinition) using [TypeStore].
+//!
+//! * `isl_constraint` module represents a public facing API for schema constraints [IslConstraint]
+//! which converts given ion content in the schema file into an internal representation of ISL constraint(not-yet-resolved constraints).
+//! This stores [IslTypeRef]s for the given ISL constraint.
+//!
+//! * `isl_type_reference` module provides an internal representation of a schema type reference.
+//! The type reference grammar is defined in the [Ion Schema Spec]: https://amzn.github.io/ion-schema/docs/spec.html#grammar
+//!
+//! ## Example usage of `isl` module to create an [IslType]:
+//! ```
+//! use ion_rs::IonType;
+//! use ion_schema_rust::isl::{isl_type::*, isl_constraint::*, isl_type_reference::*};
+//!
+//! fn main() {
+//!     // below code represents an ISL type:
+//!     // `type:: {
+//!     //      name:my_type_name,
+//!     //      type: int,
+//!     //      all_of: [
+//!     //          { type: bool }
+//!     //      ]
+//!     //  }
+//!     // `
+//!     let isl_type = IslType::named(
+//!         // represents the `name` of the defined type
+//!         "my_type_name".to_owned(),
+//!         vec![
+//!             // represents the `type: int` constraint
+//!             IslConstraint::type_constraint(
+//!                 IslTypeRef::core_isl(IonType::Integer)
+//!             ),
+//!             // represents `all_of` with anonymous type `{ type: bool }` constraint
+//!             IslConstraint::all_of(
+//!                 vec![
+//!                     IslTypeRef::anonymous(
+//!                         vec![
+//!                             IslConstraint::type_constraint(
+//!                                 IslTypeRef::core_isl(IonType::Boolean)
+//!                             )
+//!                         ]
+//!                     )
+//!                 ]
+//!             )
+//!         ]
+//!     );
+//!     assert_eq!(isl_type.constraints().len(), 2);
+//! }
+//! ```
+//! The given schema is loaded with a two phase approach:
+//! 1. Phase 1: Constructing an internal representation of ISL types/constraints from given schema file.
+//!             This phase creates all [IslType],  [IslConstraint], [IslTypeRef] structs from the ion content in schema file.
+//! 2. Phase 2: Constructing resolved types/constraints from internal representation of ISL types/constraints(not-yet-resolved types/constraints).
+//!             This is done by loading all types into [Schema] as below:
+//!                 a. Convert all [IslType] → [TypeDefinition], [IslConstraint] → [Constraint], [IslTypeRef] → [TypeDefinition]
+//!                 b. While doing (a) store all [TypeDefinition] in the [TypeStore](which could help
+//!                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
+
 pub mod isl_constraint;
 pub mod isl_type;
 pub mod isl_type_reference;
 
-/// Provides a way to construct ISL types/constraints programmatically into an internal representation.
-///
-/// This module consists of three submodules that implement public facing API for constructing ISL types/constraint:
-///
-/// * `isl_type` module represents a public facing schema type [IslType] which converts given ion content in the schema file
-/// into an internal representation of ISL types(not-yet-resolved types). It stores [IslConstraint]s defined within the given type.
-/// Also, this eventually gets converted to a solid [TypeRef](which contains a unique TypeId for the given type
-/// and a resolved type TypeDefinition) using [TypeStore].
-///
-/// * `isl_constraint` module represents a public facing API for schema constraints [IslConstraint]
-/// which converts given ion content in the schema file into an internal representation of ISL constraint(not-yet-resolved constraints).
-/// This stores [IslTypeRef]s for the given ISL constraint.
-///
-/// * `isl_type_reference` module provides an internal representation of a schema type reference.
-/// The type reference grammar is defined in the [Ion Schema Spec]: https://amzn.github.io/ion-schema/docs/spec.html#grammar
-///
-/// The given schema is loaded with a two phase approach:
-/// 1. Phase 1: Constructing an internal representation of ISL types/constraints from given schema file.
-///             This phase creates all [IslType],  [IslConstraint], [IslTypeRef] structs from the ion content in schema file.
-/// 2. Phase 2: Constructing resolved types/constraints from internal representation of ISL types/constraints(not-yet-resolved types/constraints).
-///             This is done by loading all types into [Schema] as below:
-///                 a. Convert all [IslType] → [TypeDefinition], [IslConstraint] → [Constraint], [IslTypeRef] → [TypeDefinition]
-///                 b. While doing (a) store all [TypeDefinition] in the [TypeStore](which could help
-///                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
-
 #[cfg(test)]
 mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
-    use crate::isl::isl_type::{AnonymousIslType, IslType, NamedIslType};
+    use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
@@ -39,8 +79,8 @@ mod isl_tests {
 
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
-        IslType::NamedIslType(
-            NamedIslType::parse_from_owned_element(
+        IslType::Named(
+            IslTypeImpl::parse_from_owned_element(
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),
@@ -51,8 +91,8 @@ mod isl_tests {
 
     // helper function to create AnonymousIslType for isl tests
     fn load_anonymous_type(text: &str) -> IslType {
-        IslType::AnonymousIslType(
-            AnonymousIslType::parse_from_owned_element(
+        IslType::Anonymous(
+            IslTypeImpl::parse_from_owned_element(
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),
@@ -67,43 +107,43 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with single anonymous type
                 {type: int}
             "#),
-        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))
+        IslType::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }
             "#),
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])
     ),
     case::type_constraint_with_self_reference_type(
         load_named_type(r#" // For a schema with self reference type
                 type:: { name: my_int, type: my_int }
             "#),
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))])
     ),
     case::type_constraint_with_nested_self_reference_type(
         load_named_type(r#" // For a schema with nested self reference type
                 type:: { name: my_int, type: { type: my_int } }
             "#),
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))]))])
     ),
     case::type_constraint_with_nested_type(
         load_named_type(r#" // For a schema with nested types
                 type:: { name: my_int, type: { type: int } }
             "#),
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))]))])
     ),
     case::type_constraint_with_nested_multiple_types(
         load_named_type(r#" // For a schema with nested multiple types
                 type:: { name: my_int, type: { type: int }, type: { type: my_int } }
             "#),
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))), IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])), IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::Type(IslTypeRef::named("my_int".to_owned()))]))])
     ),
     case::all_of_constraint(
         load_anonymous_type(r#" // For a schema with all_of type as below:
                 { all_of: [{ type: int }] }
             "#),
-        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::AllOf(vec![IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))])]))
+        IslType::anonymous(vec![IslConstraint::all_of(vec![IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::CoreIsl(IonType::Integer))])])])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -17,6 +17,8 @@
 //! use ion_rs::IonType;
 //! use ion_schema_rust::isl::{isl_type::*, isl_constraint::*, isl_type_reference::*};
 //! use ion_schema_rust::schema::Schema;
+//! use ion_schema_rust::system::SchemaSystem;
+//! use std::path::Path;
 //!
 //! fn main() {
 //!     // below code represents an ISL type:
@@ -50,8 +52,9 @@
 //!         ]
 //!     );
 //!
-//!     // create a schema from given IslType
-//!     let schema = Schema::try_from_isl_types("my_schema", [isl_type.to_owned()]);
+//!     // create a schema from given IslType using SchemaSystem
+//!     let schema_system = SchemaSystem::new(vec![]); // no authorities added
+//!     let schema = schema_system.schema_from_isl_types("my_schema", [isl_type.to_owned()]);
 //!
 //!     // TODO: add an assert statement for get_types method of this schema
 //!     assert_eq!(schema.is_ok(), true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,6 @@ mod import;
 pub mod isl;
 mod result;
 pub mod schema;
-mod system;
+pub mod system;
 mod types;
 mod violation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod constraint;
 mod import;
 pub mod isl;
 mod result;
-mod schema;
+pub mod schema;
 mod system;
 mod types;
 mod violation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! try_to {
 mod authority;
 mod constraint;
 mod import;
-mod isl;
+pub mod isl;
 mod result;
 mod schema;
 mod system;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::import::Import;
 use crate::system::TypeStore;
-use crate::types::{NamedTypeDefinition, TypeDefinition, TypeRef};
+use crate::types::{TypeDefinition, TypeDefinitionImpl, TypeRef};
 use std::rc::Rc;
 
 /// A Schema is a collection of zero or more [Type]s.
@@ -58,7 +58,7 @@ impl Schema {
     /// instance plus the provided type.  Note that the added type
     /// in the returned instance will hide a type of the same name
     /// from this instance.
-    fn plus_type(&self, schema_type: NamedTypeDefinition) -> Self {
+    fn plus_type(&self, schema_type: TypeDefinitionImpl) -> Self {
         todo!()
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::import::Import;
 use crate::system::TypeStore;
-use crate::types::{TypeDefinition, TypeRef};
+use crate::types::{NamedTypeDefinition, TypeDefinition, TypeRef};
 use std::rc::Rc;
 
 /// A Schema is a collection of zero or more [Type]s.
@@ -58,7 +58,7 @@ impl Schema {
     /// instance plus the provided type.  Note that the added type
     /// in the returned instance will hide a type of the same name
     /// from this instance.
-    fn plus_type(&self, schema_type: TypeDefinition) -> Self {
+    fn plus_type(&self, schema_type: NamedTypeDefinition) -> Self {
         todo!()
     }
 }
@@ -105,56 +105,46 @@ mod schema_tests {
 
     #[rstest(
     owned_elements, total_types,
-    case::type_constraint_with_anonymous_type(
-        /* For a schema with single anonymous type as below: 
-            type:: { type: int }
-         */
-        load(r#" // For a schema with single anonymous type
-            type:: {type: int}
-        "#).into_iter(),
-        2 // this includes the core type int and the anonymous type
-    ),
     case::type_constraint_with_named_type(
-        load(r#" For a schema with named type as below: 
+        load(r#" // For a schema with named type as below: 
             type:: { name: my_int, type: int }
         "#).into_iter(),
         2 // this includes the core type int and the anonymous type
     ),
     case::type_constraint_with_self_reference_type(
-        load(r#" For a schema with self reference type as below: 
+        load(r#" // For a schema with self reference type as below: 
             type:: { name: my_int, type: my_int }
         "#).into_iter(),
         1 // this includes only my_int type
     ),
     case::type_constraint_with_nested_self_reference_type(
-        load(r#" For a schema with nested self reference type as below:
+        load(r#" // For a schema with nested self reference type as below:
             type:: { name: my_int, type: { type: my_int } }
         "#).into_iter(),
         2 // this includes my_int type and the anonymous type that uses my_int
     ),
     case::type_constraint_with_nested_type(
-        load(r#" For a schema with nested types as below:
+        load(r#" // For a schema with nested types as below:
             type:: { name: my_int, type: { type: int } }
         "#).into_iter(),
         3 // this includes my_int type, the anonymous type that uses int and core type int
     ),
     case::type_constraint_with_nested_multiple_types(
-        load(r#"  For a schema with nested multiple types as below: 
+        load(r#" // For a schema with nested multiple types as below: 
             type:: { name: my_int, type: { type: int }, type: { type: my_int } }
         "#).into_iter(),
         4 //  this includes my_int type, the anonymous type that uses int, core type int and the anonymous type that uses my_int type
     ),
-    case::type_constraint_wiht_multiple_types(
-        load(r#" For a schema with multiple type as below:
+    case::type_constraint_with_multiple_types(
+        load(r#" // For a schema with multiple type as below:
              type:: { name: my_int, type: int }
              type:: { name: my_bool, type: bool }
-             type:: { type: string }
         "#).into_iter(),
-        6
+        4
     ),
     case::all_of_constraint(
-        load(r#" For a schema with all_of type as below: 
-            type:: { all_of: [{ type: int }] }
+        load(r#" // For a schema with all_of type as below: 
+            type:: { name: all_of_type, all_of: [{ type: int }] }
         "#).into_iter(),
         3
     ),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,5 @@
 use crate::import::Import;
-use crate::isl::isl_type::IslType;
-use crate::result::IonSchemaResult;
-use crate::system::{PendingTypes, TypeStore};
+use crate::system::TypeStore;
 use crate::types::{TypeDefinition, TypeDefinitionImpl, TypeRef};
 use std::rc::Rc;
 
@@ -24,38 +22,6 @@ impl Schema {
             imports: vec![],
             types,
         }
-    }
-
-    /// Creates a schema from given [IslType]s
-    pub fn try_from_isl_types<A: AsRef<str>, B: Into<Vec<IslType>>>(
-        id: A,
-        isl_types: B,
-    ) -> IonSchemaResult<Self> {
-        // create type_store and pending types which will be used to create type definition
-        let type_store = &mut TypeStore::new();
-        let pending_types = &mut PendingTypes::new();
-        for isl_type in isl_types.into() {
-            // convert [IslType] into [TypeDefinition]
-            match isl_type {
-                IslType::Named(named_isl_type) => TypeDefinition::Named(
-                    TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
-                        &named_isl_type,
-                        type_store,
-                        pending_types,
-                    )
-                    .unwrap(),
-                ),
-                IslType::Anonymous(anonymous_isl_type) => TypeDefinition::Anonymous(
-                    TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
-                        &anonymous_isl_type,
-                        type_store,
-                        pending_types,
-                    )
-                    .unwrap(),
-                ),
-            };
-        }
-        Ok(Schema::new(id, Rc::new(type_store.to_owned())))
     }
 
     /// Returns the id for this Schema

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
 use crate::isl::isl_constraint::IslConstraint;
-use crate::isl::isl_type::IslType;
+use crate::isl::isl_type::{AnonymousIslType, NamedIslType};
 use crate::result::IonSchemaResult;
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::violation::Violations;
@@ -33,22 +33,22 @@ impl TypeRef {
     }
 }
 
-/// A Type consists of an optional name and zero or more constraints.
-///
-/// Unless otherwise specified, the constraint `type: any` is automatically applied.
+/// Represents a [TypeDefinition] which stores a resolved ISL type using [TypeStore]
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeDefinition {
+    NamedTypeDefinition(NamedTypeDefinition),
+    AnonymousTypeDefinition(AnonymousTypeDefinition),
+}
+
+/// A [AnonymousTypeDefinition] consists of a name and zero or more constraints.
 #[derive(Debug, Clone)]
-pub struct TypeDefinition {
-    name: Option<String>,
+pub struct AnonymousTypeDefinition {
     constraints: Vec<Constraint>,
 }
 
-impl TypeDefinition {
-    pub fn new(name: Option<String>, constraints: Vec<Constraint>) -> Self {
-        Self { name, constraints }
-    }
-
-    pub fn name(&self) -> &Option<String> {
-        &self.name
+impl AnonymousTypeDefinition {
+    pub fn new(constraints: Vec<Constraint>) -> Self {
+        Self { constraints }
     }
 
     pub fn constraints(&self) -> &[Constraint] {
@@ -57,22 +57,14 @@ impl TypeDefinition {
 
     /// Parse constraints inside an [OwnedStruct] to a schema [Type]
     pub fn parse_from_isl_type_and_update_type_store(
-        isl_type: &IslType,
+        isl_type: &AnonymousIslType,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
 
-        // parses an isl_type to a TypeDefinition
-        let type_name = isl_type.name();
-
-        // add parent information for named type
-        if type_name.is_some() {
-            pending_types.add_parent(type_name.to_owned().unwrap())
-        }
-
         // add this unresolved type to context for type_id
-        let type_id = pending_types.add_type();
+        let type_id = pending_types.add_type(type_store);
 
         // convert IslConstraint to Constraint
         for isl_constraint in isl_type.constraints() {
@@ -98,33 +90,111 @@ impl TypeDefinition {
             constraints.push(constraint);
         }
 
-        let type_def = TypeDefinition::new(type_name.to_owned(), constraints);
+        let type_def = AnonymousTypeDefinition::new(constraints);
 
         // update with this resolved type_def to context for type_id
-        let type_name = type_def.name();
-        match type_name {
-            Some(name) => {
-                pending_types.update_named_type(type_id, name, type_def.to_owned(), type_store)
-            }
-            None => pending_types.update_anonymous_type(type_id, type_def.to_owned()),
-        };
-
-        // clear parent information from type_store as the type is already added in the type_store now
-        if type_name.is_some() {
-            pending_types.clear_parent();
-        }
+        pending_types.update_anonymous_type(type_id, type_def.to_owned(), type_store);
 
         Ok(type_def)
     }
 }
 
-impl PartialEq for TypeDefinition {
+impl PartialEq for AnonymousTypeDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.constraints == other.constraints()
+    }
+}
+
+impl TypeValidator for AnonymousTypeDefinition {
+    fn is_valid(&self, value: &OwnedElement) -> bool {
+        todo!()
+    }
+
+    fn validate(&self, value: &OwnedElement, issues: &mut Violations) {
+        todo!()
+    }
+}
+
+/// A [NamedTypeDefinition] consists of a name and zero or more constraints.
+#[derive(Debug, Clone)]
+pub struct NamedTypeDefinition {
+    name: String,
+    constraints: Vec<Constraint>,
+}
+
+impl NamedTypeDefinition {
+    pub fn new(name: String, constraints: Vec<Constraint>) -> Self {
+        Self { name, constraints }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn constraints(&self) -> &[Constraint] {
+        &self.constraints
+    }
+
+    /// Parse constraints inside an [OwnedStruct] to a schema [Type]
+    pub fn parse_from_isl_type_and_update_type_store(
+        isl_type: &NamedIslType,
+        type_store: &mut TypeStore,
+        pending_types: &mut PendingTypes,
+    ) -> IonSchemaResult<Self> {
+        let mut constraints = vec![];
+
+        // parses an isl_type to a TypeDefinition
+        let type_name = isl_type.name();
+
+        // add parent information for named type
+        pending_types.add_parent(type_name.to_owned());
+
+        // add this unresolved type to context for type_id
+        let type_id = pending_types.add_type(type_store);
+
+        // convert IslConstraint to Constraint
+        for isl_constraint in isl_type.constraints() {
+            let constraint = match isl_constraint {
+                IslConstraint::AllOf(type_references) => {
+                    let all_of: AllOfConstraint = AllOfConstraint::resolve_from_isl_constraint(
+                        type_references,
+                        type_store,
+                        pending_types,
+                    )?;
+                    Constraint::AllOf(all_of)
+                }
+                IslConstraint::Type(type_reference) => {
+                    let type_constraint: TypeConstraint =
+                        TypeConstraint::resolve_from_isl_constraint(
+                            type_reference,
+                            type_store,
+                            pending_types,
+                        )?;
+                    Constraint::Type(type_constraint)
+                }
+            };
+            constraints.push(constraint);
+        }
+
+        let type_def = NamedTypeDefinition::new(type_name.to_owned(), constraints);
+
+        // update with this resolved type_def to context for type_id
+        pending_types.update_named_type(type_id, type_name, type_def.to_owned(), type_store);
+
+        // clear parent information from type_store as the type is already added in the type_store now
+        pending_types.clear_parent();
+
+        Ok(type_def)
+    }
+}
+
+impl PartialEq for NamedTypeDefinition {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name() && self.constraints == other.constraints()
     }
 }
 
-impl TypeValidator for TypeDefinition {
+impl TypeValidator for NamedTypeDefinition {
     fn is_valid(&self, value: &OwnedElement) -> bool {
         todo!()
     }
@@ -139,7 +209,7 @@ mod type_definition_tests {
     use super::*;
     use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
     use crate::isl::isl_constraint::IslConstraint;
-    use crate::isl::isl_type::IslType;
+    use crate::isl::isl_type::{IslType, NamedIslType};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::system::PendingTypes;
     use ion_rs::IonType;
@@ -148,65 +218,79 @@ mod type_definition_tests {
     #[rstest(
     isl_type, type_def,
     case::type_constraint_with_anonymous_type(
-        /* For a schema with single anonymous type as below: 
+        /* For a schema with single anonymous type as below:
             { type: int }
          */
-        IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]),
-        TypeDefinition::new(None, vec![Constraint::Type(TypeConstraint::new(1))])
+        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])),
+        TypeDefinition::AnonymousTypeDefinition(AnonymousTypeDefinition::new(vec![Constraint::Type(TypeConstraint::new(1))]))
     ),
     case::type_constraint_with_named_type(
-        /* For a schema with named type as below: 
+        /* For a schema with named type as below:
             { name: my_int, type: int }
          */
-        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]),
-        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])),
+        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
     ),
     case::type_constraint_with_self_reference_type(
-        /* For a schema with self reference type as below: 
+        /* For a schema with self reference type as below:
             { name: my_int, type: my_int }
          */
-        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))]),
-        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(0))])
+        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])),
+        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(0))]))
     ),
     case::type_constraint_with_nested_self_reference_type(
-        /* For a schema with nested self reference type as below: 
+        /* For a schema with nested self reference type as below:
             { name: my_int, type: { type: my_int } }
          */
-        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]),
-        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))])),
+        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
     ),
     case::type_constraint_with_nested_type(
-        /* For a schema with nested types as below: 
+        /* For a schema with nested types as below:
             { name: my_int, type: { type: int } }
          */
-        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])))]),
-        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1))])
+        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])))])),
+        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
     ),
     case::type_constraint_with_nested_multiple_types(
-        /* For a schema with nested multiple types as below: 
+        /* For a schema with nested multiple types as below:
             { name: my_int, type: { type: int }, type: { type: my_int } }
          */
-        IslType::new(Some("my_int".to_owned()), vec![IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))), IslConstraint::Type(IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))]),
-        TypeDefinition::new(Some("my_int".to_owned()), vec![Constraint::Type(TypeConstraint::new(1)), Constraint::Type(TypeConstraint::new(3))])
+        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))), IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))])),
+        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1)), Constraint::Type(TypeConstraint::new(3))]))
     ),
     case::all_of_constraint(
-        /* For a schema with all_of type as below: 
+        /* For a schema with all_of type as below:
             { all_of: [{ type: int }] }
         */
-        IslType::new(None, vec![IslConstraint::AllOf(vec![IslTypeRef::AnonymousType(IslType::new(None, vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))])]),
-        TypeDefinition::new(None, vec![Constraint::AllOf(AllOfConstraint::new(vec![1]))])
+        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::AllOf(vec![IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))])])),
+        TypeDefinition::AnonymousTypeDefinition(AnonymousTypeDefinition::new(vec![Constraint::AllOf(AllOfConstraint::new(vec![1]))]))
     ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
-        // assert if both the IslType are same in terms of constraints and name
+        // assert if both the TypeDefinition are same in terms of constraints and name
         let type_store = &mut TypeStore::new();
         let pending_types = &mut PendingTypes::new();
-        let this_type_def = TypeDefinition::parse_from_isl_type_and_update_type_store(
-            &isl_type,
-            type_store,
-            pending_types,
-        )
-        .unwrap();
+        let this_type_def = match isl_type {
+            IslType::NamedIslType(named_isl_type) => TypeDefinition::NamedTypeDefinition(
+                NamedTypeDefinition::parse_from_isl_type_and_update_type_store(
+                    &named_isl_type,
+                    type_store,
+                    pending_types,
+                )
+                .unwrap(),
+            ),
+            IslType::AnonymousIslType(anonymous_isl_type) => {
+                TypeDefinition::AnonymousTypeDefinition(
+                    AnonymousTypeDefinition::parse_from_isl_type_and_update_type_store(
+                        &anonymous_isl_type,
+                        type_store,
+                        pending_types,
+                    )
+                    .unwrap(),
+                )
+            }
+        };
         assert_eq!(this_type_def, type_def);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
-use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
-use crate::isl::isl_constraint::IslConstraint;
-use crate::isl::isl_type::{AnonymousIslType, NamedIslType};
+use crate::constraint::Constraint;
+use crate::isl::isl_type::IslTypeImpl;
 use crate::result::IonSchemaResult;
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::violation::Violations;
@@ -36,98 +35,43 @@ impl TypeRef {
 /// Represents a [TypeDefinition] which stores a resolved ISL type using [TypeStore]
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDefinition {
-    NamedTypeDefinition(NamedTypeDefinition),
-    AnonymousTypeDefinition(AnonymousTypeDefinition),
+    Named(TypeDefinitionImpl),
+    Anonymous(TypeDefinitionImpl),
 }
 
-/// A [AnonymousTypeDefinition] consists of a name and zero or more constraints.
-#[derive(Debug, Clone)]
-pub struct AnonymousTypeDefinition {
-    constraints: Vec<Constraint>,
-}
-
-impl AnonymousTypeDefinition {
-    pub fn new(constraints: Vec<Constraint>) -> Self {
-        Self { constraints }
+impl TypeDefinition {
+    /// Creates a [IslType::Named] using the [IslConstraint] defined within it
+    pub fn named(name: String, constraints: Vec<Constraint>) -> TypeDefinition {
+        TypeDefinition::Named(TypeDefinitionImpl::new(Some(name), constraints))
     }
 
+    /// Creates a [IslType::Anonymous] using the [IslConstraint] defined within it
+    pub fn anonymous(constraints: Vec<Constraint>) -> TypeDefinition {
+        TypeDefinition::Anonymous(TypeDefinitionImpl::new(None, constraints))
+    }
+
+    /// Provides the underlying constraints of [TypeDefinitionImpl]
     pub fn constraints(&self) -> &[Constraint] {
-        &self.constraints
-    }
-
-    /// Parse constraints inside an [OwnedStruct] to a schema [Type]
-    pub fn parse_from_isl_type_and_update_type_store(
-        isl_type: &AnonymousIslType,
-        type_store: &mut TypeStore,
-        pending_types: &mut PendingTypes,
-    ) -> IonSchemaResult<Self> {
-        let mut constraints = vec![];
-
-        // add this unresolved type to context for type_id
-        let type_id = pending_types.add_type(type_store);
-
-        // convert IslConstraint to Constraint
-        for isl_constraint in isl_type.constraints() {
-            let constraint = match isl_constraint {
-                IslConstraint::AllOf(type_references) => {
-                    let all_of: AllOfConstraint = AllOfConstraint::resolve_from_isl_constraint(
-                        type_references,
-                        type_store,
-                        pending_types,
-                    )?;
-                    Constraint::AllOf(all_of)
-                }
-                IslConstraint::Type(type_reference) => {
-                    let type_constraint: TypeConstraint =
-                        TypeConstraint::resolve_from_isl_constraint(
-                            type_reference,
-                            type_store,
-                            pending_types,
-                        )?;
-                    Constraint::Type(type_constraint)
-                }
-            };
-            constraints.push(constraint);
+        match &self {
+            TypeDefinition::Named(named_type) => named_type.constraints(),
+            TypeDefinition::Anonymous(anonymous_type) => anonymous_type.constraints(),
         }
-
-        let type_def = AnonymousTypeDefinition::new(constraints);
-
-        // update with this resolved type_def to context for type_id
-        pending_types.update_anonymous_type(type_id, type_def.to_owned(), type_store);
-
-        Ok(type_def)
     }
 }
 
-impl PartialEq for AnonymousTypeDefinition {
-    fn eq(&self, other: &Self) -> bool {
-        self.constraints == other.constraints()
-    }
-}
-
-impl TypeValidator for AnonymousTypeDefinition {
-    fn is_valid(&self, value: &OwnedElement) -> bool {
-        todo!()
-    }
-
-    fn validate(&self, value: &OwnedElement, issues: &mut Violations) {
-        todo!()
-    }
-}
-
-/// A [NamedTypeDefinition] consists of a name and zero or more constraints.
+/// A [TypeDefinitionImpl] consists of an optional name and zero or more constraints.
 #[derive(Debug, Clone)]
-pub struct NamedTypeDefinition {
-    name: String,
+pub struct TypeDefinitionImpl {
+    name: Option<String>,
     constraints: Vec<Constraint>,
 }
 
-impl NamedTypeDefinition {
-    pub fn new(name: String, constraints: Vec<Constraint>) -> Self {
+impl TypeDefinitionImpl {
+    pub fn new(name: Option<String>, constraints: Vec<Constraint>) -> Self {
         Self { name, constraints }
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &Option<String> {
         &self.name
     }
 
@@ -137,7 +81,7 @@ impl NamedTypeDefinition {
 
     /// Parse constraints inside an [OwnedStruct] to a schema [Type]
     pub fn parse_from_isl_type_and_update_type_store(
-        isl_type: &NamedIslType,
+        isl_type: &IslTypeImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<Self> {
@@ -147,54 +91,49 @@ impl NamedTypeDefinition {
         let type_name = isl_type.name();
 
         // add parent information for named type
-        pending_types.add_parent(type_name.to_owned());
+        if type_name.is_some() {
+            pending_types.add_parent(type_name.to_owned().unwrap());
+        }
 
         // add this unresolved type to context for type_id
         let type_id = pending_types.add_type(type_store);
 
         // convert IslConstraint to Constraint
         for isl_constraint in isl_type.constraints() {
-            let constraint = match isl_constraint {
-                IslConstraint::AllOf(type_references) => {
-                    let all_of: AllOfConstraint = AllOfConstraint::resolve_from_isl_constraint(
-                        type_references,
-                        type_store,
-                        pending_types,
-                    )?;
-                    Constraint::AllOf(all_of)
-                }
-                IslConstraint::Type(type_reference) => {
-                    let type_constraint: TypeConstraint =
-                        TypeConstraint::resolve_from_isl_constraint(
-                            type_reference,
-                            type_store,
-                            pending_types,
-                        )?;
-                    Constraint::Type(type_constraint)
-                }
-            };
+            let constraint =
+                Constraint::parse_from_isl_constraint(isl_constraint, type_store, pending_types)?;
             constraints.push(constraint);
         }
 
-        let type_def = NamedTypeDefinition::new(type_name.to_owned(), constraints);
+        let type_def = TypeDefinitionImpl::new(type_name.to_owned(), constraints);
 
-        // update with this resolved type_def to context for type_id
-        pending_types.update_named_type(type_id, type_name, type_def.to_owned(), type_store);
+        if type_name.is_some() {
+            // update with this resolved type_def to context for type_id
+            pending_types.update_named_type(
+                type_id,
+                type_name.as_ref().unwrap(),
+                type_def.to_owned(),
+                type_store,
+            );
 
-        // clear parent information from type_store as the type is already added in the type_store now
-        pending_types.clear_parent();
+            // clear parent information from type_store as the type is already added in the type_store now
+            pending_types.clear_parent();
+        } else {
+            // update with this resolved type_def to context for type_id
+            pending_types.update_anonymous_type(type_id, type_def.to_owned(), type_store);
+        }
 
         Ok(type_def)
     }
 }
 
-impl PartialEq for NamedTypeDefinition {
+impl PartialEq for TypeDefinitionImpl {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name() && self.constraints == other.constraints()
     }
 }
 
-impl TypeValidator for NamedTypeDefinition {
+impl TypeValidator for TypeDefinitionImpl {
     fn is_valid(&self, value: &OwnedElement) -> bool {
         todo!()
     }
@@ -207,9 +146,9 @@ impl TypeValidator for NamedTypeDefinition {
 #[cfg(test)]
 mod type_definition_tests {
     use super::*;
-    use crate::constraint::{AllOfConstraint, Constraint, TypeConstraint};
+    use crate::constraint::Constraint;
     use crate::isl::isl_constraint::IslConstraint;
-    use crate::isl::isl_type::{IslType, NamedIslType};
+    use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::system::PendingTypes;
     use ion_rs::IonType;
@@ -221,50 +160,50 @@ mod type_definition_tests {
         /* For a schema with single anonymous type as below:
             { type: int }
          */
-        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])),
-        TypeDefinition::AnonymousTypeDefinition(AnonymousTypeDefinition::new(vec![Constraint::Type(TypeConstraint::new(1))]))
+        IslType::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))]),
+        TypeDefinition::anonymous(vec![Constraint::type_constraint(1)])
     ),
     case::type_constraint_with_named_type(
         /* For a schema with named type as below:
             { name: my_int, type: int }
          */
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])),
-        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))]),
+        TypeDefinition::named("my_int".to_owned(), vec![Constraint::type_constraint(1)])
     ),
     case::type_constraint_with_self_reference_type(
         /* For a schema with self reference type as below:
             { name: my_int, type: my_int }
          */
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])),
-        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(0))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))]),
+        TypeDefinition::named("my_int".to_owned(), vec![Constraint::type_constraint(0)])
     ),
     case::type_constraint_with_nested_self_reference_type(
         /* For a schema with nested self reference type as below:
             { name: my_int, type: { type: my_int } }
          */
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))])),
-        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))]))]),
+        TypeDefinition::named("my_int".to_owned(), vec![Constraint::type_constraint(1)])
     ),
     case::type_constraint_with_nested_type(
         /* For a schema with nested types as below:
             { name: my_int, type: { type: int } }
          */
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))])))])),
-        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))]))]),
+        TypeDefinition::named("my_int".to_owned(), vec![Constraint::type_constraint(1)])
     ),
     case::type_constraint_with_nested_multiple_types(
         /* For a schema with nested multiple types as below:
             { name: my_int, type: { type: int }, type: { type: my_int } }
          */
-        IslType::NamedIslType(NamedIslType::new("my_int".to_owned(), vec![IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))), IslConstraint::Type(IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::NamedType("my_int".to_owned()))])))])),
-        TypeDefinition::NamedTypeDefinition(NamedTypeDefinition::new("my_int".to_owned(), vec![Constraint::Type(TypeConstraint::new(1)), Constraint::Type(TypeConstraint::new(3))]))
+        IslType::named("my_int".to_owned(), vec![IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])), IslConstraint::type_constraint(IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::named("my_int".to_owned()))]))]),
+        TypeDefinition::named("my_int".to_owned(), vec![Constraint::type_constraint(1), Constraint::type_constraint(3)])
     ),
     case::all_of_constraint(
         /* For a schema with all_of type as below:
             { all_of: [{ type: int }] }
         */
-        IslType::AnonymousIslType(AnonymousIslType::new(vec![IslConstraint::AllOf(vec![IslTypeRef::AnonymousType(AnonymousIslType::new(vec![IslConstraint::Type(IslTypeRef::CoreIslType(IonType::Integer))]))])])),
-        TypeDefinition::AnonymousTypeDefinition(AnonymousTypeDefinition::new(vec![Constraint::AllOf(AllOfConstraint::new(vec![1]))]))
+        IslType::anonymous(vec![IslConstraint::all_of(vec![IslTypeRef::anonymous(vec![IslConstraint::type_constraint(IslTypeRef::core_isl(IonType::Integer))])])]),
+        TypeDefinition::anonymous(vec![Constraint::all_of(vec![1])])
     ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
@@ -272,24 +211,22 @@ mod type_definition_tests {
         let type_store = &mut TypeStore::new();
         let pending_types = &mut PendingTypes::new();
         let this_type_def = match isl_type {
-            IslType::NamedIslType(named_isl_type) => TypeDefinition::NamedTypeDefinition(
-                NamedTypeDefinition::parse_from_isl_type_and_update_type_store(
+            IslType::Named(named_isl_type) => TypeDefinition::Named(
+                TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
                     &named_isl_type,
                     type_store,
                     pending_types,
                 )
                 .unwrap(),
             ),
-            IslType::AnonymousIslType(anonymous_isl_type) => {
-                TypeDefinition::AnonymousTypeDefinition(
-                    AnonymousTypeDefinition::parse_from_isl_type_and_update_type_store(
-                        &anonymous_isl_type,
-                        type_store,
-                        pending_types,
-                    )
-                    .unwrap(),
+            IslType::Anonymous(anonymous_isl_type) => TypeDefinition::Anonymous(
+                TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
+                    &anonymous_isl_type,
+                    type_store,
+                    pending_types,
                 )
-            }
+                .unwrap(),
+            ),
         };
         assert_eq!(this_type_def, type_def);
     }


### PR DESCRIPTION
*Issue:*
Fixes #25 

*Description of changes:*
- adds `IslType` enum with two different implementations for anonymous and named ISL types
- adds `TypeDefinition` enum with two implementations for anonymous and named type definitions
- Fixes a bug in `PendingType`s to store correct `TypeId` in `Constraint`s (`type_id + type_store.types_by_id.len()`)

*Tests:*
adds changes for using corresponding anonymous/named types in unit tests.
