### PR TITLE
Adds changes for core isl types

### DIFF
--- a/src/isl/core_types.rs
+++ b/src/isl/core_types.rs
@@ -1,0 +1,8 @@
+HashMap::from([
+    ("any", "type::{ name: any, one_of: [ blob, bool, clob, decimal,
+                                    float, int, string, symbol, timestamp,
+                                    list, sexp, struct ] }"),
+    ("lob" , "type::{ name: lob, one_of: [ blob, clob ] }"),
+    ("number", "type::{ name: number, one_of: [ decimal, float, int ] }"),
+    ("text", "type::{ name: text, one_of: [ string, symbol ] }")
+])

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -89,12 +89,7 @@ impl IslTypeRef {
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<TypeId> {
-        let invalid_type_reference_error = unresolvable_schema_error(format!(
-            "Could not resolve type reference: {:?} does not exist",
-            alias
-        ));
-
-        return if let Some(type_id) = type_store.get_builtin_type_id(alias) {
+        if let Some(type_id) = type_store.get_builtin_type_id(alias) {
             // verify if the given alias is a Built-in type and if it is then return the type id from type_store
             // All Built-in types are preloaded into the type_store
             // Built-in types includes all ion types and derived types like any, lob, text, number, $int, $float, ...
@@ -107,11 +102,17 @@ impl IslTypeRef {
             if parent.0.eq(alias) {
                 Ok(parent.1)
             } else {
-                invalid_type_reference_error
+                unresolvable_schema_error(format!(
+                    "Could not resolve type reference: {:?} does not exist",
+                    alias
+                ))
             }
         } else {
-            invalid_type_reference_error
-        };
+            unresolvable_schema_error(format!(
+                "Could not resolve type reference: {:?} does not exist",
+                alias
+            ))
+        }
     }
 
     // TODO: break match arms into helper methods as we add more constraints

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -168,9 +168,9 @@ mod isl_tests {
     isl_type1,isl_type2,
     case::type_constraint_with_anonymous_type(
         load_anonymous_type(r#" // For a schema with single anonymous type
-                {type: int}
+                {type: any}
             "#),
-        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])
+        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::core_isl_type_from_type_name("any"))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -38,7 +38,7 @@
 //!         vec![
 //!             // represents the `type: int` constraint
 //!             IslConstraint::type_constraint(
-//!                 IslTypeRef::core(IonType::Integer)
+//!                 IslTypeRef::named("int")
 //!             ),
 //!             // represents `all_of` with anonymous type `{ type: bool }` constraint
 //!             IslConstraint::all_of(
@@ -46,7 +46,7 @@
 //!                     IslTypeRef::anonymous(
 //!                         vec![
 //!                             IslConstraint::type_constraint(
-//!                                 IslTypeRef::core(IonType::Boolean)
+//!                                 IslTypeRef::named("bool")
 //!                             )
 //!                         ]
 //!                     )
@@ -135,7 +135,6 @@ mod isl_tests {
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
     use ion_rs::value::AnyInt;
-    use ion_rs::IonType;
     use rstest::*;
 
     // helper function to create NamedIslType for isl tests
@@ -170,13 +169,19 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with single anonymous type
                 {type: any}
             "#),
-        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::core_isl_type_from_type_name("any"))])
+        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::named("any"))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("int"))])
+    ),
+    case::type_constraint_with_named_nullable_type(
+        load_named_type(r#" // For a schema with named type
+                type:: { name: my_nullable_int, type: $int }
+            "#),
+        IslType::named("my_nullable_int", [IslConstraint::type_constraint(IslTypeRef::named("$int"))])
     ),
     case::type_constraint_with_self_reference_type(
         load_named_type(r#" // For a schema with self reference type
@@ -194,43 +199,43 @@ mod isl_tests {
         load_named_type(r#" // For a schema with nested types
                 type:: { name: my_int, type: { type: int } }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))]))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))])
     ),
     case::type_constraint_with_nested_multiple_types(
         load_named_type(r#" // For a schema with nested multiple types
                 type:: { name: my_int, type: { type: int }, type: { type: my_int } }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::Type(IslTypeRef::named("my_int"))]))])
+        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::Type(IslTypeRef::named("my_int"))]))])
     ),
     case::all_of_constraint(
         load_anonymous_type(r#" // For a schema with all_of type as below:
                 { all_of: [{ type: int }] }
             "#),
-        IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))])])])
+        IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])])])
     ),
     case::any_of_constraint(
         load_anonymous_type(r#" // For a schema with any_of constraint as below:
                     { any_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([IslConstraint::any_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Decimal))])])])
+        IslType::anonymous([IslConstraint::any_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])])
     ),
     case::one_of_constraint(
         load_anonymous_type(r#" // For a schema with one_of constraint as below:
                     { one_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([IslConstraint::one_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Decimal))])])])
+        IslType::anonymous([IslConstraint::one_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])])
     ),
     case::not_constraint(
         load_anonymous_type(r#" // For a schema with not constraint as below:
                     { not: { type: int } }
                 "#),
-        IslType::anonymous([IslConstraint::not(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer))]))])
+        IslType::anonymous([IslConstraint::not(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))])
     ),
     case::ordered_elements_constraint(
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
                     { ordered_elements: [  symbol, { type: int, occurs: optional },  ] }
                 "#),
-        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::core(IonType::Symbol), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::core(IonType::Integer)), IslConstraint::Occurs(IslOccurs::Optional)])])])
+        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -117,7 +117,7 @@ mod schema_tests {
     fn load_schema_from_text(text: &str) -> Rc<Schema> {
         let owned_elements = load(text).into_iter();
         // create a type_store and resolver instance to be used for loading OwnedElements as schema
-        let type_store = &mut TypeStore::new().unwrap();
+        let type_store = &mut TypeStore::new();
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and create a schema from isl
@@ -203,7 +203,7 @@ mod schema_tests {
         total_types: usize,
     ) {
         // create a type_store and resolver instance to be used for loading OwnedElements as schema
-        let type_store = &mut TypeStore::new().unwrap();
+        let type_store = &mut TypeStore::new();
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -132,7 +132,7 @@ mod schema_tests {
     owned_elements, total_types,
     case::type_constraint_with_named_type(
         load(r#" // For a schema with named type as below:
-            type:: { name: my_int, type: int }
+            type:: { name: my_type, type: any }
         "#).into_iter(),
         1 // this includes the named type my_int
     ),
@@ -221,7 +221,7 @@ mod schema_tests {
     }
 
     #[rstest(
-        valid_values, invalid_values, schema,
+        valid_values, invalid_values, schema, type_name,
         case::type_constraint(
             load(r#"
                 5
@@ -236,6 +236,7 @@ mod schema_tests {
             load_schema_from_text(r#" // For a schema with named type as below: 
                 type:: { name: my_int, type: int }
             "#),
+            "my_int"
         ),
         case::not_constraint(
             load(r#"
@@ -252,6 +253,7 @@ mod schema_tests {
             load_schema_from_text(r#" // For a schema with not constraint as below: 
                 type:: { name: not_type, not: { type: int } }
             "#),
+            "not_type"
         ),
         case::one_of_constraint(
             load(r#"
@@ -268,6 +270,7 @@ mod schema_tests {
             load_schema_from_text(r#" // For a schema with one_of constraint as below: 
                 type:: { name: one_of_type, one_of: [int, decimal] }
             "#),
+            "one_of_type"
         ),
         // TODO: add a test case for all_of constraint
         case::any_of_constraint(
@@ -284,14 +287,16 @@ mod schema_tests {
             load_schema_from_text(r#" // For a schema with any_of constraint as below: 
                 type:: { name: any_of_type, any_of: [int, decimal, bool] }
             "#),
+            "any_of_type"
         ),
     )]
     fn type_validation(
         valid_values: Vec<OwnedElement>,
         invalid_values: Vec<OwnedElement>,
         schema: Rc<Schema>,
+        type_name: &str,
     ) {
-        let type_ref: TypeRef = schema.get_types().next().expect("Loaded schema was empty.");
+        let type_ref: TypeRef = schema.get_type(type_name).unwrap();
         // check for validation without any violations
         for valid_value in valid_values.iter() {
             // there is only a single type in each schema defined above hence validate with that type

--- a/src/system.rs
+++ b/src/system.rs
@@ -7,10 +7,9 @@ use crate::result::{
     IonSchemaResult,
 };
 use crate::schema::Schema;
-use crate::types::{TypeDefinition, TypeDefinitionImpl};
+use crate::types::{CoreISLTypeDefinition, TypeDefinition, TypeDefinitionImpl};
 use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
 use ion_rs::value::{Element, Sequence, Struct};
-use ion_rs::IonType;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::rc::Rc;
@@ -30,7 +29,7 @@ use std::rc::Rc;
 /// [PendingTypes] can be promoted the [TypeStore].
 #[derive(Debug, Clone)]
 pub struct PendingTypes {
-    core_type_ids_by_ion_type: HashMap<String, TypeId>,
+    core_type_ids_by_name: HashMap<String, TypeId>,
     ids_by_name: HashMap<String, TypeId>,
     parent: Option<(String, TypeId)>,
     types_by_id: Vec<Option<TypeDefinition>>, // a None in this vector represents a not-yet-resolved type
@@ -40,7 +39,7 @@ impl PendingTypes {
     pub fn new() -> Self {
         Self {
             parent: None,
-            core_type_ids_by_ion_type: HashMap::new(),
+            core_type_ids_by_name: HashMap::new(),
             ids_by_name: HashMap::new(),
             types_by_id: Vec::new(),
         }
@@ -181,7 +180,7 @@ impl PendingTypes {
                 TypeDefinition::Anonymous(anonymous_type_def) => {
                     type_store.add_anonymous_type(anonymous_type_def)
                 }
-                TypeDefinition::Core(ion_type) => type_store.add_core_type(ion_type),
+                TypeDefinition::Core(core_type) => type_store.add_core_type(&core_type),
             };
         }
         Ok(())
@@ -227,8 +226,8 @@ impl PendingTypes {
                 TypeDefinition::Anonymous(anonymous_type_def) => {
                     type_store.add_anonymous_type(anonymous_type_def);
                 }
-                TypeDefinition::Core(ion_type) => {
-                    type_store.add_core_type(ion_type);
+                TypeDefinition::Core(core_type) => {
+                    type_store.add_core_type(&core_type);
                 }
             };
         }
@@ -272,20 +271,29 @@ impl PendingTypes {
         type_id + type_store.types_by_id.len()
     }
 
-    /// Adds the [CoreTypeDefinition] and the associated ion_type in the [PendingTypes] and returns the [TypeId] for it
+    /// Adds the [CoreISLTypeDefinition] in the [PendingTypes] and returns the [TypeId] for it
     /// If the given name already exists in the [TypeStore] or [PendingTypes] it returns the associated [TypeId]
-    pub fn add_core_type(&mut self, ion_type: IonType, type_store: &mut TypeStore) -> TypeId {
-        let core_type = &format!("{:?}", ion_type);
-        if let Some(exists) = self.core_type_ids_by_ion_type.get(core_type) {
+    pub fn add_core_type(
+        &mut self,
+        core_isl_type: &CoreISLTypeDefinition,
+        type_store: &mut TypeStore,
+    ) -> TypeId {
+        let core_type_name = match core_isl_type {
+            CoreISLTypeDefinition::IonType(ion_type) => format!("{}", ion_type),
+            CoreISLTypeDefinition::Other(other_type) => other_type.name().to_owned().unwrap(),
+        };
+
+        if let Some(exists) = self.core_type_ids_by_name.get(&core_type_name) {
             return exists.to_owned();
         }
-        if let Some(exists) = type_store.get_core_type_id_by_ion_type(&ion_type) {
+        if let Some(exists) = type_store.get_core_type_id(core_isl_type) {
             return exists.to_owned();
         }
         let type_id = self.types_by_id.len();
-        self.core_type_ids_by_ion_type
-            .insert(core_type.to_owned(), type_id);
-        self.types_by_id.push(Some(TypeDefinition::Core(ion_type)));
+        self.core_type_ids_by_name
+            .insert(core_type_name.to_owned(), type_id);
+        self.types_by_id
+            .push(Some(TypeDefinition::Core(core_isl_type.to_owned())));
         type_id + type_store.types_by_id.len()
     }
 
@@ -351,16 +359,16 @@ pub type TypeId = usize;
 /// Defines a cache that can be used to store resolved [Type]s of a [Schema]
 #[derive(Debug, Clone)]
 pub struct TypeStore {
-    core_type_ids_by_ion_type: HashMap<String, TypeId>, // stores all the core types used within this schema
+    core_type_ids_by_name: HashMap<String, TypeId>, // stores all the core types used within this schema
     imported_type_ids_by_name: HashMap<String, TypeId>, // stores all the imported types of a schema
-    ids_by_name: HashMap<String, TypeId>, // stores named types defined within the schema
+    ids_by_name: HashMap<String, TypeId>,           // stores named types defined within the schema
     types_by_id: Vec<TypeDefinition>,
 }
 
 impl TypeStore {
     pub fn new() -> Self {
         Self {
-            core_type_ids_by_ion_type: HashMap::new(),
+            core_type_ids_by_name: HashMap::new(),
             imported_type_ids_by_name: HashMap::new(),
             ids_by_name: HashMap::new(),
             types_by_id: Vec::new(),
@@ -398,11 +406,14 @@ impl TypeStore {
             .or_else(|| self.imported_type_ids_by_name.get(name))
     }
 
-    /// Provides the [TypeId] associated with given [IonType] if it exists in the [TypeStore]  
+    /// Provides the [TypeId] associated with given [CoreISLTypeDefinition] if it exists in the [TypeStore]  
     /// Otherwise returns None
-    pub fn get_core_type_id_by_ion_type(&self, ion_type: &IonType) -> Option<&TypeId> {
-        self.core_type_ids_by_ion_type
-            .get(&format!("{:?}", ion_type))
+    pub fn get_core_type_id(&self, core_isl_type: &CoreISLTypeDefinition) -> Option<&TypeId> {
+        let core_type_name = match core_isl_type {
+            CoreISLTypeDefinition::IonType(ion_type) => format!("{}", ion_type),
+            CoreISLTypeDefinition::Other(other_type) => other_type.name().to_owned().unwrap(),
+        };
+        self.core_type_ids_by_name.get(&core_type_name)
     }
 
     /// Provides the [Type] associated with given [TypeId] if it exists in the [TypeStore]  
@@ -424,17 +435,22 @@ impl TypeStore {
         type_id
     }
 
-    /// Adds the [CoreTypeDefinition] and the associated [IonType] in the [TypeStore] and returns the [TypeId] for it
+    /// Adds the [CoreISLTypeDefinition] in the [TypeStore] and returns the [TypeId] for it
     /// If the name already exists in the [TypeStore] it returns the associated [TypeId]
-    pub fn add_core_type(&mut self, ion_type: IonType) -> TypeId {
-        let core_type = &format!("{:?}", ion_type);
-        if let Some(exists) = self.core_type_ids_by_ion_type.get(core_type) {
+    pub fn add_core_type(&mut self, core_isl_type: &CoreISLTypeDefinition) -> TypeId {
+        let core_type_name = match core_isl_type {
+            CoreISLTypeDefinition::IonType(ion_type) => format!("{}", ion_type),
+            CoreISLTypeDefinition::Other(other_type) => other_type.name().to_owned().unwrap(),
+        };
+
+        if let Some(exists) = self.core_type_ids_by_name.get(&core_type_name) {
             return exists.to_owned();
         }
         let type_id = self.types_by_id.len();
-        self.core_type_ids_by_ion_type
-            .insert(core_type.to_owned(), type_id);
-        self.types_by_id.push(TypeDefinition::Core(ion_type));
+        self.core_type_ids_by_name
+            .insert(core_type_name.to_owned(), type_id);
+        self.types_by_id
+            .push(TypeDefinition::Core(core_isl_type.to_owned()));
         type_id
     }
 
@@ -494,7 +510,7 @@ impl Resolver {
             // convert [IslType] into [TypeDefinition]
             match isl_type {
                 IslType::Named(named_isl_type) => TypeDefinition::Named(
-                    TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
+                    TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
                         &named_isl_type,
                         type_store,
                         pending_types,
@@ -502,7 +518,7 @@ impl Resolver {
                     .unwrap(),
                 ),
                 IslType::Anonymous(anonymous_isl_type) => TypeDefinition::Anonymous(
-                    TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
+                    TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
                         &anonymous_isl_type,
                         type_store,
                         pending_types,
@@ -601,7 +617,7 @@ impl Resolver {
 
             // convert IslType to TypeDefinition
             let type_def: TypeDefinitionImpl =
-                TypeDefinitionImpl::parse_from_isl_type_and_update_type_store(
+                TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
                     isl_type,
                     type_store,
                     pending_types,
@@ -970,6 +986,7 @@ mod schema_system_tests {
         let schema = schema_system.load_schema("sample_number.isl");
         assert_eq!(true, schema.is_ok());
     }
+
     #[test]
     fn schema_system_map_authority_with_incorrect_inline_import_type_test() {
         // map with (id, ion content)
@@ -1022,9 +1039,67 @@ mod schema_system_tests {
         ];
         let mut schema_system =
             SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
-        // verify if the schema loads without any errors
+        // verify if the schema loads with specific errors
         let schema = schema_system.load_schema("sample_number.isl");
         assert_eq!(true, schema.is_err());
         assert!(matches!(schema.unwrap_err(), InvalidSchemaError { .. }));
+    }
+
+    #[test]
+    fn schema_system_map_authority_with_isl_core_types() {
+        // map with (id, ion content)
+        let map_authority = [
+            (
+                "sample.isl",
+                r#"
+                    schema_header::{
+                      imports: [ { id: "sample_core_types.isl" } ],
+                    }
+                    
+                    type::{
+                        name: my_number,
+                        type: number,
+                    }
+                    
+                    type::{
+                      name: my_type,
+                      one_of: [
+                        my_number,
+                        my_text,
+                        my_lob
+                      ],
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+            (
+                "sample_core_types.isl",
+                r#"
+                    schema_header::{
+                      imports: [],
+                    }
+                    
+                    type::{
+                      name: my_text,
+                      type: text,
+                    }
+                    
+                    type::{
+                        name: my_lob,
+                        type: lob,
+                    }
+                    
+                    schema_footer::{
+                    }
+                "#,
+            ),
+        ];
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema loads without any errors
+        let schema = schema_system.load_schema("sample.isl");
+        assert_eq!(true, schema.is_ok());
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -402,6 +402,7 @@ impl TypeStore {
 
     /// Preloads all [builtin isl types] into the TypeStore
     /// [builtin isl types]: https://amzn.github.io/ion-schema/docs/spec.html#type-system
+    /// TODO: add document builtin type
     pub fn preload(&mut self) -> IonSchemaResult<()> {
         // add all ion types to the type store
         // TODO: this array can be turned into an iterator implementation in ion-rust for IonType
@@ -484,6 +485,13 @@ impl TypeStore {
     /// Provides the [TypeId] associated with given type name if it exists in the [TypeStore]  
     /// Otherwise returns None
     pub fn get_builtin_type_id(&self, type_name: &str) -> Option<TypeId> {
+        let type_name = match type_name {
+            "int" => "integer",
+            "bool" => "boolean",
+            "$int" => "$integer",
+            "$bool" => "$boolean",
+            _ => type_name,
+        };
         self.builtin_type_ids_by_name
             .get(type_name)
             .and_then(|t| Some(t.to_owned()))

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -50,7 +50,7 @@ impl fmt::Display for Violation {
 #[derive(Debug, Clone)]
 pub enum ViolationCode {
     NoTypesMatched,
-    InvalidNull,
+    InvalidNull, // if the value is a null for type references that doesn't allow null
     MoreThanOneTypeMatched,
     TypeMatched,
     AllTypesNotMatched,

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -50,6 +50,7 @@ impl fmt::Display for Violation {
 #[derive(Debug, Clone)]
 pub enum ViolationCode {
     NoTypesMatched,
+    InvalidNull,
     MoreThanOneTypeMatched,
     TypeMatched,
     AllTypesNotMatched,
@@ -69,6 +70,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::AllTypesNotMatched => "all_types_not_matched",
                 ViolationCode::TypeMismatched => "type_mismatched",
                 ViolationCode::TypeConstraintsUnsatisfied => "type_constraints_unsatisfied",
+                ViolationCode::InvalidNull => "invalid_null",
             }
         )
     }


### PR DESCRIPTION
*Issue #13*

*Description of changes:*
This PR works on implementing [ISL core types](https://amzn.github.io/ion-schema/docs/spec.html#core-types)

*Changes:*
* adds `CoreIslType` and `CoreISLTypeDefinition` for lob, number, text, any
core types implementation
* renames `TypeDefintionImpl` method
`parse_from_isl_type_and_update_pending_types`
* adds changes to `TypeStore`, `PedningTypes` to store core types
* adds unit tests for this change
* `core_types.rs` stores `Hashmap` of ISL core types and their definition

*Test:*
adds tests for ISL core types
