### PR TITLE
adds changes for implmentation of `IslImport`

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -1,7 +1,8 @@
-use crate::result::IonSchemaResult;
+use crate::result::{unresolvable_schema_error_raw, IonSchemaResult};
 use ion_rs::result::IonError;
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::reader::{element_reader, ElementReader};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -42,6 +43,35 @@ impl DocumentAuthority for FileSystemDocumentAuthority {
         // if absolute_path exists for the given id then load schema with file contents
         let ion_content = fs::read(absolute_path)?;
         let iterator = element_reader().iterate_over(&ion_content)?;
+        let schema_content = iterator.collect::<Result<Vec<OwnedElement>, IonError>>()?;
+        Ok(schema_content)
+    }
+}
+
+/// An [Authority] implementation that attempts to resolve schema ids to ion elements using the map.
+#[derive(Debug, Clone)]
+pub struct MapDocumentAuthority {
+    ion_content_by_id: HashMap<String, String>, // This map represents (id, ion content) which can used to resolve schema ids to Vec<OwnedElement>
+}
+
+impl MapDocumentAuthority {
+    pub fn new(ion_content_by_id: HashMap<String, String>) -> Self {
+        Self { ion_content_by_id }
+    }
+}
+
+impl DocumentAuthority for MapDocumentAuthority {
+    /// Returns a vector of [OwnedElement]s based on given schema id using ion_content_by_id map
+    fn elements(&self, id: &str) -> IonSchemaResult<Vec<OwnedElement>> {
+        // if ion content exists for the given id  in the map then return ion content as OwnedElements
+        let ion_content = self
+            .ion_content_by_id
+            .get(id)
+            .ok_or(unresolvable_schema_error_raw(format!(
+                "MapDocumentAuthority does not contain schema with id: {}",
+                id
+            )))?;
+        let iterator = element_reader().iterate_over(ion_content.as_bytes())?;
         let schema_content = iterator.collect::<Result<Vec<OwnedElement>, IonError>>()?;
         Ok(schema_content)
     }

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -55,8 +55,13 @@ pub struct MapDocumentAuthority {
 }
 
 impl MapDocumentAuthority {
-    pub fn new(ion_content_by_id: HashMap<String, String>) -> Self {
-        Self { ion_content_by_id }
+    pub fn new<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(ion_content_by_id: I) -> Self {
+        Self {
+            ion_content_by_id: ion_content_by_id
+                .into_iter()
+                .map(|(id, ion)| (id.to_owned(), ion.to_owned()))
+                .collect(),
+        }
     }
 }
 

--- a/src/isl/isl_import.rs
+++ b/src/isl/isl_import.rs
@@ -19,6 +19,7 @@ impl IslImport {
             IslImport::TypeAlias(isl_import_impl) => isl_import_impl.id(),
         }
     }
+
     /// Parse constraints inside an [OwnedElement] to an [IslImport]
     pub fn parse_from_ion_element(value: &OwnedElement) -> IonSchemaResult<IslImport> {
         let import = try_to!(value.as_struct());
@@ -39,6 +40,14 @@ impl IslImport {
         let alias = import
             .get("as")
             .and_then(|alias| alias.as_str().and_then(|a| Some(a.to_owned())));
+
+        if alias.is_none() {
+            return Ok(IslImport::Type(IslImportImpl::new(
+                id.to_owned(),
+                type_name.to_owned(),
+                None,
+            )));
+        }
 
         Ok(IslImport::TypeAlias(IslImportImpl::new(
             id.to_owned(),
@@ -69,5 +78,13 @@ impl IslImportImpl {
 
     fn id(&self) -> &String {
         &self.id
+    }
+
+    pub fn type_name(&self) -> &String {
+        &self.type_name
+    }
+
+    pub fn alias(&self) -> &Option<String> {
+        &self.alias
     }
 }

--- a/src/isl/isl_import.rs
+++ b/src/isl/isl_import.rs
@@ -1,0 +1,73 @@
+use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
+use ion_rs::value::owned::OwnedElement;
+use ion_rs::value::{Element, Struct};
+
+/// Represents an import in an ISL schema.
+/// For more information: https://amzn.github.io/ion-schema/docs/spec.html#imports
+#[derive(Debug, Clone, PartialEq)]
+pub enum IslImport {
+    Schema(String),
+    Type(IslImportImpl),
+    TypeAlias(IslImportImpl),
+}
+
+impl IslImport {
+    pub fn id(&self) -> &String {
+        match self {
+            IslImport::Schema(id) => id,
+            IslImport::Type(isl_import_impl) => isl_import_impl.id(),
+            IslImport::TypeAlias(isl_import_impl) => isl_import_impl.id(),
+        }
+    }
+    /// Parse constraints inside an [OwnedElement] to an [IslImport]
+    pub fn parse_from_ion_element(value: &OwnedElement) -> IonSchemaResult<IslImport> {
+        let import = try_to!(value.as_struct());
+        let id = match import.get("id") {
+            Some(import_id) => try_to!(import_id.as_str()),
+            None => {
+                return Err(invalid_schema_error_raw(
+                    "import must have an id field in its definition",
+                ))
+            }
+        };
+
+        let type_name = match import.get("type") {
+            Some(type_name) => try_to!(type_name.as_str()),
+            None => return Ok(IslImport::Schema(id.to_owned())),
+        };
+
+        let alias = import
+            .get("as")
+            .and_then(|alias| alias.as_str().and_then(|a| Some(a.to_owned())));
+
+        Ok(IslImport::TypeAlias(IslImportImpl::new(
+            id.to_owned(),
+            type_name.to_owned(),
+            alias,
+        )))
+    }
+}
+
+/// Represents typed and type aliased [IslImport]s
+/// Typed import grammar: `{ id: <ID>, type: <TYPE_NAME> }`
+/// Type aliased import grammar: `{ id: <ID>, type: <TYPE_NAME>, as: <TYPE_ALIAS> }`
+#[derive(Debug, Clone, PartialEq)]
+pub struct IslImportImpl {
+    id: String,
+    type_name: String,
+    alias: Option<String>,
+}
+
+impl IslImportImpl {
+    pub fn new(id: String, type_name: String, alias: Option<String>) -> Self {
+        Self {
+            id,
+            type_name,
+            alias,
+        }
+    }
+
+    fn id(&self) -> &String {
+        &self.id
+    }
+}

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -52,7 +52,7 @@ impl IslTypeImpl {
         &self.constraints
     }
 
-    /// Parse constraints inside an [OwnedElement] to an [NamedIslType]
+    /// Parse constraints inside an [OwnedElement] to an [IslTypeImpl]
     pub fn parse_from_owned_element(ion: &OwnedElement) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
         let annotations: Vec<&OwnedSymbolToken> = ion.annotations().collect();

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -5,6 +5,9 @@
 //! * `isl_type` module represents a schema type [IslType] which converts given ion content in the schema file
 //! into an ISL types(not-yet-resolved types). It stores [IslConstraint]s defined within the given type.
 //!
+//! * `isl_import` module represents a schema import [IslImport] which converts given ion content in the schema file
+//! into an ISL import. It stores schema id, an optional type that needs to be imported and an optional alias to that type.
+//!
 //! * `isl_constraint` module represents schema constraints [IslConstraint]
 //! which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
 //! This stores [IslTypeRef]s for the given ISL constraint.
@@ -71,6 +74,7 @@
 //                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
 
 pub mod isl_constraint;
+pub mod isl_import;
 pub mod isl_type;
 pub mod isl_type_reference;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -39,7 +39,7 @@ impl Schema {
     }
 
     /// Returns an iterator over the imported types of this [Schema].
-    fn import_types(&self) -> SchemaTypeIterator {
+    fn imported_types(&self) -> SchemaTypeIterator {
         SchemaTypeIterator::new(Rc::clone(&self.types), self.types.get_imports())
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -162,7 +162,7 @@ mod schema_tests {
 
         // create a schema from owned_elements and verifies if the result is `ok`
         let schema =
-            resolver.schema_from_elements(owned_elements, "my_schema.isl", type_store, false);
+            resolver.schema_from_elements(owned_elements, "my_schema.isl", type_store, false, None);
         assert_eq!(schema.is_ok(), true);
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -162,7 +162,7 @@ mod schema_tests {
 
         // create a schema from owned_elements and verifies if the result is `ok`
         let schema =
-            resolver.schema_from_elements(owned_elements, "my_schema.isl", type_store, false, None);
+            resolver.schema_from_elements(owned_elements, "my_schema.isl", type_store, None);
         assert_eq!(schema.is_ok(), true);
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -35,6 +35,11 @@ impl Schema {
 
     /// Returns an iterator over the imports of this [Schema].
     fn imports(&self) -> SchemaTypeIterator {
+        todo!()
+    }
+
+    /// Returns an iterator over the imported types of this [Schema].
+    fn import_types(&self) -> SchemaTypeIterator {
         SchemaTypeIterator::new(Rc::clone(&self.types), self.types.get_imports())
     }
 
@@ -45,6 +50,7 @@ impl Schema {
     }
 
     /// Returns an iterator over the types in this schema.
+    /// This includes the core types and named types defined within this schema.
     pub(crate) fn get_types(&self) -> SchemaTypeIterator {
         SchemaTypeIterator::new(Rc::clone(&self.types), self.types.get_types())
     }
@@ -112,7 +118,7 @@ mod schema_tests {
         load(r#" // For a schema with named type as below: 
             type:: { name: my_int, type: int }
         "#).into_iter(),
-        2 // this includes the core type int and the anonymous type
+        2 // this includes the named type my_int and core type int
     ),
     case::type_constraint_with_self_reference_type(
         load(r#" // For a schema with self reference type as below: 
@@ -124,19 +130,19 @@ mod schema_tests {
         load(r#" // For a schema with nested self reference type as below:
             type:: { name: my_int, type: { type: my_int } }
         "#).into_iter(),
-        1 // this includes my_int type and the anonymous type that uses my_int
+        1 // this includes my_int type 
     ),
     case::type_constraint_with_nested_type(
         load(r#" // For a schema with nested types as below:
             type:: { name: my_int, type: { type: int } }
         "#).into_iter(),
-        2 // this includes my_int type, the anonymous type that uses int and core type int
+        2 // this includes my_int type and core type int
     ),
     case::type_constraint_with_nested_multiple_types(
         load(r#" // For a schema with nested multiple types as below: 
             type:: { name: my_int, type: { type: int }, type: { type: my_int } }
         "#).into_iter(),
-        2 //  this includes my_int type, the anonymous type that uses int, core type int and the anonymous type that uses my_int type
+        2 //  this includes my_int type and core type int
     ),
     case::type_constraint_with_multiple_types(
         load(r#" // For a schema with multiple type as below:

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -124,19 +124,19 @@ mod schema_tests {
         load(r#" // For a schema with nested self reference type as below:
             type:: { name: my_int, type: { type: my_int } }
         "#).into_iter(),
-        2 // this includes my_int type and the anonymous type that uses my_int
+        1 // this includes my_int type and the anonymous type that uses my_int
     ),
     case::type_constraint_with_nested_type(
         load(r#" // For a schema with nested types as below:
             type:: { name: my_int, type: { type: int } }
         "#).into_iter(),
-        3 // this includes my_int type, the anonymous type that uses int and core type int
+        2 // this includes my_int type, the anonymous type that uses int and core type int
     ),
     case::type_constraint_with_nested_multiple_types(
         load(r#" // For a schema with nested multiple types as below: 
             type:: { name: my_int, type: { type: int }, type: { type: my_int } }
         "#).into_iter(),
-        4 //  this includes my_int type, the anonymous type that uses int, core type int and the anonymous type that uses my_int type
+        2 //  this includes my_int type, the anonymous type that uses int, core type int and the anonymous type that uses my_int type
     ),
     case::type_constraint_with_multiple_types(
         load(r#" // For a schema with multiple type as below:
@@ -149,7 +149,7 @@ mod schema_tests {
         load(r#" // For a schema with all_of type as below: 
             type:: { name: all_of_type, all_of: [{ type: int }] }
         "#).into_iter(),
-        3
+        2
     ),
     )]
     fn owned_elements_to_schema<'a, I: Iterator<Item = OwnedElement>>(

--- a/src/system.rs
+++ b/src/system.rs
@@ -42,12 +42,127 @@ impl PendingTypes {
         }
     }
 
-    /// Adds all the types from Context into given TypeStore and clears Context types for loading next set of types
-    /// this is used after a schema named type/root type is loaded entirely into Context
+    /// Adds all the types from Context into given [TypeStore] including adding all the imported types into imports of [TypeStore].
+    /// It also clears [Context] types for loading next set of types.
+    /// This method is used after a schema named type/root type is loaded entirely into [Context]
+    /// * `type_store` - The TypeStore which will be updated with the types within this PendingType
+    /// * `load_isl_import` - If this argument is Some(isl_import), then we are not within an import process of schema.
+    ///                       Based on given enum variant isl_import we will add the types to type_store.
+    ///                       Otherwise we will add all the types from this PendingTypes to TypeStore.
     pub fn update_type_store(
         &mut self,
         type_store: &mut TypeStore,
         load_isl_import: Option<&IslImport>,
+    ) -> IonSchemaResult<bool> {
+        // if load_isl_import is not None, then match the enum variant and update type store with import types accordingly
+        if load_isl_import.is_some() {
+            match load_isl_import.unwrap() {
+                IslImport::Schema(_) => {
+                    self.update_type_store_with_all_import_types(None, type_store)?;
+                }
+                IslImport::Type(isl_import) => {
+                    // if import has a specified type to import then only add that type
+                    if let Some(named_type_def) =
+                        self.get_type_by_name_for_import(isl_import.type_name(), type_store)
+                    {
+                        type_store.add_import_type(isl_import.alias().as_ref(), named_type_def?);
+                        self.update_type_store_with_all_import_types(
+                            Some(isl_import.type_name()),
+                            type_store,
+                        )?;
+                    } else {
+                        // if the named_type_def appears as None then it means we haven't reached
+                        // the named type to be imported yet hence we return with false pointing
+                        // we haven't yet resolved this import.
+                        return Ok(false);
+                    }
+                }
+                IslImport::TypeAlias(isl_import) => {
+                    // if import has a specified type with an alias then renamed that type to the given alias and add it
+                    if type_store
+                        .imported_type_ids_by_name
+                        .contains_key(isl_import.alias().as_ref().unwrap())
+                    {
+                        // if the type_store already has the import in it then return true (i.e. TypeAlias has already been imported)
+                        return Ok(true);
+                    } else if let Some(named_type_def) =
+                        self.get_type_by_name_for_import(isl_import.type_name(), type_store)
+                    {
+                        let aliased_type_def = named_type_def?
+                            .with_name(isl_import.alias().as_ref().unwrap().to_owned());
+                        type_store.add_import_type(isl_import.alias().as_ref(), aliased_type_def);
+                        self.update_type_store_with_all_import_types(
+                            Some(isl_import.type_name()),
+                            type_store,
+                        )?;
+                    } else {
+                        // if the named_type_def appears as None then it means we haven't reached
+                        // the named type to be imported yet hence we return with false pointing
+                        // we haven't yet resolved this import.
+                        return Ok(false);
+                    }
+                }
+            }
+        } else {
+            // if load_isl_import is None i.e. it is the root schema, then update type_store with all the types inside this PendingTypes
+            self.update_type_store_with_all_types(type_store)?;
+        }
+        self.types_by_id.clear();
+        self.ids_by_name.clear();
+        Ok(true)
+    }
+
+    // helper method get named type for given import_type_name from this PendingTypes
+    // this return type will be used by update_type_store method to then update type_store with this named type as import
+    fn get_type_by_name_for_import(
+        &self,
+        import_type_name: &str,
+        type_store: &mut TypeStore,
+    ) -> Option<IonSchemaResult<TypeDefinitionImpl>> {
+        let type_def = self
+            .get_type_id_by_name(import_type_name, type_store)
+            .and_then(|id| self.types_by_id[id].to_owned());
+
+        match type_def {
+            None => None,
+            Some(type_def) => match type_def {
+                TypeDefinition::Named(named_type_def) => Some(Ok(named_type_def)),
+                TypeDefinition::Anonymous(_) => Some(unresolvable_schema_error(format!(
+                    "Unable to load import type: {} for schema",
+                    import_type_name
+                ))),
+            },
+        }
+    }
+
+    // helper method to update type store with all the types from this PendingTypes
+    fn update_type_store_with_all_types(&self, type_store: &mut TypeStore) -> IonSchemaResult<()> {
+        for optional_type in &self.types_by_id {
+            // return an error if any of the type in types_by_id vector is None/Unresolved
+            let type_def = optional_type
+                .to_owned()
+                .ok_or(unresolvable_schema_error_raw(
+                    "Unable to load schema due to unresolvable type",
+                ))?;
+
+            match type_def.to_owned() {
+                TypeDefinition::Named(named_type_def) => type_store.add_named_type(named_type_def),
+                TypeDefinition::Anonymous(anonymous_type_def) => {
+                    type_store.add_anonymous_type(anonymous_type_def)
+                }
+            };
+        }
+        Ok(())
+    }
+
+    // helper method to update type store with all the types from this PendingTypes
+    // import_type_name: this argument represents whether the import type is SchemaImport or a TypeImport (includes both TypeImport and TypeAliasImport)
+    //                   None - represents its a schema import which imports all types into imported_type_ids_by_name section of type_store
+    //                   Some(_) - represents a type import which import all types into types_by_id of type_store except specified import type as it will be already loaded by parent method that uses this helper method
+    fn update_type_store_with_all_import_types(
+        &self,
+        import_type_name: Option<&str>,
+        type_store: &mut TypeStore,
     ) -> IonSchemaResult<()> {
         for optional_type in &self.types_by_id {
             // return an error if any of the type in types_by_id vector is None/Unresolved
@@ -57,57 +172,30 @@ impl PendingTypes {
                     "Unable to load schema due to unresolvable type",
                 ))?;
 
-            if load_isl_import.is_some() {
-                match type_def.to_owned() {
-                    TypeDefinition::Named(named_type_def) => match load_isl_import.unwrap() {
-                        IslImport::Schema(_) => type_store.add_import_type(named_type_def),
-                        IslImport::Type(isl_import) => {
-                            // if import has a specified type to import then only add that type
-                            if named_type_def
-                                .name()
-                                .as_ref()
-                                .unwrap()
-                                .eq(isl_import.type_name())
-                            {
-                                type_store.add_import_type(named_type_def)
-                            } else {
+            match type_def.to_owned() {
+                TypeDefinition::Named(named_type_def) => {
+                    match import_type_name {
+                        None => {
+                            // imports all types into imported_type_ids_by_name section of type_store
+                            type_store.add_import_type(None, named_type_def);
+                        }
+                        Some(import_type_name) => {
+                            // skip the specified import type as it will be already loaded by parent method that uses this helper method
+                            if named_type_def.name().as_ref().unwrap().eq(import_type_name) {
                                 continue;
                             }
+                            // import all types into types_by_id of type_store which will help resolving the given import type
+                            type_store
+                                .types_by_id
+                                .push(TypeDefinition::Named(named_type_def));
                         }
-                        IslImport::TypeAlias(isl_import) => {
-                            // if import has a specified type with an alias then renamed that type to the given alias and add it
-                            if named_type_def
-                                .name()
-                                .as_ref()
-                                .unwrap()
-                                .eq(isl_import.type_name())
-                            {
-                                type_store.add_alias_import_type(
-                                    isl_import.alias().as_ref().unwrap(),
-                                    named_type_def,
-                                )
-                            } else {
-                                continue;
-                            }
-                        }
-                    },
-                    TypeDefinition::Anonymous(anonymous_type_def) => {
-                        type_store.add_anonymous_type(anonymous_type_def)
                     }
-                };
-            } else {
-                match type_def.to_owned() {
-                    TypeDefinition::Named(named_type_def) => {
-                        type_store.add_named_type(named_type_def)
-                    }
-                    TypeDefinition::Anonymous(anonymous_type_def) => {
-                        type_store.add_anonymous_type(anonymous_type_def)
-                    }
-                };
-            }
+                }
+                TypeDefinition::Anonymous(anonymous_type_def) => {
+                    type_store.add_anonymous_type(anonymous_type_def);
+                }
+            };
         }
-        self.types_by_id.clear();
-        self.ids_by_name.clear();
         Ok(())
     }
 
@@ -120,9 +208,9 @@ impl PendingTypes {
     /// Otherwise returns None
     pub fn get_type_id_by_name(&self, name: &str, type_store: &mut TypeStore) -> Option<TypeId> {
         match self.ids_by_name.get(name) {
-            Some(id) => Some(*id),
+            Some(id) => Some(*id + type_store.types_by_id.len()),
             None => match type_store.get_type_id_by_name(name) {
-                Some(id) => Some(*id + type_store.types_by_id.len()),
+                Some(id) => Some(*id),
                 None => None,
             },
         }
@@ -210,15 +298,15 @@ pub type TypeId = usize;
 /// Defines a cache that can be used to store resolved [Type]s of a [Schema]
 #[derive(Debug, Clone)]
 pub struct TypeStore {
-    imports: HashMap<String, TypeId>, // stores all the imported types of a schema
-    ids_by_name: HashMap<String, TypeId>,
+    imported_type_ids_by_name: HashMap<String, TypeId>, // stores all the imported types of a schema
+    ids_by_name: HashMap<String, TypeId>, // stores all the core types and named types defined within the schema
     types_by_id: Vec<TypeDefinition>,
 }
 
 impl TypeStore {
     pub fn new() -> Self {
         Self {
-            imports: HashMap::new(),
+            imported_type_ids_by_name: HashMap::new(),
             ids_by_name: HashMap::new(),
             types_by_id: Vec::new(),
         }
@@ -231,7 +319,7 @@ impl TypeStore {
 
     /// Returns import [TypeId]s stored in the [TypeStore] to be used by [SchemaTypeIterator]
     pub fn get_imports(&self) -> Vec<TypeId> {
-        self.imports.values().cloned().collect()
+        self.imported_type_ids_by_name.values().cloned().collect()
     }
 
     /// Provides the [Type] associated with given name if it exists in the [TypeStore]  
@@ -241,7 +329,7 @@ impl TypeStore {
             .get(name)
             .and_then(|id| self.types_by_id.get(*id))
             .or_else(|| {
-                self.imports
+                self.imported_type_ids_by_name
                     .get(name)
                     .and_then(|id| self.types_by_id.get(*id))
             })
@@ -252,7 +340,7 @@ impl TypeStore {
     pub fn get_type_id_by_name(&self, name: &str) -> Option<&TypeId> {
         self.ids_by_name
             .get(name)
-            .or_else(|| self.imports.get(name))
+            .or_else(|| self.imported_type_ids_by_name.get(name))
     }
 
     /// Provides the [Type] associated with given [TypeId] if it exists in the [TypeStore]  
@@ -276,25 +364,22 @@ impl TypeStore {
 
     /// Adds the [NamedTypeDefinition] and the associated name as the imports of [TypeStore]
     ///  and returns the [TypeId] for it. If the name already exists in the [TypeStore] it returns the associated [TypeId]
-    pub fn add_import_type(&mut self, type_def: TypeDefinitionImpl) -> TypeId {
-        let name = type_def.name().as_ref().unwrap();
-        if let Some(exists) = self.imports.get(name) {
-            return exists.to_owned();
-        }
-        let type_id = self.types_by_id.len();
-        self.imports.insert(name.to_owned(), type_id);
-        self.types_by_id.push(TypeDefinition::Named(type_def));
-        type_id
-    }
+    pub fn add_import_type(
+        &mut self,
+        alias: Option<&String>,
+        type_def: TypeDefinitionImpl,
+    ) -> TypeId {
+        let name = match alias {
+            None => type_def.name().as_ref().unwrap(),
+            Some(name) => name,
+        };
 
-    /// Adds the [NamedTypeDefinition] and the associated alias as the [TypeAlias] import in [TypeStore]
-    ///  and returns the [TypeId] for it. If the name already exists in the [TypeStore] it returns the associated [TypeId]
-    pub fn add_alias_import_type(&mut self, alias: &str, type_def: TypeDefinitionImpl) -> TypeId {
-        if let Some(exists) = self.imports.get(alias) {
+        if let Some(exists) = self.imported_type_ids_by_name.get(name) {
             return exists.to_owned();
         }
         let type_id = self.types_by_id.len();
-        self.imports.insert(alias.to_owned(), type_id);
+        self.imported_type_ids_by_name
+            .insert(name.to_owned(), type_id);
         self.types_by_id.push(TypeDefinition::Named(type_def));
         type_id
     }
@@ -362,6 +447,9 @@ impl Resolver {
     ) -> IonSchemaResult<Rc<Schema>> {
         let mut found_header = false;
         let mut found_footer = false;
+        // this is used to determine when resolving an import whether it has been imported to the type_store or not
+        let mut update_type_store_result = false;
+
         for value in elements {
             let annotations: Vec<&OwnedSymbolToken> = value.annotations().collect();
             // load header for schema
@@ -372,7 +460,7 @@ impl Resolver {
                     .and_then(|it| it.as_sequence())
                 {
                     for import in imports.iter() {
-                        let isl_import = IslImport::parse_from_ion_element(import)?;
+                        let isl_import = IslImport::from_ion_element(import)?;
                         let import_id = isl_import.id();
                         let imported_schema =
                             self.load_schema(import_id, type_store, Some(&isl_import))?;
@@ -395,7 +483,8 @@ impl Resolver {
                     )?;
 
                 // add all types from context to type_store
-                pending_types.update_type_store(type_store, load_isl_import)?;
+                update_type_store_result =
+                    pending_types.update_type_store(type_store, load_isl_import)?;
             }
             // load footer for schema
             else if annotations.contains(&&text_token("schema_footer")) {
@@ -403,6 +492,9 @@ impl Resolver {
             } else {
                 continue;
             }
+        }
+        if load_isl_import.is_some() && !update_type_store_result {
+            return unresolvable_schema_error(format!("Unable to load import: {}", id));
         }
         if found_footer ^ found_header {
             return invalid_schema_error("For any schema while a header and footer are both optional, a footer is required if a header is present (and vice-versa).");
@@ -412,11 +504,16 @@ impl Resolver {
     }
 
     /// Loads a [Schema] with resolved [Type]s using authorities and type_store
+    // If we are loading the root schema then this will be set to `None` ( i.e. in the beginning when
+    // this method is called from the load_schema method of schema_system it is set to `None`)
+    // Otherwise if we are loading an import of the schema then this will be set to `Some(isl_import)`
+    // to be loaded (i.e. Inside schema_from_elements while loading imports this will be set to
+    // `Some(isl_import)`)
     fn load_schema<A: AsRef<str>>(
         &mut self,
         id: A,
         type_store: &mut TypeStore,
-        load_isl_import: Option<&IslImport>, // if its the root of schema set it to None otherwise will be set to the IslImport to be loaded
+        load_isl_import: Option<&IslImport>,
     ) -> IonSchemaResult<Rc<Schema>> {
         let id: &str = id.as_ref();
         if let Some(schema) = self.resolved_schema_cache.get(id) {
@@ -499,7 +596,7 @@ impl SchemaSystem {
 #[cfg(test)]
 mod schema_system_tests {
     use super::*;
-    use crate::authority::FileSystemDocumentAuthority;
+    use crate::authority::{FileSystemDocumentAuthority, MapDocumentAuthority};
     use std::path::Path;
 
     #[test]
@@ -537,5 +634,172 @@ mod schema_system_tests {
         ]);
         let schema_system_authorities = schema_system.authorities();
         assert_eq!(2, schema_system_authorities.len());
+    }
+
+    #[test]
+    fn schema_system_map_authority_with_type_alias_import_test() {
+        // map with (id, ion content)
+        let map_authority: HashMap<String, String> = [
+            (
+                "sample_number.isl",
+                r#"
+                    schema_header::{
+                      imports: [{ id: "sample_decimal.isl", type: my_decimal, as: other_decimal }],
+                    }
+                    
+                    type::{
+                      name: my_int,
+                      type: int,
+                    }
+                    
+                    type::{
+                      name: my_number,
+                      all_of: [
+                        my_int,
+                        other_decimal,
+                      ],
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+            (
+                "sample_decimal.isl",
+                r#"
+                    schema_header::{
+                      imports: [],
+                    }
+                    
+                    type::{
+                      name: my_decimal,
+                      type: decimal,
+                    }
+                    
+                    type::{
+                      name: my_string,
+                      type: string,
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+        ]
+        .iter()
+        .map(|(id, ion)| (id.to_owned().to_owned(), ion.to_owned().to_owned()))
+        .collect();
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema loads without any errors
+        let schema = schema_system.load_schema("sample_number.isl");
+        assert_eq!(true, schema.is_ok());
+    }
+
+    #[test]
+    fn schema_system_map_authority_with_type_import_test() {
+        // map with (id, ion content)
+        let map_authority: HashMap<String, String> = [
+            (
+                "sample_number.isl",
+                r#"
+                    schema_header::{
+                      imports: [{ id: "sample_decimal.isl", type: my_decimal }],
+                    }
+                    
+                    type::{
+                      name: my_int,
+                      type: int,
+                    }
+                    
+                    type::{
+                      name: my_number,
+                      all_of: [
+                        my_int,
+                        my_decimal,
+                      ],
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+            (
+                "sample_decimal.isl",
+                r#"
+                    schema_header::{
+                      imports: [],
+                    }
+                    
+                    type::{
+                      name: my_decimal,
+                      type: decimal,
+                    }
+                    
+                    type::{
+                      name: my_string,
+                      type: string,
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+        ]
+        .iter()
+        .map(|(id, ion)| (id.to_owned().to_owned(), ion.to_owned().to_owned()))
+        .collect();
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema loads without any errors
+        let schema = schema_system.load_schema("sample_number.isl");
+        assert_eq!(true, schema.is_ok());
+    }
+
+    #[test]
+    fn schema_system_map_authority_with_schema_import_test() {
+        // map with (id, ion content)
+        let map_authority: HashMap<String, String> = [
+            (
+                "sample_import_string.isl",
+                r#"
+                    schema_header::{
+                      imports: [{ id: "sample_string.isl" }],
+                    }
+                    
+                    type::{
+                      name: import_string,
+                      type: my_string,
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+            (
+                "sample_string.isl",
+                r#"
+                    schema_header::{
+                      imports: [],
+                    }
+                    
+                    type::{
+                      name: my_string,
+                      type: string,
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+        ]
+        .iter()
+        .map(|(id, ion)| (id.to_owned().to_owned(), ion.to_owned().to_owned()))
+        .collect();
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema loads without any errors
+        let schema = schema_system.load_schema("sample_import_string.isl");
+        assert_eq!(true, schema.is_ok());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,6 +81,13 @@ impl TypeDefinitionImpl {
         &self.name
     }
 
+    pub fn with_name(self, alias: String) -> Self {
+        Self {
+            name: Some(alias),
+            constraints: self.constraints,
+        }
+    }
+
     pub fn constraints(&self) -> &[Constraint] {
         &self.constraints
     }


### PR DESCRIPTION
*Issue #34, #22*

*Description of changes:*
This PR works on adding changes for `IslImport`

*Changes:*
- Implementation of IslImport to represent an import in ISL.
- Changes in `Resolver` `load_schema` and `schema_from_elements` method signature to not load imports to `type_store` when in the root of schema.
- New methods in type_store and pending_types to store imports separately.
- Changes in schema ` get_types` to rightly return only named types within that schema and not include the import types
- Changes in `SchemaTypeIterator` to return appropriate types within the schema and changes in `get_imports` to return import types.

*Tests:*
Ran all the unit tests as well as examples to verify if everything works fine.

*Questions:*
- Currently `get_types` returns named types + core types within the given schema. Should there be a `core_types` property in `TypeStore` which could store all the `core_types` differently. These can also be prefilled before we start loading a schema.
- `schema.rs` contains a method called `get_import` which gets imports for given schema id from within the schema.
- Does this mean we need an equivalent `Import` to `IslImport` which could be returned for `get_import` method.