### PR TITLE
adds changes for implementation of ISL ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [dependencies]
 ion-rs = "0.6.0"
 thiserror = "1.0"
+num-bigint = "0.3"
+num-traits = "0.2"
+chrono = "0.4"
 
 [dev-dependencies]
 rstest = "0.9"

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -124,13 +124,14 @@ impl IslTypeImpl {
 // Related issue: https://github.com/amzn/ion-rust/issues/200
 impl PartialEq for IslTypeImpl {
     fn eq(&self, other: &Self) -> bool {
-        let matching = self.constraints.iter().all(|constraint| {
-            other
-                .constraints
-                .iter()
-                .find(|other_constraint| &constraint == other_constraint)
-                .is_some()
-        });
-        matching && self.constraints.len() == other.constraints.len() && self.name == other.name
+        self.constraints.len() == other.constraints.len()
+            && self.name == other.name
+            && self.constraints.iter().all(|constraint| {
+                other
+                    .constraints
+                    .iter()
+                    .find(|other_constraint| &constraint == other_constraint)
+                    .is_some()
+            })
     }
 }

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -34,7 +34,7 @@ impl IslType {
 /// Represents both named and anonymous [IslType]s and can be converted to a solid [TypeDefinition] using TypeStore
 /// Named ISL type grammar: `type:: { name: <NAME>, <CONSTRAINT>...}`
 /// Anonymous ISL type grammar: `{ <CONSTRAINT>... }`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct IslTypeImpl {
     name: Option<String>,
     constraints: Vec<IslConstraint>,
@@ -117,5 +117,20 @@ impl IslTypeImpl {
             constraints.push(constraint);
         }
         Ok(IslTypeImpl::new(type_name, constraints))
+    }
+}
+
+// OwnedStruct doesn't preserve field order hence the PartialEq won't work properly for unordered constraints
+// Related issue: https://github.com/amzn/ion-rust/issues/200
+impl PartialEq for IslTypeImpl {
+    fn eq(&self, other: &Self) -> bool {
+        let matching = self.constraints.iter().all(|constraint| {
+            other
+                .constraints
+                .iter()
+                .find(|other_constraint| &constraint == other_constraint)
+                .is_some()
+        });
+        matching && self.constraints.len() == other.constraints.len() && self.name == other.name
     }
 }

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -132,6 +132,7 @@ mod isl_tests {
     use ion_rs::types::timestamp::Timestamp;
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
+    use ion_rs::value::AnyInt;
     use ion_rs::IonType;
     use rstest::*;
 
@@ -248,9 +249,9 @@ mod isl_tests {
                     range::[min, 5]
                 "#
             ),
-            Range::int_range(
+            Range::range(
                 RangeBoundaryValue::Min,
-                RangeBoundaryValue::int_value(5, RangeBoundaryType::Inclusive)
+                RangeBoundaryValue::int_value(AnyInt::I64(5), RangeBoundaryType::Inclusive)
             )
         ),
         case::range_with_float(
@@ -259,7 +260,7 @@ mod isl_tests {
                     range::[2e1, 5e1]
                 "#
             ),
-            Range::float_range(
+            Range::range(
                 RangeBoundaryValue::float_value(2e1, RangeBoundaryType::Inclusive),
                 RangeBoundaryValue::float_value(5e1, RangeBoundaryType::Inclusive)
             )
@@ -270,7 +271,7 @@ mod isl_tests {
                     range::[20.4, 50.5]
                 "#
             ),
-            Range::decimal_range(
+            Range::range(
                 RangeBoundaryValue::decimal_value(Decimal::new(204, -1), RangeBoundaryType::Inclusive),
                 RangeBoundaryValue::decimal_value(Decimal::new(505, -1), RangeBoundaryType::Inclusive)
             )
@@ -281,7 +282,7 @@ mod isl_tests {
                     range::[2020-01-01T, 2021-01-01T]
                 "#
             ),
-            Range::timestamp_range(
+            Range::range(
                 RangeBoundaryValue::timestamp_value(Timestamp::with_year(2020).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive),
                 RangeBoundaryValue::timestamp_value(Timestamp::with_year(2021).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive)
             )
@@ -311,6 +312,11 @@ mod isl_tests {
         case::range_with_min_upper_bound(load_range(
             r#"
                 range::[5, min]
+            "#
+        )),
+        case::range_with_mismatched_bounds(load_range(
+            r#"
+                range::[5, 7.834]
             "#
         )),
         // TODO: uncomment below test case once we have a comparator for timestamp in ion-rust 

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -80,6 +80,7 @@ pub mod isl_constraint;
 pub mod isl_import;
 pub mod isl_type;
 pub mod isl_type_reference;
+mod util;
 
 /// Provides an internal representation of an schema file
 #[derive(Debug, Clone)]
@@ -125,6 +126,10 @@ mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue};
+    use crate::result::IonSchemaResult;
+    use ion_rs::types::decimal::*;
+    use ion_rs::types::timestamp::Timestamp;
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
     use ion_rs::IonType;
@@ -222,5 +227,101 @@ mod isl_tests {
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name
         assert_eq!(isl_type1, isl_type2);
+    }
+
+    // helper function to create a range
+    fn load_range(text: &str) -> IonSchemaResult<Range> {
+        Range::from_ion_element(
+            &element_reader()
+                .read_one(text.as_bytes())
+                .expect("parsing failed unexpectedly"),
+            false,
+        )
+    }
+
+    #[rstest(
+        range1,
+        range2,
+        case::range_with_integer(
+            load_range(
+                r#"
+                    range::[min, 5]
+                "#
+            ),
+            Range::int_range(
+                RangeBoundaryValue::Min,
+                RangeBoundaryValue::int_value(5, RangeBoundaryType::Inclusive)
+            )
+        ),
+        case::range_with_float(
+            load_range(
+                r#"
+                    range::[2e1, 5e1]
+                "#
+            ),
+            Range::float_range(
+                RangeBoundaryValue::float_value(2e1, RangeBoundaryType::Inclusive),
+                RangeBoundaryValue::float_value(5e1, RangeBoundaryType::Inclusive)
+            )
+        ),
+        case::range_with_decimal(
+            load_range(
+                r#"
+                    range::[20.4, 50.5]
+                "#
+            ),
+            Range::decimal_range(
+                RangeBoundaryValue::decimal_value(Decimal::new(204, -1), RangeBoundaryType::Inclusive),
+                RangeBoundaryValue::decimal_value(Decimal::new(505, -1), RangeBoundaryType::Inclusive)
+            )
+        ),
+        case::range_with_timestamp(
+            load_range(
+                r#"
+                    range::[2020-01-01T, 2021-01-01T]
+                "#
+            ),
+            Range::timestamp_range(
+                RangeBoundaryValue::timestamp_value(Timestamp::with_year(2020).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive),
+                RangeBoundaryValue::timestamp_value(Timestamp::with_year(2021).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive)
+            )
+        )
+    )]
+    fn owned_struct_to_range(range1: IonSchemaResult<Range>, range2: IonSchemaResult<Range>) {
+        // determine that both the ranges are created with no errors
+        assert_eq!(range1.is_ok(), true);
+        assert_eq!(range2.is_ok(), true);
+
+        // assert if both the ranges are same
+        assert_eq!(range1.unwrap(), range2.unwrap());
+    }
+
+    #[rstest(
+        range,
+        case::range_with_min_max(load_range(
+            r#"
+                range::[min, max]
+            "#
+        )),
+        case::range_with_max_lower_bound(load_range(
+            r#"
+                range::[max, 5]
+            "#
+        )),
+        case::range_with_min_upper_bound(load_range(
+            r#"
+                range::[5, min]
+            "#
+        )),
+        // TODO: uncomment below test case once we have a comparator for timestamp in ion-rust 
+        // case::range_with_lower_bound_greater_than_upper_bound(load_range(
+        //     r#"
+        //         range::[10, 5]
+        //     "#
+        // ))
+    )]
+    fn invalid_ranges(range: IonSchemaResult<Range>) {
+        // determine that the range is created with an error for an invalid range
+        assert_eq!(range.is_err(), true);
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -96,13 +96,11 @@ impl Range {
     }
 
     // helper method to which validates a non negative integer range boundary value
-    fn validate_non_negative_integer_range_boundary_value(
-        value: &AnyInt,
-    ) -> IonSchemaResult<&AnyInt> {
+    fn validate_non_negative_integer_range_boundary_value(value: &AnyInt) -> IonSchemaResult<()> {
         match value.as_i64() {
             Some(v) => {
                 if v >= 0 {
-                    Ok(value)
+                    Ok(())
                 } else {
                     invalid_schema_error(format!(
                         "Expected non negative integer for range boundary values, found {}",
@@ -116,7 +114,7 @@ impl Range {
                 }
                 Some(v) => {
                     if !v.is_negative() {
-                        Ok(value)
+                        Ok(())
                     } else {
                         invalid_schema_error(format!(
                             "Expected non negative integer for range boundary values, found {}",
@@ -194,12 +192,11 @@ impl RangeBoundaryValue {
             }
             IonType::Integer => {
                 if is_non_negative {
-                    let value = Range::validate_non_negative_integer_range_boundary_value(
+                    Range::validate_non_negative_integer_range_boundary_value(
                         value.as_any_int().unwrap(),
-                    )?
-                    .to_owned();
+                    )?;
                     Ok(RangeBoundaryValue::int_non_negative_value(
-                        value,
+                        value.as_any_int().unwrap().to_owned(),
                         range_boundary_type,
                     ))
                 } else {

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -1,0 +1,286 @@
+use crate::result::{invalid_schema_error, IonSchemaResult};
+use ion_rs::types::decimal::Decimal;
+use ion_rs::types::timestamp::Timestamp;
+use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
+use ion_rs::value::{AnyInt, Element, IntAccess, Sequence, SymbolToken};
+use ion_rs::IonType;
+use num_traits::Signed;
+use std::convert::TryInto;
+
+/// Represents ISL [Range]s where some constraints can be defined by a range
+/// <RANGE<RANGE_TYPE>> ::= range::[ <EXCLUSIVITY><RANGE_TYPE>, <EXCLUSIVITY><RANGE_TYPE> ]
+///                       | range::[ min, <EXCLUSIVITY><RANGE_TYPE> ]
+///                       | range::[ <EXCLUSIVITY><RANGE_TYPE>, max ]
+/// Grammar: <RANGE_TYPE> ::= <DECIMAL>
+///                | <FLOAT>
+///                | <INT>
+///                | <NUMBER>
+///                | <TIMESTAMP>
+///                | <TIMESTAMP_PRECISION_VALUE>
+/// For more information on [Range]: <https://amzn.github.io/ion-schema/docs/spec.html#constraints>
+#[derive(Debug, Clone, PartialEq)]
+pub enum Range {
+    Decimal(RangeBoundaryValue, RangeBoundaryValue),
+    Float(RangeBoundaryValue, RangeBoundaryValue),
+    Integer(RangeBoundaryValue, RangeBoundaryValue),
+    IntegerNonNegative(RangeBoundaryValue, RangeBoundaryValue),
+    Timestamp(RangeBoundaryValue, RangeBoundaryValue),
+}
+
+impl Range {
+    pub fn decimal_range(
+        start: RangeBoundaryValue,
+        end: RangeBoundaryValue,
+    ) -> IonSchemaResult<Range> {
+        Range::validate_range_boundaries(&start, &end)?;
+        Ok(Range::Decimal(start, end))
+    }
+
+    pub fn float_range(
+        start: RangeBoundaryValue,
+        end: RangeBoundaryValue,
+    ) -> IonSchemaResult<Range> {
+        Range::validate_range_boundaries(&start, &end)?;
+        Ok(Range::Float(start, end))
+    }
+
+    pub fn int_range(start: RangeBoundaryValue, end: RangeBoundaryValue) -> IonSchemaResult<Range> {
+        Range::validate_range_boundaries(&start, &end)?;
+        Ok(Range::Integer(start, end))
+    }
+
+    pub fn int_non_negative_range(
+        start: RangeBoundaryValue,
+        end: RangeBoundaryValue,
+    ) -> IonSchemaResult<Range> {
+        Range::validate_range_boundaries(&start, &end)?;
+        Ok(Range::IntegerNonNegative(start, end))
+    }
+
+    pub fn timestamp_range(
+        start: RangeBoundaryValue,
+        end: RangeBoundaryValue,
+    ) -> IonSchemaResult<Range> {
+        Range::validate_range_boundaries(&start, &end)?;
+        Ok(Range::Timestamp(start, end))
+    }
+
+    pub fn from_ion_element(value: &OwnedElement, is_non_negative: bool) -> IonSchemaResult<Range> {
+        let range = try_to!(value.as_sequence());
+        if range.len() != 2 {
+            return invalid_schema_error(
+                "Ranges must contain two values representing minimum and maximum ends of range.",
+            );
+        }
+
+        // set start of the range
+        let start = RangeBoundaryValue::from_ion_element(try_to!(range.get(0)), is_non_negative)?;
+
+        // set end of the range
+        let end = RangeBoundaryValue::from_ion_element(try_to!(range.get(1)), is_non_negative)?;
+
+        // validate both range boundary values
+        let range_type = Range::validate_range_boundaries(&start, &end)?;
+        match range_type {
+            RangeBoundaryValueType::Decimal(_) => Ok(Range::Decimal(start, end)),
+            RangeBoundaryValueType::Float(_) => Ok(Range::Float(start, end)),
+            RangeBoundaryValueType::Integer(_) => Ok(Range::Integer(start, end)),
+            RangeBoundaryValueType::IntegerNonNegative(_) => {
+                Ok(Range::IntegerNonNegative(start, end))
+            }
+            RangeBoundaryValueType::Timestamp(_) => Ok(Range::Timestamp(start, end)),
+        }
+    }
+
+    // helper method to which validates a non negative integer range boundary value
+    fn validate_non_negative_integer_range_boundary_value(
+        value: &AnyInt,
+    ) -> IonSchemaResult<usize> {
+        match value.as_i64() {
+            Some(v) => {
+                if v > 0 {
+                    match v.try_into() {
+                        Err(_) => invalid_schema_error(format!(
+                            "Expected non negative integer for range boundary values, found {}",
+                            v
+                        )),
+                        Ok(non_negative_int_value) => Ok(non_negative_int_value),
+                    }
+                } else {
+                    invalid_schema_error(format!(
+                        "Expected non negative integer for range boundary values, found {}",
+                        v
+                    ))
+                }
+            }
+            None => match value.as_big_int() {
+                None => {
+                    unreachable!("Expected range boundary values must be a non negative integer")
+                }
+                Some(v) => {
+                    if v.is_negative() {
+                        match v.try_into() {
+                            Err(_) => invalid_schema_error(format!(
+                                "Expected non negative integer for range boundary values, found {}",
+                                v
+                            )),
+                            Ok(non_negative_int_value) => Ok(non_negative_int_value),
+                        }
+                    } else {
+                        invalid_schema_error(format!(
+                            "Expected non negative integer for range boundary values, found {}",
+                            v
+                        ))
+                    }
+                }
+            },
+        }
+    }
+
+    // this function validates the range boundaries and returns a range boundary value type,
+    // which helps determine the range type (Decimal, integer, etc.)
+    fn validate_range_boundaries(
+        start: &RangeBoundaryValue,
+        end: &RangeBoundaryValue,
+    ) -> IonSchemaResult<RangeBoundaryValueType> {
+        use RangeBoundaryValue::*;
+        match (start, end) {
+            (Min, Max) => {
+                return invalid_schema_error("Range boundaries can not be min and max together (i.e. range::[min, max] is not allowed)")
+            }
+            (Min, Value(v, _)) => {
+                Ok(v.to_owned())
+            }
+            (Value(v, _), Max) => {
+                Ok(v.to_owned())
+            }
+            (Value(v1, _), Value(v2, _)) => {
+                match (v1, v2) {
+                    (RangeBoundaryValueType::Integer(_), RangeBoundaryValueType::Integer(_)) => {}
+                    (RangeBoundaryValueType::IntegerNonNegative(_), RangeBoundaryValueType::IntegerNonNegative(_)) => {}
+                    (RangeBoundaryValueType::Decimal(_), RangeBoundaryValueType::Decimal(_)) => {}
+                    (RangeBoundaryValueType::Float(_), RangeBoundaryValueType::Float(_)) => {}
+                    (RangeBoundaryValueType::Timestamp(_), RangeBoundaryValueType::Timestamp(_)) => {},
+                    _ => {
+                        return invalid_schema_error("Both range boundary values must be of same type")
+                    }
+                };
+                // TODO: un-comment below code once the timestamp comparator for ion-rust is implemented
+                // if start > end {
+                //     return invalid_schema_error("Lower range boundary value can not be bigger than upper range boundary")
+                // }
+                Ok(v1.to_owned())
+            }
+            (Max, _) => {
+                return invalid_schema_error("Lower range boundary value must not be max")
+            }
+            (_, Min) => {
+                return invalid_schema_error("Upper range boundary value must not be min")
+            }
+        }
+    }
+}
+
+/// Represents the type of range boundary value
+#[derive(Debug, Clone, PartialEq)]
+pub enum RangeBoundaryValueType {
+    Decimal(Decimal),
+    Float(f64),
+    Integer(i64),
+    IntegerNonNegative(usize),
+    Timestamp(Timestamp),
+}
+
+/// Represents a range boundary value (i.e. min, max or a value in terms of [RangeBoundaryValueType])
+#[derive(Debug, Clone, PartialEq)]
+pub enum RangeBoundaryValue {
+    Max,
+    Min,
+    Value(RangeBoundaryValueType, RangeBoundaryType),
+}
+
+impl RangeBoundaryValue {
+    pub fn int_value(value: i64, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(RangeBoundaryValueType::Integer(value), range_boundary_type)
+    }
+    pub fn int_non_negative_value(value: usize, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(
+            RangeBoundaryValueType::IntegerNonNegative(value),
+            range_boundary_type,
+        )
+    }
+    pub fn float_value(value: f64, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(RangeBoundaryValueType::Float(value), range_boundary_type)
+    }
+    pub fn timestamp_value(value: Timestamp, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(
+            RangeBoundaryValueType::Timestamp(value),
+            range_boundary_type,
+        )
+    }
+    pub fn decimal_value(value: Decimal, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(RangeBoundaryValueType::Decimal(value), range_boundary_type)
+    }
+
+    fn from_ion_element(value: &OwnedElement, is_non_negative: bool) -> IonSchemaResult<Self> {
+        let value_annotations: Vec<&OwnedSymbolToken> = value.annotations().collect();
+        let range_boundary_type = if value_annotations.contains(&&text_token("exclusive")) {
+            RangeBoundaryType::Exclusive
+        } else {
+            RangeBoundaryType::Inclusive
+        };
+
+        match value.ion_type() {
+            IonType::Symbol => {
+                let sym = try_to!(try_to!(value.as_sym()).text());
+                match sym {
+                    "min" => Ok(RangeBoundaryValue::Min),
+                    "max" => Ok(RangeBoundaryValue::Max),
+                    _ => {
+                        return invalid_schema_error(format!(
+                            "Range boundary value: {} is not supported",
+                            sym
+                        ))
+                    }
+                }
+            }
+            IonType::Integer => {
+                if is_non_negative {
+                    let value = Range::validate_non_negative_integer_range_boundary_value(
+                        value.as_any_int().unwrap(),
+                    )?
+                    .to_owned();
+                    Ok(RangeBoundaryValue::int_non_negative_value(
+                        value,
+                        range_boundary_type,
+                    ))
+                } else {
+                    Ok(RangeBoundaryValue::int_value(
+                        value.as_any_int().unwrap().as_i64().unwrap(),
+                        range_boundary_type,
+                    ))
+                }
+            }
+            IonType::Decimal => Ok(RangeBoundaryValue::decimal_value(
+                value.as_decimal().unwrap().to_owned(),
+                range_boundary_type,
+            )),
+            IonType::Float => Ok(RangeBoundaryValue::float_value(
+                value.as_f64().unwrap(),
+                range_boundary_type,
+            )),
+            IonType::Timestamp => Ok(RangeBoundaryValue::timestamp_value(
+                value.as_timestamp().unwrap().to_owned(),
+                range_boundary_type,
+            )),
+            _ => return invalid_schema_error("Unsupported range type specified"),
+        }
+    }
+}
+
+/// Represents the range boundary types in terms of exclusivity (i.e. inclusive or exclusive)
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub enum RangeBoundaryType {
+    Inclusive,
+    Exclusive,
+}


### PR DESCRIPTION
*Issue #10*

*Description of changes:*
This PR works on creating ISL ranges.

*Changes:*
* adds changes for ISL `Range`
  *  `RangeBoundaryValue`: represents a range boundary value (i.e. min, max or a value in terms of `RangeBoundaryValueType`)
  * `RangeBoundaryValueType`: represents a range boundary value which can be a `Decimal`/`Integer`/...
  * `RangBoundaryType`: defines exclusivity of the range boundary
* adds a bugfix for unordered types comparison (a new `PartialEq` implementation for `IslTypeImpl`)
* adds unit tests related to ranges

*Test:*
Adds unit tests for ISL `Range`s