### PR TITLE
Adds changes for integrating ion-schema-tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ chrono = "0.4"
 [dev-dependencies]
 rstest = "0.9"
 clap = {version = "2.33.3", features = ["yaml"]}
+test-generator = "0.3.0"

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -64,6 +64,7 @@ impl IslConstraint {
                 let types: Vec<IslTypeRef> = IslConstraint::isl_type_references_from_ion_element(
                     value,
                     inline_imported_types,
+                    "all_of",
                 )?;
                 Ok(IslConstraint::AllOf(types))
             }
@@ -71,6 +72,7 @@ impl IslConstraint {
                 let types: Vec<IslTypeRef> = IslConstraint::isl_type_references_from_ion_element(
                     value,
                     inline_imported_types,
+                    "any_of",
                 )?;
                 Ok(IslConstraint::AnyOf(types))
             }
@@ -78,6 +80,7 @@ impl IslConstraint {
                 let types: Vec<IslTypeRef> = IslConstraint::isl_type_references_from_ion_element(
                     value,
                     inline_imported_types,
+                    "one_of",
                 )?;
                 Ok(IslConstraint::OneOf(types))
             }
@@ -108,6 +111,7 @@ impl IslConstraint {
                 let types: Vec<IslTypeRef> = IslConstraint::isl_type_references_from_ion_element(
                     value,
                     inline_imported_types,
+                    "ordered_elements",
                 )?;
                 Ok(IslConstraint::OrderedElements(types))
             }
@@ -127,11 +131,19 @@ impl IslConstraint {
     fn isl_type_references_from_ion_element(
         value: &OwnedElement,
         inline_imported_types: &mut Vec<IslImportType>,
+        constraint_name: &str,
     ) -> IonSchemaResult<Vec<IslTypeRef>> {
         //TODO: create a method/macro for this ion type check which can be reused
+        if value.is_null() {
+            return Err(invalid_schema_error_raw(format!(
+                "{} constraint was a null instead of a list",
+                constraint_name
+            )));
+        }
         if value.ion_type() != IonType::List {
             return Err(invalid_schema_error_raw(format!(
-                "all_of constraint was a {:?} instead of a list",
+                "{} constraint was a {:?} instead of a list",
+                constraint_name,
                 value.ion_type()
             )));
         }

--- a/src/isl/isl_import.rs
+++ b/src/isl/isl_import.rs
@@ -75,7 +75,7 @@ impl IslImportType {
         }
     }
 
-    pub(crate) fn id(&self) -> &String {
+    pub fn id(&self) -> &String {
         &self.id
     }
 

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -78,12 +78,7 @@ impl IslTypeImpl {
             None => None, // If there is no name field then it is an anonymous type
         };
 
-        if contains_annotations && type_name.is_none() {
-            // If a named type doesn't have name field return an error
-            return Err(invalid_schema_error_raw(
-                "Top level types must have a name field in its definition",
-            ));
-        } else if !contains_annotations && type_name.is_some() {
+        if !contains_annotations && type_name.is_some() {
             // For named types if it does not have the `type::` annotation return an error
             return Err(invalid_schema_error_raw(
                 "Top level types must have `type::` annotation in their definition",

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -42,6 +42,11 @@ impl IslTypeRef {
     ) -> IonSchemaResult<Self> {
         match value.ion_type() {
             IonType::Symbol => {
+                if value.is_null() {
+                    return invalid_schema_error(
+                        "a base or alias type reference can not be null.symbol",
+                    )
+                }
                 value.as_sym().unwrap()
                     .text()
                     .ok_or_else(|| {
@@ -50,13 +55,15 @@ impl IslTypeRef {
                         )
                     })
                     .and_then(|type_name| {
-                        let ion_type = match type_name {
-                            _ => IslTypeRef::Named(type_name.to_owned()),
-                        };
-                        Ok(ion_type)
+                        Ok(IslTypeRef::Named(type_name.to_owned()))
                     })
             }
             IonType::Struct => {
+                if value.is_null() {
+                    return invalid_schema_error(
+                        "a base or alias type reference can not be null.struct",
+                    )
+                }
                 let value_struct = try_to!(value.as_struct());
                 // if the struct doesn't have an id field then it must be an anonymous type
                 if value_struct.get("id").is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,5 @@ pub mod isl;
 pub mod result;
 pub mod schema;
 pub mod system;
-mod types;
+pub mod types;
 mod violation;

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -5,163 +5,152 @@ use ion_rs::value::{Element, Sequence};
 use ion_schema::authority::FileSystemDocumentAuthority;
 use ion_schema::system::{SchemaSystem, TypeStore};
 use ion_schema::types::{TypeDefinitionImpl, TypeValidator};
+use rstest::*;
 use std::fs;
 use std::path::Path;
+use test_generator::test_resources;
 
 const TEST_ROOT_DIR: &str = "ion-schema-tests/";
 
-const SCHEMA_TEST_LIST: &[&str] = &[
-    "ion-schema-tests/constraints/all_of/core_types.isl",
-    "ion-schema-tests/constraints/all_of/empty_type.isl",
-    "ion-schema-tests/constraints/all_of/invalid.isl",
-    "ion-schema-tests/constraints/any_of/core_types.isl",
-    "ion-schema-tests/constraints/any_of/empty_type.isl",
-    "ion-schema-tests/constraints/any_of/invalid.isl",
-    "ion-schema-tests/constraints/not/empty_type.isl",
-    "ion-schema-tests/constraints/not/$string.isl",
-    "ion-schema-tests/constraints/not/invalid.isl",
-    "ion-schema-tests/constraints/not/nested.isl",
-    "ion-schema-tests/constraints/not/string.isl",
-    "ion-schema-tests/constraints/one_of/core_types.isl",
-    "ion-schema-tests/constraints/one_of/empty_type.isl",
-    "ion-schema-tests/constraints/one_of/invalid.isl",
-    "ion-schema-tests/constraints/type/empty_type.isl",
-    "ion-schema-tests/constraints/type/validation_any.isl",
-    "ion-schema-tests/constraints/type/validation_int.isl",
-    "ion-schema-tests/core_types/any.isl",
-    "ion-schema-tests/core_types/blob.isl",
-    "ion-schema-tests/core_types/bool.isl",
-    "ion-schema-tests/core_types/clob.isl",
-    "ion-schema-tests/core_types/decimal.isl",
-    "ion-schema-tests/core_types/float.isl",
-    "ion-schema-tests/core_types/int.isl",
-    "ion-schema-tests/core_types/list.isl",
-    "ion-schema-tests/core_types/lob.isl",
-    "ion-schema-tests/core_types/number.isl",
-    "ion-schema-tests/core_types/sexp.isl",
-    "ion-schema-tests/core_types/struct.isl",
-    "ion-schema-tests/core_types/symbol.isl",
-    "ion-schema-tests/core_types/text.isl",
-    "ion-schema-tests/core_types/timestamp.isl",
-    "ion-schema-tests/ion_types/$any.isl",
-    "ion-schema-tests/ion_types/$blob.isl",
-    "ion-schema-tests/ion_types/$bool.isl",
-    "ion-schema-tests/ion_types/$clob.isl",
-    "ion-schema-tests/ion_types/$decimal.isl",
-    "ion-schema-tests/ion_types/$float.isl",
-    "ion-schema-tests/ion_types/$int.isl",
-    "ion-schema-tests/ion_types/$list.isl",
-    "ion-schema-tests/ion_types/$lob.isl",
-    "ion-schema-tests/ion_types/$null.isl",
-    "ion-schema-tests/ion_types/$number.isl",
-    "ion-schema-tests/ion_types/$sexp.isl",
-    "ion-schema-tests/ion_types/$struct.isl",
-    "ion-schema-tests/ion_types/$symbol.isl",
-    "ion-schema-tests/ion_types/$text.isl",
-    "ion-schema-tests/ion_types/$timestamp.isl",
+// following test files will be ignored while testing
+// `test-resources` don't support to provide a skip-list of test files
+const SKIP_LIST: &[&str] = &[
+    "ion-schema-tests/constraints/all_of/inlined_types.isl",
+    "ion-schema-tests/constraints/all_of/inlined_type_import.isl",
+    "ion-schema-tests/constraints/all_of/validation.isl",
+    "ion-schema-tests/constraints/any_of/inlined_types.isl",
+    "ion-schema-tests/constraints/any_of/inlined_type_import.isl",
+    "ion-schema-tests/constraints/any_of/validation.isl",
+    "ion-schema-tests/constraints/one_of/inlined_types.isl",
+    "ion-schema-tests/constraints/one_of/inlined_type_import.isl",
+    "ion-schema-tests/constraints/one_of/validation.isl",
+    "ion-schema-tests/constraints/type/inlined_types.isl",
+    "ion-schema-tests/constraints/type/inlined_type_import.isl",
+    "ion-schema-tests/constraints/type/validation.isl",
+    "ion-schema-tests/constraints/type/nullable.isl",
+    "ion-schema-tests/core_types/nothing.isl",
+    "ion-schema-tests/core_types/document.isl",
 ];
 
-#[test]
-fn validation_tests() {
+#[test_resources("ion-schema-tests/core_types/*.isl")]
+#[test_resources("ion-schema-tests/constraints/all_of/*.isl")]
+#[test_resources("ion-schema-tests/constraints/any_of/*.isl")]
+#[test_resources("ion-schema-tests/constraints/not/invalid.isl")]
+#[test_resources("ion-schema-tests/constraints/not/nested.isl")]
+#[test_resources("ion-schema-tests/constraints/not/string.isl")]
+#[test_resources("ion-schema-tests/constraints/one_of/*.isl")]
+#[test_resources("ion-schema-tests/constraints/type/*.isl")]
+// `test_resources` breaks for test-case names containing `$` and it doesn't allow
+// to rename test-case names hence using `rstest` for `$*.isl` test files
+#[rstest(
+    path,
+    case::nullable_any_type("ion-schema-tests/ion_types/$any.isl"),
+    case::nullable_blob_type("ion-schema-tests/ion_types/$blob.isl"),
+    case::nullable_bool_type("ion-schema-tests/ion_types/$bool.isl"),
+    case::nullable_clob_type("ion-schema-tests/ion_types/$clob.isl"),
+    case::nullable_decimal_type("ion-schema-tests/ion_types/$decimal.isl"),
+    case::nullable_float_type("ion-schema-tests/ion_types/$float.isl"),
+    case::nullable_int_type("ion-schema-tests/ion_types/$int.isl"),
+    case::nullable_list_type("ion-schema-tests/ion_types/$list.isl"),
+    case::nullable_lob_type("ion-schema-tests/ion_types/$lob.isl"),
+    case::nullable_null_type("ion-schema-tests/ion_types/$null.isl"),
+    case::nullable_number_type("ion-schema-tests/ion_types/$number.isl"),
+    case::nullable_sexp_type("ion-schema-tests/ion_types/$sexp.isl"),
+    case::nullable_string_type("ion-schema-tests/ion_types/$string.isl"),
+    case::nullable_strcut_type("ion-schema-tests/ion_types/$struct.isl"),
+    case::nullable_symbol_type("ion-schema-tests/ion_types/$symbol.isl"),
+    case::nullable_text_type("ion-schema-tests/ion_types/$text.isl"),
+    case::nullable_timestamp_type("ion-schema-tests/ion_types/$timestamp.isl")
+)]
+fn validation_tests(path: &str) {
+    print!("{}...", path);
+
+    // ignore the files that are in SKIP_LIST
+    if SKIP_LIST.contains(&path) {
+        println!("IGNORED");
+        return;
+    }
     // create a schema system for validation test
     let authority = FileSystemDocumentAuthority::new(Path::new(TEST_ROOT_DIR));
     let mut schema_system = SchemaSystem::new(vec![Box::new(authority)]);
 
-    for path in SCHEMA_TEST_LIST {
-        print!("Reading {}... ", path);
+    // get the schema content from given schema file path
+    let ion_content = fs::read(path).unwrap();
+    let iterator = element_reader().iterate_over(&ion_content).unwrap();
+    let schema_content = iterator
+        .collect::<Result<Vec<OwnedElement>, IonError>>()
+        .unwrap();
 
-        // get the schema content from given schema file path
-        let ion_content = fs::read(path).unwrap();
-        let iterator = element_reader().iterate_over(&ion_content).unwrap();
-        let schema_content = iterator
-            .collect::<Result<Vec<OwnedElement>, IonError>>()
-            .unwrap();
+    let type_store = &mut TypeStore::new();
+    let mut invalid_values: Vec<OwnedElement> = vec![];
+    let mut valid_values: Vec<OwnedElement> = vec![];
+    let mut type_def: Option<TypeDefinitionImpl> = None;
 
-        let type_store = &mut TypeStore::new();
-        let mut invalid_values: Vec<OwnedElement> = vec![];
-        let mut valid_values: Vec<OwnedElement> = vec![];
-        let mut type_def: Option<TypeDefinitionImpl> = None;
-        let mut test_failed: bool = false;
+    // store all the errors encountered while testing
+    let mut failed_tests = vec![];
 
-        for element in schema_content {
-            let annotations: Vec<&OwnedSymbolToken> = element.annotations().collect();
-            if annotations.contains(&&text_token("invalid_type")) {
-                // check for an invalid type validation
-                let type_def_result = schema_system.schema_type_from_element(&element, type_store);
-                if type_def_result.is_ok() {
-                    println!("ERROR: expected error for invalid type {:?}", element);
-                    test_failed = true;
-                    break;
-                }
-            } else if annotations.contains(&&text_token("invalid")) {
-                // get invalid values to validate
-                invalid_values = element
-                    .as_sequence()
-                    .unwrap()
-                    .iter()
-                    .map(|v| v.to_owned())
-                    .collect();
-            } else if annotations.contains(&&text_token("valid")) {
-                // get valid values to validate
-                valid_values = element
-                    .as_sequence()
-                    .unwrap()
-                    .iter()
-                    .map(|v| v.to_owned())
-                    .collect();
-            } else if annotations.contains(&&text_token("type")) {
-                // get type definition for type validation
-                type_def = Some(
-                    schema_system
-                        .schema_type_from_element(&element, type_store)
-                        .unwrap(),
-                );
-            } else {
-                continue;
+    for element in schema_content {
+        let annotations: Vec<&OwnedSymbolToken> = element.annotations().collect();
+        if annotations.contains(&&text_token("invalid_type")) {
+            // check for an invalid type validation
+            let type_def_result = schema_system.schema_type_from_element(&element, type_store);
+            if type_def_result.is_ok() {
+                failed_tests.push(format!("Expected error for invalid type: {:?}", element));
+            }
+        } else if annotations.contains(&&text_token("invalid")) {
+            // get invalid values to validate
+            invalid_values = element
+                .as_sequence()
+                .unwrap()
+                .iter()
+                .map(|v| v.to_owned())
+                .collect();
+        } else if annotations.contains(&&text_token("valid")) {
+            // get valid values to validate
+            valid_values = element
+                .as_sequence()
+                .unwrap()
+                .iter()
+                .map(|v| v.to_owned())
+                .collect();
+        } else if annotations.contains(&&text_token("type")) {
+            // get type definition for type validation
+            type_def = Some(
+                schema_system
+                    .schema_type_from_element(&element, type_store)
+                    .unwrap(),
+            );
+        } else {
+            continue;
+        }
+    }
+
+    if let Some(schema_type) = type_def {
+        for valid_value in valid_values {
+            if let Err(error) = schema_type.validate(&valid_value, type_store) {
+                failed_tests.push(format!("{} for {:?}", error, valid_value));
             }
         }
 
-        match type_def {
-            None => {}
-            Some(schema_type) => {
-                for valid_value in valid_values {
-                    match schema_type.validate(&valid_value, type_store) {
-                        Ok(_) => {
-                            continue;
-                        }
-                        Err(error) => {
-                            println!("ERROR: {} for {:?}", error, valid_value);
-                            test_failed = true;
-                        }
-                    };
-                }
-
-                if test_failed {
-                    // move to next test file if any test failed
-                    continue;
-                }
-
-                for invalid_value in invalid_values {
-                    match schema_type.validate(&invalid_value, type_store) {
-                        Ok(_) => {
-                            println!(
-                                "ERROR: expected invalid value to return error for {:?}",
-                                &invalid_value
-                            );
-                            test_failed = true;
-                            break;
-                        }
-                        Err(_) => {
-                            continue;
-                        }
-                    };
-                }
+        for invalid_value in invalid_values {
+            if schema_type.validate(&invalid_value, type_store).is_ok() {
+                failed_tests.push(format!(
+                    "Expected error for invalid value: {:?}",
+                    &invalid_value
+                ));
             }
         }
+    }
 
-        // print "OK" for a successful validation test
-        if !test_failed {
-            println!("OK");
+    if failed_tests.is_empty() {
+        // print "OK" for a successful test
+        println!("OK");
+    } else {
+        // print all errors found during test
+        println!("ERROR");
+        for failed_test in failed_tests {
+            println!("{}", failed_test);
         }
+        panic!("Found error in ion schema tests")
     }
 }

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -1,0 +1,167 @@
+use ion_rs::result::IonError;
+use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
+use ion_rs::value::reader::{element_reader, ElementReader};
+use ion_rs::value::{Element, Sequence};
+use ion_schema::authority::FileSystemDocumentAuthority;
+use ion_schema::system::{SchemaSystem, TypeStore};
+use ion_schema::types::{TypeDefinitionImpl, TypeValidator};
+use std::fs;
+use std::path::Path;
+
+const TEST_ROOT_DIR: &str = "ion-schema-tests/";
+
+const SCHEMA_TEST_LIST: &[&str] = &[
+    "ion-schema-tests/constraints/all_of/core_types.isl",
+    "ion-schema-tests/constraints/all_of/empty_type.isl",
+    "ion-schema-tests/constraints/all_of/invalid.isl",
+    "ion-schema-tests/constraints/any_of/core_types.isl",
+    "ion-schema-tests/constraints/any_of/empty_type.isl",
+    "ion-schema-tests/constraints/any_of/invalid.isl",
+    "ion-schema-tests/constraints/not/empty_type.isl",
+    "ion-schema-tests/constraints/not/$string.isl",
+    "ion-schema-tests/constraints/not/invalid.isl",
+    "ion-schema-tests/constraints/not/nested.isl",
+    "ion-schema-tests/constraints/not/string.isl",
+    "ion-schema-tests/constraints/one_of/core_types.isl",
+    "ion-schema-tests/constraints/one_of/empty_type.isl",
+    "ion-schema-tests/constraints/one_of/invalid.isl",
+    "ion-schema-tests/constraints/type/empty_type.isl",
+    "ion-schema-tests/constraints/type/validation_any.isl",
+    "ion-schema-tests/constraints/type/validation_int.isl",
+    "ion-schema-tests/core_types/any.isl",
+    "ion-schema-tests/core_types/blob.isl",
+    "ion-schema-tests/core_types/bool.isl",
+    "ion-schema-tests/core_types/clob.isl",
+    "ion-schema-tests/core_types/decimal.isl",
+    "ion-schema-tests/core_types/float.isl",
+    "ion-schema-tests/core_types/int.isl",
+    "ion-schema-tests/core_types/list.isl",
+    "ion-schema-tests/core_types/lob.isl",
+    "ion-schema-tests/core_types/number.isl",
+    "ion-schema-tests/core_types/sexp.isl",
+    "ion-schema-tests/core_types/struct.isl",
+    "ion-schema-tests/core_types/symbol.isl",
+    "ion-schema-tests/core_types/text.isl",
+    "ion-schema-tests/core_types/timestamp.isl",
+    "ion-schema-tests/ion_types/$any.isl",
+    "ion-schema-tests/ion_types/$blob.isl",
+    "ion-schema-tests/ion_types/$bool.isl",
+    "ion-schema-tests/ion_types/$clob.isl",
+    "ion-schema-tests/ion_types/$decimal.isl",
+    "ion-schema-tests/ion_types/$float.isl",
+    "ion-schema-tests/ion_types/$int.isl",
+    "ion-schema-tests/ion_types/$list.isl",
+    "ion-schema-tests/ion_types/$lob.isl",
+    "ion-schema-tests/ion_types/$null.isl",
+    "ion-schema-tests/ion_types/$number.isl",
+    "ion-schema-tests/ion_types/$sexp.isl",
+    "ion-schema-tests/ion_types/$struct.isl",
+    "ion-schema-tests/ion_types/$symbol.isl",
+    "ion-schema-tests/ion_types/$text.isl",
+    "ion-schema-tests/ion_types/$timestamp.isl",
+];
+
+#[test]
+fn validation_tests() {
+    // create a schema system for validation test
+    let authority = FileSystemDocumentAuthority::new(Path::new(TEST_ROOT_DIR));
+    let mut schema_system = SchemaSystem::new(vec![Box::new(authority)]);
+
+    for path in SCHEMA_TEST_LIST {
+        print!("Reading {}... ", path);
+
+        // get the schema content from given schema file path
+        let ion_content = fs::read(path).unwrap();
+        let iterator = element_reader().iterate_over(&ion_content).unwrap();
+        let schema_content = iterator
+            .collect::<Result<Vec<OwnedElement>, IonError>>()
+            .unwrap();
+
+        let type_store = &mut TypeStore::new();
+        let mut invalid_values: Vec<OwnedElement> = vec![];
+        let mut valid_values: Vec<OwnedElement> = vec![];
+        let mut type_def: Option<TypeDefinitionImpl> = None;
+        let mut test_failed: bool = false;
+
+        for element in schema_content {
+            let annotations: Vec<&OwnedSymbolToken> = element.annotations().collect();
+            if annotations.contains(&&text_token("invalid_type")) {
+                // check for an invalid type validation
+                let type_def_result = schema_system.schema_type_from_element(&element, type_store);
+                if type_def_result.is_ok() {
+                    println!("ERROR: expected error for invalid type {:?}", element);
+                    test_failed = true;
+                    break;
+                }
+            } else if annotations.contains(&&text_token("invalid")) {
+                // get invalid values to validate
+                invalid_values = element
+                    .as_sequence()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.to_owned())
+                    .collect();
+            } else if annotations.contains(&&text_token("valid")) {
+                // get valid values to validate
+                valid_values = element
+                    .as_sequence()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.to_owned())
+                    .collect();
+            } else if annotations.contains(&&text_token("type")) {
+                // get type definition for type validation
+                type_def = Some(
+                    schema_system
+                        .schema_type_from_element(&element, type_store)
+                        .unwrap(),
+                );
+            } else {
+                continue;
+            }
+        }
+
+        match type_def {
+            None => {}
+            Some(schema_type) => {
+                for valid_value in valid_values {
+                    match schema_type.validate(&valid_value, type_store) {
+                        Ok(_) => {
+                            continue;
+                        }
+                        Err(error) => {
+                            println!("ERROR: {} for {:?}", error, valid_value);
+                            test_failed = true;
+                        }
+                    };
+                }
+
+                if test_failed {
+                    // move to next test file if any test failed
+                    continue;
+                }
+
+                for invalid_value in invalid_values {
+                    match schema_type.validate(&invalid_value, type_store) {
+                        Ok(_) => {
+                            println!(
+                                "ERROR: expected invalid value to return error for {:?}",
+                                &invalid_value
+                            );
+                            test_failed = true;
+                            break;
+                        }
+                        Err(_) => {
+                            continue;
+                        }
+                    };
+                }
+            }
+        }
+
+        // print "OK" for a successful validation test
+        if !test_failed {
+            println!("OK");
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR adds changes for integrating [ion-schema-tests](https://github.com/amzn/ion-schema-tests)

*Changes:*
* Bug fix: Found null instead of lists while converting
`Vec<OwnedElement>` to `Vec<IslTypeRef>`
* Removed an invalid check to require all 'type::' annotated types to be
named types
* Bug Fix: Found `null.*` as alias for type reference
* Made types module public to be used for tests
* Added `$null` in derived built-in types
* Added `schema_type_from_element()`
* Adds `type: any` as default type constraint if no type constraint
available

*Tests:*
* Adds validation tests from [ion-schema-tests](https://github.com/amzn/ion-schema-tests)