### PR TITLE
Implements `contains()` for `Range`s

### DIFF
--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -35,210 +35,147 @@ impl Range {
         use RangeBoundaryValueType::*;
         match self {
             Range::Integer(start, end) => {
-                match (start, end) {
-                    (Min, Max) => {
-                        unreachable!("Range boundaries can not be min and max together (i.e. range::[min, max] is not allowed)")
+                let unwrapped_value = value.as_any_int().unwrap();
+                let is_in_lower_bound = match start {
+                    Min => true,
+                    Value(start_value, boundary_type) => match start_value {
+                        Integer(min_value) => {
+                            match unwrapped_value {
+                                AnyInt::I64(int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => &min_value.as_i64().unwrap() <= int_value,
+                                    RangeBoundaryType::Exclusive => &min_value.as_i64().unwrap() < int_value,
+                                }},
+                                AnyInt::BigInt(big_int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => min_value.as_big_int().unwrap() <= big_int_value,
+                                    RangeBoundaryType::Exclusive => min_value.as_big_int().unwrap() < big_int_value,
+                                }}
+                            }
+                        },
+                        _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
                     },
-                    (Min, Value(end_value, boundary_type)) => {
-                        match end_value {
-                            Integer(range_end_value) => {
-                                return match range_end_value {
-                                    AnyInt::I64(int_end_value) => {
-                                        Ok(int_end_value > &value.as_any_int().unwrap().as_i64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && int_end_value == &value.as_any_int().unwrap().as_i64().unwrap()))
-                                    }
-                                    AnyInt::BigInt(big_int_end_value) => {
-                                        Ok(big_int_end_value > &value.as_any_int().unwrap().as_big_int().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && big_int_end_value == value.as_any_int().unwrap().as_big_int().unwrap()))
-                                    }
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, boundary_type), Max) => {
-                        match start_value {
-                            Integer(range_start_value) => {
-                                return match range_start_value {
-                                    AnyInt::I64(int_start_value) => {
-                                        Ok(int_start_value < &value.as_any_int().unwrap().as_i64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && int_start_value == &value.as_any_int().unwrap().as_i64().unwrap()))
-                                    }
-                                    AnyInt::BigInt(big_int_start_value) => {
-                                        Ok(big_int_start_value < &value.as_any_int().unwrap().as_big_int().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && big_int_start_value == value.as_any_int().unwrap().as_big_int().unwrap()))
-                                    }
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, start_boundary_type), Value(end_value, end_boundary_type)) => {
-                        match (start_value, end_value) {
-                            (Integer(range_start_value), Integer(range_end_value)) => {
-                                return match (range_start_value, range_end_value) {
-                                    (AnyInt::I64(int_start_value), AnyInt::I64(int_end_value)) => {
-                                        let range_start_validation = int_start_value < &value.as_any_int().unwrap().as_i64().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && int_start_value == &value.as_any_int().unwrap().as_i64().unwrap());
-                                        let range_end_validation = int_end_value > &value.as_any_int().unwrap().as_i64().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && int_end_value == &value.as_any_int().unwrap().as_i64().unwrap());
-                                        Ok(range_start_validation && range_end_validation)
-                                    }
-                                    (AnyInt::BigInt(big_int_end_value), AnyInt::BigInt(big_int_start_value)) => {
-                                        let range_start_validation = big_int_start_value < &value.as_any_int().unwrap().as_big_int().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && big_int_start_value == value.as_any_int().unwrap().as_big_int().unwrap());
-                                        let range_end_validation = big_int_end_value > &value.as_any_int().unwrap().as_big_int().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && big_int_end_value == value.as_any_int().unwrap().as_big_int().unwrap());
-                                        Ok(range_start_validation && range_end_validation)
-                                    }
-                                    _ => unreachable!("Both range boundary value should be of same types")
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
-                    }
-                    (Max, _) => {
-                        unreachable!("Lower range boundary value must not be max")
-                    }
-                    (_, Min) => {
-                        unreachable!("Upper range boundary value must not be min")
-                    }
-                }
-            },
-            Range::IntegerNonNegative(start, end) => {
-                match (start, end) {
-                    (Min, Max) => {
-                        unreachable!("Range boundaries can not be min and max together (i.e. range::[min, max] is not allowed)")
-                    },
-                    (Min, Value(end_value, boundary_type)) => {
-                        match end_value {
-                            Integer(range_end_value) => {
-                                return match range_end_value {
-                                    AnyInt::I64(int_end_value) => {
-                                        Ok(0 <= value.as_any_int().unwrap().as_i64().unwrap() && int_end_value > &value.as_any_int().unwrap().as_i64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && int_end_value == &value.as_any_int().unwrap().as_i64().unwrap()))
-                                    }
-                                    AnyInt::BigInt(big_int_end_value) => {
-                                        Ok(BigInt::zero() <= *value.as_any_int().unwrap().as_big_int().unwrap() && big_int_end_value > &value.as_any_int().unwrap().as_big_int().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && big_int_end_value == value.as_any_int().unwrap().as_big_int().unwrap()))
-                                    }
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, boundary_type), Max) => {
-                        match start_value {
-                            Integer(range_start_value) => {
-                                return match range_start_value {
-                                    AnyInt::I64(int_start_value) => {
-                                        Ok(int_start_value < &value.as_any_int().unwrap().as_i64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && int_start_value == &value.as_any_int().unwrap().as_i64().unwrap()))
-                                    }
-                                    AnyInt::BigInt(big_int_start_value) => {
-                                        Ok(big_int_start_value < &value.as_any_int().unwrap().as_big_int().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && big_int_start_value == value.as_any_int().unwrap().as_big_int().unwrap()))
-                                    }
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, start_boundary_type), Value(end_value, end_boundary_type)) => {
-                        match (start_value, end_value) {
-                            (Integer(range_start_value), Integer(range_end_value)) => {
-                                return match (range_start_value, range_end_value) {
-                                    (AnyInt::I64(int_start_value), AnyInt::I64(int_end_value)) => {
-                                        let range_start_validation = int_start_value < &value.as_any_int().unwrap().as_i64().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && int_start_value == &value.as_any_int().unwrap().as_i64().unwrap());
-                                        let range_end_validation = int_end_value > &value.as_any_int().unwrap().as_i64().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && int_end_value == &value.as_any_int().unwrap().as_i64().unwrap());
-                                        Ok(range_start_validation && range_end_validation)
-                                    }
-                                    (AnyInt::BigInt(big_int_end_value), AnyInt::BigInt(big_int_start_value)) => {
-                                        let range_start_validation = big_int_start_value < &value.as_any_int().unwrap().as_big_int().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && big_int_start_value == value.as_any_int().unwrap().as_big_int().unwrap());
-                                        let range_end_validation = big_int_end_value > &value.as_any_int().unwrap().as_big_int().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && big_int_end_value == value.as_any_int().unwrap().as_big_int().unwrap());
-                                        Ok(range_start_validation && range_end_validation)
-                                    }
-                                    _ =>
-                                        unreachable!("Both range boundary value should be of same types")
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
 
-                                }
-                            },
-                            _ => unreachable!("Integer range can only have integers as lower and upper range boundary value")
-                        }
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        Integer(max_value) => {
+                            match unwrapped_value {
+                                AnyInt::I64(int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => &max_value.as_i64().unwrap() >= int_value,
+                                    RangeBoundaryType::Exclusive => &max_value.as_i64().unwrap() > int_value,
+                                }},
+                                AnyInt::BigInt(big_int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => max_value.as_big_int().unwrap() >= big_int_value,
+                                    RangeBoundaryType::Exclusive => max_value.as_big_int().unwrap() > big_int_value,
+                                }}
+                            }
+                        },
+                        _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
                     }
-                    (Max, _) => {
-                        unreachable!("Lower range boundary value must not be max")
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
+            }
+            Range::IntegerNonNegative(start, end) => {
+                let unwrapped_value = value.as_any_int().unwrap();
+                let is_in_lower_bound = match start {
+                    Min => match unwrapped_value {
+                        AnyInt::I64(int_value) => &0 <= int_value,
+                        AnyInt::BigInt(big_int_value) => &BigInt::zero() <= big_int_value,
+                    },
+                    Value(start_value, boundary_type) => match start_value {
+                        Integer(min_value) => {
+                            match unwrapped_value {
+                                AnyInt::I64(int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => &min_value.as_i64().unwrap() <= int_value,
+                                    RangeBoundaryType::Exclusive => &min_value.as_i64().unwrap() < int_value,
+                                }},
+                                AnyInt::BigInt(big_int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => min_value.as_big_int().unwrap() <= big_int_value,
+                                    RangeBoundaryType::Exclusive => min_value.as_big_int().unwrap() < big_int_value,
+                                }}
+                            }
+                        },
+                        _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
+                    },
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
+
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        Integer(max_value) => {
+                            match unwrapped_value {
+                                AnyInt::I64(int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => &max_value.as_i64().unwrap() >= int_value,
+                                    RangeBoundaryType::Exclusive => &max_value.as_i64().unwrap() > int_value,
+                                }},
+                                AnyInt::BigInt(big_int_value) => { match boundary_type {
+                                    RangeBoundaryType::Inclusive => max_value.as_big_int().unwrap() >= big_int_value,
+                                    RangeBoundaryType::Exclusive => max_value.as_big_int().unwrap() > big_int_value,
+                                }}
+                            }
+                        },
+                        _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
                     }
-                    (_, Min) => {
-                        unreachable!("Upper range boundary value must not be min")
-                    }
-                }
-            },
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
+            }
             Range::Float(start, end) => {
-                match (start, end) {
-                    (Min, Max) => {
-                        unreachable!("Range boundaries can not be min and max together (i.e. range::[min, max] is not allowed)")
+                let unwrapped_value = &value.as_f64().unwrap();
+                let is_in_lower_bound = match start {
+                    Min => true,
+                    Value(start_value, boundary_type) => match start_value {
+                        Float(min_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => min_value <= unwrapped_value,
+                            RangeBoundaryType::Exclusive => min_value < unwrapped_value,
+                        },
+                        _ => unreachable!("Float range can only have floats as lower and upper range boundary value"),
                     },
-                    (Min, Value(end_value, boundary_type)) => {
-                        match end_value {
-                            Float(float_end_value) => {
-                                Ok(float_end_value > &value.as_f64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && float_end_value == &value.as_f64().unwrap()))
-                            }
-                            _ => unreachable!("Float range can only have floats as lower and upper range boundary value")
-                        }
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
+
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        Float(max_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => max_value >= unwrapped_value,
+                            RangeBoundaryType::Exclusive => max_value > unwrapped_value,
+                        },
+                        _ => unreachable!("Float range can only have floats as lower and upper range boundary value"),
                     }
-                    (Value(start_value, boundary_type), Max) => {
-                        match start_value {
-                            Float(float_start_value) => {
-                                Ok(float_start_value < &value.as_f64().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && float_start_value == &value.as_f64().unwrap()))
-                            }
-                            _ => unreachable!("Float range can only have floats as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, start_boundary_type), Value(end_value, end_boundary_type)) => {
-                        match (start_value, end_value) {
-                            (Float(range_start_value), Float(range_end_value)) => {
-                                let range_start_validation = range_start_value < &value.as_f64().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && range_start_value == &value.as_f64().unwrap());
-                                let range_end_validation = range_end_value > &value.as_f64().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && range_end_value == &value.as_f64().unwrap());
-                                Ok(range_start_validation && range_end_validation)
-                            },
-                            _ => unreachable!("Float range can only have floats as lower and upper range boundary value")
-                        }
-                    }
-                    (Max, _) => {
-                        unreachable!("Lower range boundary value must not be max")
-                    }
-                    (_, Min) => {
-                        unreachable!("Upper range boundary value must not be min")
-                    }
-                }
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
             }
             Range::Decimal(start, end) => {
-                match (start, end) {
-                    (Min, Max) => {
-                        unreachable!("Range boundaries can not be min and max together (i.e. range::[min, max] is not allowed)")
+                let unwrapped_value = &value.as_decimal().unwrap();
+                let is_in_lower_bound = match start {
+                    Min => true,
+                    Value(start_value, boundary_type) => match start_value {
+                        Decimal(min_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => min_value <= unwrapped_value,
+                            RangeBoundaryType::Exclusive => min_value < unwrapped_value,
+                        },
+                        _ => unreachable!("Decimal range can only have decimals as lower and upper range boundary value"),
                     },
-                    (Min, Value(end_value, boundary_type)) => {
-                        match end_value {
-                            Decimal(decimal_end_value) => {
-                                Ok(decimal_end_value > &value.as_decimal().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && decimal_end_value == value.as_decimal().unwrap()))
-                            }
-                            _ => unreachable!("Decimal range can only have decimals as lower and upper range boundary value")
-                        }
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
+
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        Decimal(max_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => max_value >= unwrapped_value,
+                            RangeBoundaryType::Exclusive => max_value > unwrapped_value,
+                        },
+                        _ => unreachable!("Decimal range can only have decimals as lower and upper range boundary value"),
                     }
-                    (Value(start_value, boundary_type), Max) => {
-                        match start_value {
-                            Decimal(decimal_start_value) => {
-                                Ok(decimal_start_value < &value.as_decimal().unwrap() || (*boundary_type == RangeBoundaryType::Inclusive && decimal_start_value == value.as_decimal().unwrap()))
-                            }
-                            _ => unreachable!("Decimal range can only have decimals as lower and upper range boundary value")
-                        }
-                    },
-                    (Value(start_value, start_boundary_type), Value(end_value, end_boundary_type)) => {
-                        match (start_value, end_value) {
-                            (Decimal(range_start_value), Decimal(range_end_value)) => {
-                                let range_start_validation = range_start_value < &value.as_decimal().unwrap() || (*start_boundary_type == RangeBoundaryType::Inclusive && range_start_value == value.as_decimal().unwrap());
-                                let range_end_validation = range_end_value > &value.as_decimal().unwrap() || (*end_boundary_type == RangeBoundaryType::Inclusive && range_end_value == value.as_decimal().unwrap());
-                                Ok(range_start_validation && range_end_validation)
-                            },
-                            _ => unreachable!("Decimal range can only have decimals as lower and upper range boundary value")
-                        }
-                    }
-                    (Max, _) => {
-                        unreachable!("Lower range boundary value must not be max")
-                    }
-                    (_, Min) => {
-                        unreachable!("Upper range boundary value must not be min")
-                    }
-                }
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
             }
             Range::Timestamp(start, end) => {
                 // TODO: Implement this section once the timestamp comparator for ion-rust is implemented

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -36,9 +36,9 @@ impl Range {
         match self {
             Range::Integer(start, end) => {
                 let value = value.as_any_int().ok_or_else(|| {
-                    return invalid_schema_error_raw(
+                    invalid_schema_error_raw(
                         "Integer ranges can only have integer value for validation",
-                    );
+                    )
                 })?;
                 let is_in_lower_bound = match start {
                     Min => true,
@@ -83,9 +83,9 @@ impl Range {
             }
             Range::IntegerNonNegative(start, end) => {
                 let value = value.as_any_int().ok_or_else(|| {
-                    return invalid_schema_error_raw(
+                    invalid_schema_error_raw(
                         "Integer ranges can only have integer value for validation",
-                    );
+                    )
                 })?;
                 let is_in_lower_bound = match start {
                     Min => match value {
@@ -133,9 +133,9 @@ impl Range {
             }
             Range::Float(start, end) => {
                 let value = &value.as_f64().ok_or_else(|| {
-                    return invalid_schema_error_raw(
+                    invalid_schema_error_raw(
                         "Float ranges can only have float value for validation",
-                    );
+                    )
                 })?;
                 let is_in_lower_bound = match start {
                     Min => true,
@@ -164,9 +164,9 @@ impl Range {
             }
             Range::Decimal(start, end) => {
                 let value = &value.as_decimal().ok_or_else(|| {
-                    return invalid_schema_error_raw(
+                    invalid_schema_error_raw(
                         "Decimal ranges can only have decimal value for validation",
-                    );
+                    )
                 })?;
                 let is_in_lower_bound = match start {
                     Min => true,


### PR DESCRIPTION
*Description of changes:*
This PR works on changes for implementation of `contains()` in `Range`.

*Changes:*
* adds `contains()` for Range struct
* Note: TODO - implement contains for Timestamp ranges.

*Tests:*
* adds unit tests for `contains()`
