### PR TITLE
adds changes for `contains` constraint implementation

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -25,6 +25,7 @@ pub trait ConstraintValidator {
 pub enum Constraint {
     AllOf(AllOfConstraint),
     AnyOf(AnyOfConstraint),
+    Contains(ContainsConstraint),
     ContentClosed,
     Fields(FieldsConstraint),
     Not(NotConstraint),
@@ -65,6 +66,11 @@ impl Constraint {
         Constraint::OrderedElements(OrderedElementsConstraint::new(type_ids.into()))
     }
 
+    /// Creates a [Constraint::Contains] referring to [OwnedElements] specified inside it
+    pub fn contains<A: Into<Vec<OwnedElement>>>(values: A) -> Constraint {
+        Constraint::Contains(ContainsConstraint::new(values.into()))
+    }
+
     /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
     /// By default, fields created using this method will allow open content
     pub fn fields<I>(fields: I) -> Constraint
@@ -98,6 +104,11 @@ impl Constraint {
                     pending_types,
                 )?;
                 Ok(Constraint::AnyOf(any_of))
+            }
+            IslConstraint::Contains(values) => {
+                let contains_constraint: ContainsConstraint =
+                    ContainsConstraint::new(values.to_owned());
+                Ok(Constraint::Contains(contains_constraint))
             }
             IslConstraint::ContentClosed => Ok(Constraint::ContentClosed),
             IslConstraint::Fields(fields) => {
@@ -153,6 +164,7 @@ impl Constraint {
         match self {
             Constraint::AllOf(all_of) => all_of.validate(value, type_store),
             Constraint::AnyOf(any_of) => any_of.validate(value, type_store),
+            Constraint::Contains(contains) => contains.validate(value, type_store),
             Constraint::ContentClosed => {
                 // No op
                 // `content: closed` does not work as a constraint by its own, it needs to be used with other container constraints
@@ -700,6 +712,65 @@ impl ConstraintValidator for FieldsConstraint {
                 violations,
             ));
         }
+        Ok(())
+    }
+}
+
+/// Implements an `contains` constraint of Ion Schema
+/// [contains]: https://amzn.github.io/ion-schema/docs/spec.html#contains
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContainsConstraint {
+    // TODO: convert this into a HashSet once we have an implementation of Hash for OwnedElement in ion-rust
+    // Reference ion-rust issue: https://github.com/amzn/ion-rust/issues/220
+    values: Vec<OwnedElement>,
+}
+
+impl ContainsConstraint {
+    pub fn new(values: Vec<OwnedElement>) -> Self {
+        Self { values }
+    }
+}
+
+impl ConstraintValidator for ContainsConstraint {
+    fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
+        // get the expected values from the contains constraint
+        let mut expected_values = self.values.clone();
+
+        // Check for null sequence
+        if value.is_null() {
+            return Err(Violation::new(
+                "contains",
+                ViolationCode::TypeMismatched,
+                &format!("Null sequence not allowed for contains constraint"),
+            ));
+        }
+
+        let values: Vec<&OwnedElement> = match value.as_sequence() {
+            None => {
+                return Err(Violation::new(
+                    "contains",
+                    ViolationCode::TypeMismatched,
+                    &format!("expected list found {}", value.ion_type()),
+                ));
+            }
+            Some(ion_sequence) => ion_sequence.iter().collect(),
+        };
+
+        for value in values {
+            if let Some(pos) = expected_values.iter().position(|v| v == value) {
+                expected_values.remove(pos);
+            }
+        }
+
+        // return error if there were any values left in the expected values vector
+        if !expected_values.is_empty() {
+            return Err(Violation::new(
+                "contains",
+                ViolationCode::MissingValue,
+                &format!("{:?} has missing value(s): {:?}", value, expected_values),
+            ));
+        }
+
         Ok(())
     }
 }

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -243,6 +243,12 @@ mod isl_tests {
                 "#),
         IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
     ),
+    case::contains_constraint(
+        load_anonymous_type(r#" // For a schema with contains constraint as below:
+                    { contains: [true, 1, "hello"] }
+                "#),
+        IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -203,6 +203,12 @@ mod schema_tests {
             "#).into_iter(),
         1 // this includes named type fields_type
     ),
+    case::contains_constraint(
+        load(r#" // For a schema with contains constraint as below:
+                type:: { name: contains_type, contains: [true, 1, "hello"] }
+            "#).into_iter(),
+        1 // this includes named type contains_type
+    ),
     )]
     fn owned_elements_to_schema<'a, I: Iterator<Item = OwnedElement>>(
         owned_elements: I,
@@ -410,6 +416,25 @@ mod schema_tests {
                         type:: { name: fields_type,  content: closed, fields: { name: { type: string, occurs: range::[0,2] }, id: int } }
                 "#),
                 "fields_type"
+        ),
+        case::contains_constraint(
+                load(r#"
+                    [[5], '3', {a: 7}, true, 2.0, "4", (6), 1, extra_value]
+                    ([5]  '3'  {a: 7}  true  2.0  "4"  (6)  1 extra_value)
+                "#),
+                load(r#"
+                    null
+                    null.null
+                    null.int
+                    null.list
+                    null.sexp
+                    null.struct
+                    [true, 1, 2.0, '3', "4", [5], (6)]
+                "#),
+                load_schema_from_text(r#" // For a schema with fields constraint as below:
+                        type::{ name: contains_type, contains: [true, 1, 2.0, '3', "4", [5], (6), {a: 7} ] }
+                "#),
+                "contains_type"
         ),
     )]
     fn type_validation(

--- a/src/types.rs
+++ b/src/types.rs
@@ -448,6 +448,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
         TypeDefinition::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(25)])
     ),
+    case::contains_constraint(
+        /* For a schema with contains constraint as below:
+            { contains: [true, 1, "hello"] }
+        */
+        IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])]),
+        TypeDefinition::anonymous([Constraint::contains([true.into(), 1.into(), "hello".to_owned().into()]), Constraint::type_constraint(25)])
+        ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -55,6 +55,7 @@ pub enum ViolationCode {
     TypeMatched,
     AllTypesNotMatched,
     TypeMismatched,
+    MissingValue, // if the ion value is missing for a particular constraint
     FieldsNotMatched,
     InvalidOpenContent, // if a container contains open content when `content: closed` is specified
     TypeConstraintsUnsatisfied,
@@ -73,6 +74,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::TypeMismatched => "type_mismatched",
                 ViolationCode::TypeConstraintsUnsatisfied => "type_constraints_unsatisfied",
                 ViolationCode::InvalidNull => "invalid_null",
+                ViolationCode::MissingValue => "missing_value",
                 ViolationCode::FieldsNotMatched => "fields_not_matched",
                 ViolationCode::InvalidOpenContent => "invalid_open_content",
             }

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -37,6 +37,9 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/core_types/document.isl",
     "ion-schema-tests/constraints/content/validation_closed.isl",
     "ion-schema-tests/constraints/content/validation_mixed.isl",
+    "ion-schema-tests/constraints/contains/nulls.isl",
+    "ion-schema-tests/constraints/contains/validation.isl",
+    "ion-schema-tests/constraints/contains/various_values.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -49,6 +52,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/one_of/*.isl")]
 #[test_resources("ion-schema-tests/constraints/type/*.isl")]
 #[test_resources("ion-schema-tests/constraints/content/*.isl")]
+#[test_resources("ion-schema-tests/constraints/contains/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of contains constraint.

*Grammar:*
```ANTLR
<CONTAINS> ::= contains: [ <VALUE>... ]
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#contains

*List of changes:*
* adds implementation of `ContainsConstraint`
* adds `enum` variant `IslConstraint::Contains` and `Constraint::Contains`
* `contains()` method to create `IslConstraint::Contains` and
`Constraint::Contains` programmatically
* adds unit tests for contains constraint implementation (for
programmatically creating contains, loading schema using contains and
validation of contains)
* adds `ViolationCode` `MissingValue` for a missing value found during
contains validation

*Tests:*
added unit tests for `contains` implementation.
- adds tests for programmatically creating `contains` constraint
- adds tests for loading a schema using `contains` constraint 
- adds validation tests for `contains` constraint
