### PR TITLE
adds changes for fields constraint implementation

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -215,7 +215,7 @@ impl ConstraintValidator for AllOfConstraint {
 }
 
 /// Implements an `any_of` constraint of Ion Schema
-/// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#any_of
+/// [any_of]: https://amzn.github.io/ion-schema/docs/spec.html#any_of
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnyOfConstraint {
     type_ids: Vec<TypeId>,
@@ -265,7 +265,7 @@ impl ConstraintValidator for AnyOfConstraint {
 }
 
 /// Implements an `one_of` constraint of Ion Schema
-/// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#one_of
+/// [one_of]: https://amzn.github.io/ion-schema/docs/spec.html#one_of
 #[derive(Debug, Clone, PartialEq)]
 pub struct OneOfConstraint {
     type_ids: Vec<TypeId>,
@@ -421,7 +421,7 @@ impl ConstraintValidator for OccursConstraint {
 }
 
 /// Implements an `ordered_elements` constraint of Ion Schema
-/// [ordered_elements]: https://amzn.github.io/ion-schema/docs/spec.html#all_of
+/// [ordered_elements]: https://amzn.github.io/ion-schema/docs/spec.html#ordered_elements
 #[derive(Debug, Clone, PartialEq)]
 pub struct OrderedElementsConstraint {
     type_ids: Vec<TypeId>,
@@ -578,8 +578,8 @@ impl ConstraintValidator for OrderedElementsConstraint {
     }
 }
 
-/// Implements an `all_of` constraint of Ion Schema
-/// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#all_of
+/// Implements an `fields` constraint of Ion Schema
+/// [fields]: https://amzn.github.io/ion-schema/docs/spec.html#fields
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldsConstraint {
     fields: HashMap<String, TypeId>,

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -7,6 +7,7 @@ use crate::types::{TypeDefinition, TypeValidator};
 use crate::violation::{Violation, ViolationCode};
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, Sequence};
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::iter::Peekable;
 
@@ -25,6 +26,7 @@ pub trait ConstraintValidator {
 pub enum Constraint {
     AllOf(AllOfConstraint),
     AnyOf(AnyOfConstraint),
+    Fields(FieldsConstraint),
     Not(NotConstraint),
     OneOf(OneOfConstraint),
     OrderedElements(OrderedElementsConstraint),
@@ -63,6 +65,14 @@ impl Constraint {
         Constraint::OrderedElements(OrderedElementsConstraint::new(type_ids.into()))
     }
 
+    /// Creates a [Constraint::fields] referring to the fields represented by the provided field name and [TypeId]s.
+    pub fn fields<I>(fields: I) -> Constraint
+    where
+        I: Iterator<Item = (String, TypeId)>,
+    {
+        Constraint::Fields(FieldsConstraint::new(fields.collect()))
+    }
+
     /// Parse an [IslConstraint] to a [Constraint]
     pub fn resolve_from_isl_constraint(
         isl_constraint: &IslConstraint,
@@ -86,6 +96,15 @@ impl Constraint {
                     pending_types,
                 )?;
                 Ok(Constraint::AnyOf(any_of))
+            }
+            IslConstraint::Fields(fields) => {
+                let fields_constraint: FieldsConstraint =
+                    FieldsConstraint::resolve_from_isl_constraint(
+                        fields,
+                        type_store,
+                        pending_types,
+                    )?;
+                Ok(Constraint::Fields(fields_constraint))
             }
             IslConstraint::OneOf(type_references) => {
                 let one_of: OneOfConstraint = OneOfConstraint::resolve_from_isl_constraint(
@@ -130,6 +149,7 @@ impl Constraint {
         match self {
             Constraint::AllOf(all_of) => all_of.validate(value, type_store),
             Constraint::AnyOf(any_of) => any_of.validate(value, type_store),
+            Constraint::Fields(fields) => fields.validate(value, type_store),
             Constraint::Not(not) => not.validate(value, type_store),
             Constraint::OneOf(one_of) => one_of.validate(value, type_store),
             Constraint::Type(type_constraint) => type_constraint.validate(value, type_store),
@@ -555,5 +575,40 @@ impl ConstraintValidator for OrderedElementsConstraint {
         } else {
             Ok(())
         };
+    }
+}
+
+/// Implements an `all_of` constraint of Ion Schema
+/// [all_of]: https://amzn.github.io/ion-schema/docs/spec.html#all_of
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldsConstraint {
+    fields: HashMap<String, TypeId>,
+}
+
+impl FieldsConstraint {
+    pub fn new(fields: HashMap<String, TypeId>) -> Self {
+        Self { fields }
+    }
+
+    /// Tries to create an [Fields] constraint from the given OwnedElement
+    pub fn resolve_from_isl_constraint(
+        fields: &HashMap<String, IslTypeRef>,
+        type_store: &mut TypeStore,
+        pending_types: &mut PendingTypes,
+    ) -> IonSchemaResult<Self> {
+        let resolved_fields: HashMap<String, TypeId> = fields
+            .iter()
+            .map(|(f, t)| {
+                IslTypeRef::resolve_type_reference(t, type_store, pending_types)
+                    .and_then(|type_id| Ok((f.to_owned(), type_id)))
+            })
+            .collect::<IonSchemaResult<HashMap<String, TypeId>>>()?;
+        Ok(FieldsConstraint::new(resolved_fields))
+    }
+}
+
+impl ConstraintValidator for FieldsConstraint {
+    fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
+        todo!()
     }
 }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -65,7 +65,7 @@ impl Constraint {
         Constraint::OrderedElements(OrderedElementsConstraint::new(type_ids.into()))
     }
 
-    /// Creates a [Constraint::fields] referring to the fields represented by the provided field name and [TypeId]s.
+    /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
     pub fn fields<I>(fields: I) -> Constraint
     where
         I: Iterator<Item = (String, TypeId)>,

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -237,6 +237,12 @@ mod isl_tests {
                 "#),
         IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])])
     ),
+    case::fields_constraint(
+        load_anonymous_type(r#" // For a schema with fields constraint as below:
+                    { fields: { name: string, id: int} }
+                "#),
+        IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -130,72 +130,78 @@ mod schema_tests {
 
     #[rstest(
     owned_elements, total_types,
-    case::type_constraint_with_named_type(
-        load(r#" // For a schema with named type as below:
-            type:: { name: my_type, type: any }
-        "#).into_iter(),
-        1 // this includes the named type my_int
-    ),
-    case::type_constraint_with_self_reference_type(
-        load(r#" // For a schema with self reference type as below:
-            type:: { name: my_int, type: my_int }
-        "#).into_iter(),
-        1 // this includes only my_int type
-    ),
-    case::type_constraint_with_nested_self_reference_type(
-        load(r#" // For a schema with nested self reference type as below:
-            type:: { name: my_int, type: { type: my_int } }
-        "#).into_iter(),
-        1 // this includes my_int type
-    ),
-    case::type_constraint_with_nested_type(
-        load(r#" // For a schema with nested types as below:
-            type:: { name: my_int, type: { type: int } }
-        "#).into_iter(),
-        1 // this includes my_int type
-    ),
-    case::type_constraint_with_nested_multiple_types(
-        load(r#" // For a schema with nested multiple types as below:
-            type:: { name: my_int, type: { type: int }, type: { type: my_int } }
-        "#).into_iter(),
-        1 //  this includes my_int type
-    ),
-    case::type_constraint_with_multiple_types(
-        load(r#" // For a schema with multiple type as below:
-             type:: { name: my_int, type: int }
-             type:: { name: my_bool, type: bool }
-        "#).into_iter(),
-        2
-    ),
-    case::all_of_constraint(
-        load(r#" // For a schema with all_of type as below:
-            type:: { name: all_of_type, all_of: [{ type: int }] }
-        "#).into_iter(),
-        1 // this includes named type all_of_type
-    ),
-    case::any_of_constraint(
-        load(r#" // For a schema with any_of constraint as below:
-                type:: { name: any_of_type, any_of: [{ type: int }, { type: decimal }] }
+    // case::type_constraint_with_named_type(
+    //     load(r#" // For a schema with named type as below:
+    //         type:: { name: my_type, type: any }
+    //     "#).into_iter(),
+    //     1 // this includes the named type my_int
+    // ),
+    // case::type_constraint_with_self_reference_type(
+    //     load(r#" // For a schema with self reference type as below:
+    //         type:: { name: my_int, type: my_int }
+    //     "#).into_iter(),
+    //     1 // this includes only my_int type
+    // ),
+    // case::type_constraint_with_nested_self_reference_type(
+    //     load(r#" // For a schema with nested self reference type as below:
+    //         type:: { name: my_int, type: { type: my_int } }
+    //     "#).into_iter(),
+    //     1 // this includes my_int type
+    // ),
+    // case::type_constraint_with_nested_type(
+    //     load(r#" // For a schema with nested types as below:
+    //         type:: { name: my_int, type: { type: int } }
+    //     "#).into_iter(),
+    //     1 // this includes my_int type
+    // ),
+    // case::type_constraint_with_nested_multiple_types(
+    //     load(r#" // For a schema with nested multiple types as below:
+    //         type:: { name: my_int, type: { type: int }, type: { type: my_int } }
+    //     "#).into_iter(),
+    //     1 //  this includes my_int type
+    // ),
+    // case::type_constraint_with_multiple_types(
+    //     load(r#" // For a schema with multiple type as below:
+    //          type:: { name: my_int, type: int }
+    //          type:: { name: my_bool, type: bool }
+    //     "#).into_iter(),
+    //     2
+    // ),
+    // case::all_of_constraint(
+    //     load(r#" // For a schema with all_of type as below:
+    //         type:: { name: all_of_type, all_of: [{ type: int }] }
+    //     "#).into_iter(),
+    //     1 // this includes named type all_of_type
+    // ),
+    // case::any_of_constraint(
+    //     load(r#" // For a schema with any_of constraint as below:
+    //             type:: { name: any_of_type, any_of: [{ type: int }, { type: decimal }] }
+    //         "#).into_iter(),
+    //     1 // this includes named type any_of_type
+    // ),
+    // case::one_of_constraint(
+    //     load(r#" // For a schema with one_of constraint as below:
+    //             type:: { name: one_of_type, one_of: [{ type: int }, { type: decimal }] }
+    //         "#).into_iter(),
+    //     1 // this includes named type one_of_type
+    // ),
+    // case::not_constraint(
+    //     load(r#" // For a schema with not constraint as below:
+    //             type:: { name: not_type, not: { type: int } }
+    //         "#).into_iter(),
+    //     1 // this includes named type not_type
+    // ),
+    // case::ordred_elements_constraint(
+    //     load(r#" // For a schema with ordered_elements constraint as below:
+    //             type:: { name: ordred_elements_type, ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
+    //         "#).into_iter(),
+    //     1 // this includes named type ordered_elements_type
+    // ),
+    case::fields_constraint(
+        load(r#" // For a schema with fields constraint as below:
+                type:: { name: fields_type, fields: { name: string, id: int} }
             "#).into_iter(),
-        1 // this includes named type any_of_type
-    ),
-    case::one_of_constraint(
-        load(r#" // For a schema with one_of constraint as below:
-                type:: { name: one_of_type, one_of: [{ type: int }, { type: decimal }] }
-            "#).into_iter(),
-        1 // this includes named type one_of_type
-    ),
-    case::not_constraint(
-        load(r#" // For a schema with not constraint as below:
-                type:: { name: not_type, not: { type: int } }
-            "#).into_iter(),
-        1 // this includes named type not_type
-    ),
-    case::ordred_elements_constraint(
-        load(r#" // For a schema with ordered_elements constraint as below:
-                type:: { name: ordred_elements_type, ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
-            "#).into_iter(),
-        1 // this includes named type ordered_elements_type
+        1 // this includes named type fields_type
     ),
     )]
     fn owned_elements_to_schema<'a, I: Iterator<Item = OwnedElement>>(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -130,73 +130,73 @@ mod schema_tests {
 
     #[rstest(
     owned_elements, total_types,
-    // case::type_constraint_with_named_type(
-    //     load(r#" // For a schema with named type as below:
-    //         type:: { name: my_type, type: any }
-    //     "#).into_iter(),
-    //     1 // this includes the named type my_int
-    // ),
-    // case::type_constraint_with_self_reference_type(
-    //     load(r#" // For a schema with self reference type as below:
-    //         type:: { name: my_int, type: my_int }
-    //     "#).into_iter(),
-    //     1 // this includes only my_int type
-    // ),
-    // case::type_constraint_with_nested_self_reference_type(
-    //     load(r#" // For a schema with nested self reference type as below:
-    //         type:: { name: my_int, type: { type: my_int } }
-    //     "#).into_iter(),
-    //     1 // this includes my_int type
-    // ),
-    // case::type_constraint_with_nested_type(
-    //     load(r#" // For a schema with nested types as below:
-    //         type:: { name: my_int, type: { type: int } }
-    //     "#).into_iter(),
-    //     1 // this includes my_int type
-    // ),
-    // case::type_constraint_with_nested_multiple_types(
-    //     load(r#" // For a schema with nested multiple types as below:
-    //         type:: { name: my_int, type: { type: int }, type: { type: my_int } }
-    //     "#).into_iter(),
-    //     1 //  this includes my_int type
-    // ),
-    // case::type_constraint_with_multiple_types(
-    //     load(r#" // For a schema with multiple type as below:
-    //          type:: { name: my_int, type: int }
-    //          type:: { name: my_bool, type: bool }
-    //     "#).into_iter(),
-    //     2
-    // ),
-    // case::all_of_constraint(
-    //     load(r#" // For a schema with all_of type as below:
-    //         type:: { name: all_of_type, all_of: [{ type: int }] }
-    //     "#).into_iter(),
-    //     1 // this includes named type all_of_type
-    // ),
-    // case::any_of_constraint(
-    //     load(r#" // For a schema with any_of constraint as below:
-    //             type:: { name: any_of_type, any_of: [{ type: int }, { type: decimal }] }
-    //         "#).into_iter(),
-    //     1 // this includes named type any_of_type
-    // ),
-    // case::one_of_constraint(
-    //     load(r#" // For a schema with one_of constraint as below:
-    //             type:: { name: one_of_type, one_of: [{ type: int }, { type: decimal }] }
-    //         "#).into_iter(),
-    //     1 // this includes named type one_of_type
-    // ),
-    // case::not_constraint(
-    //     load(r#" // For a schema with not constraint as below:
-    //             type:: { name: not_type, not: { type: int } }
-    //         "#).into_iter(),
-    //     1 // this includes named type not_type
-    // ),
-    // case::ordred_elements_constraint(
-    //     load(r#" // For a schema with ordered_elements constraint as below:
-    //             type:: { name: ordred_elements_type, ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
-    //         "#).into_iter(),
-    //     1 // this includes named type ordered_elements_type
-    // ),
+    case::type_constraint_with_named_type(
+        load(r#" // For a schema with named type as below:
+            type:: { name: my_type, type: any }
+        "#).into_iter(),
+        1 // this includes the named type my_int
+    ),
+    case::type_constraint_with_self_reference_type(
+        load(r#" // For a schema with self reference type as below:
+            type:: { name: my_int, type: my_int }
+        "#).into_iter(),
+        1 // this includes only my_int type
+    ),
+    case::type_constraint_with_nested_self_reference_type(
+        load(r#" // For a schema with nested self reference type as below:
+            type:: { name: my_int, type: { type: my_int } }
+        "#).into_iter(),
+        1 // this includes my_int type
+    ),
+    case::type_constraint_with_nested_type(
+        load(r#" // For a schema with nested types as below:
+            type:: { name: my_int, type: { type: int } }
+        "#).into_iter(),
+        1 // this includes my_int type
+    ),
+    case::type_constraint_with_nested_multiple_types(
+        load(r#" // For a schema with nested multiple types as below:
+            type:: { name: my_int, type: { type: int }, type: { type: my_int } }
+        "#).into_iter(),
+        1 //  this includes my_int type
+    ),
+    case::type_constraint_with_multiple_types(
+        load(r#" // For a schema with multiple type as below:
+             type:: { name: my_int, type: int }
+             type:: { name: my_bool, type: bool }
+        "#).into_iter(),
+        2
+    ),
+    case::all_of_constraint(
+        load(r#" // For a schema with all_of type as below:
+            type:: { name: all_of_type, all_of: [{ type: int }] }
+        "#).into_iter(),
+        1 // this includes named type all_of_type
+    ),
+    case::any_of_constraint(
+        load(r#" // For a schema with any_of constraint as below:
+                type:: { name: any_of_type, any_of: [{ type: int }, { type: decimal }] }
+            "#).into_iter(),
+        1 // this includes named type any_of_type
+    ),
+    case::one_of_constraint(
+        load(r#" // For a schema with one_of constraint as below:
+                type:: { name: one_of_type, one_of: [{ type: int }, { type: decimal }] }
+            "#).into_iter(),
+        1 // this includes named type one_of_type
+    ),
+    case::not_constraint(
+        load(r#" // For a schema with not constraint as below:
+                type:: { name: not_type, not: { type: int } }
+            "#).into_iter(),
+        1 // this includes named type not_type
+    ),
+    case::ordred_elements_constraint(
+        load(r#" // For a schema with ordered_elements constraint as below:
+                type:: { name: ordred_elements_type, ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
+            "#).into_iter(),
+        1 // this includes named type ordered_elements_type
+    ),
     case::fields_constraint(
         load(r#" // For a schema with fields constraint as below:
                 type:: { name: fields_type, fields: { name: string, id: int} }

--- a/src/types.rs
+++ b/src/types.rs
@@ -404,8 +404,8 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])]),
         TypeDefinition::anonymous([Constraint::ordered_elements([5, 34]), Constraint::type_constraint(25)])
     ),
-    case::ordered_elements_constraint(
-        /* For a schema with ordered_elements constraint as below:
+    case::fieldss_constraint(
+        /* For a schema with fields constraint as below:
             { fields: { name: string, id: int} }
         */
         IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),

--- a/src/types.rs
+++ b/src/types.rs
@@ -404,7 +404,7 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])]),
         TypeDefinition::anonymous([Constraint::ordered_elements([5, 34]), Constraint::type_constraint(25)])
     ),
-    case::fieldss_constraint(
+    case::fields_constraint(
         /* For a schema with fields constraint as below:
             { fields: { name: string, id: int} }
         */

--- a/src/types.rs
+++ b/src/types.rs
@@ -324,6 +324,7 @@ mod type_definition_tests {
     use crate::system::PendingTypes;
     use rstest::*;
 
+    // TODO: Remove type ids for assertion to make tests more readable
     #[rstest(
     isl_type, type_def,
     case::type_constraint_with_anonymous_type(
@@ -402,6 +403,13 @@ mod type_definition_tests {
         */
         IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])]),
         TypeDefinition::anonymous([Constraint::ordered_elements([5, 34]), Constraint::type_constraint(25)])
+    ),
+    case::ordered_elements_constraint(
+        /* For a schema with ordered_elements constraint as below:
+            { fields: { name: string, id: int} }
+        */
+        IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
+        TypeDefinition::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(25)])
     ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {


### PR DESCRIPTION
*Issue #10*

*Description of changes:*
This PR works on the implementation of `fields` constraint.

*Changes:*
- adds implementation of `IslConstraint::Fields`
- adds implementation of `FieldsConstraint`

*Ion Schema specification:*
```
fields: { <FIELD>... }
```
Declares one or more field constraints of a struct, where `<FIELD>` is defined as:
```
<SYMBOL>: <VARIABLY_OCCURRING_TYPE>
```
For more information: https://amzn.github.io/ion-schema/docs/spec.html#fields


*Tests:*
Adds unit tests as following:
- Owned element --> ISL type
- ISL type --> Type Definition
- Owned elements --> Schema