### PR TITLE
adds changes for `container_length` implementation

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -487,9 +487,7 @@ impl OrderedElementsConstraint {
         values_iter: &mut Peekable<Box<dyn Iterator<Item = &OwnedElement> + 'a>>,
         type_store: &TypeStore,
     ) -> ValidationResult {
-        let occurs_range: Range = type_def
-            .get_occurs_constraint("ordered_elements")
-            .expect("Unable to parse occurs to range");
+        let occurs_range: Range = type_def.get_occurs_constraint("ordered_elements");
 
         // use this counter to keep track of valid values for given type_def
         let mut count: i64 = 0;
@@ -687,9 +685,7 @@ impl ConstraintValidator for FieldsConstraint {
             let values: Vec<&OwnedElement> = ion_struct.get_all(field_name).collect();
 
             // perform occurs validation for type_def for all values of the given field_name
-            let occurs_range: Range = type_def
-                .get_occurs_constraint("fields")
-                .expect("Unable to parse occurs to range");
+            let occurs_range: Range = type_def.get_occurs_constraint("fields");
 
             // verify if values follow occurs_range constraint
             if !occurs_range
@@ -837,7 +833,6 @@ impl ConstraintValidator for ContainerLengthConstraint {
         };
 
         // get isl length as a range
-        // TODO: include IonSchemaError in Violations to remove usage of expect
         let length: &Range = self.length();
 
         // return a Violation if the container size didn't follow container_length constraint

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -73,7 +73,7 @@ impl Constraint {
         Constraint::Contains(ContainsConstraint::new(values.into()))
     }
 
-    /// Creates a [Constraint::ContainerLength] from an [Range] specifying a length range.
+    /// Creates a [Constraint::ContainerLength] from a [Range] specifying a length range.
     pub fn container_length(length: Range) -> Constraint {
         Constraint::ContainerLength(ContainerLengthConstraint::new(length))
     }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -845,10 +845,11 @@ impl ConstraintValidator for ContainerLengthConstraint {
             .try_into()
             .expect("Unable to parse container_length to range");
 
+        // return a Violation if the container size didn't follow container_length constraint
         if !isl_length.contains(&(size as i64).into()).unwrap() {
             return Err(Violation::new(
                 "container_length",
-                ViolationCode::TypeMismatched,
+                ViolationCode::InvalidLength,
                 &format!("expected container length {:?} found {}", isl_length, size),
             ));
         }

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -124,6 +124,7 @@ impl IslSchema {
 #[cfg(test)]
 mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_constraint::IslLength;
     use crate::isl::isl_constraint::IslOccurs;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
@@ -248,6 +249,12 @@ mod isl_tests {
                     { contains: [true, 1, "hello"] }
                 "#),
         IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])])
+    ),
+    case::container_length_constraint(
+        load_anonymous_type(r#" // For a schema with container_length constraint as below:
+                    { container_length: 3 }
+                "#),
+        IslType::anonymous([IslConstraint::container_length(IslLength::Int(AnyInt::I64(3)))])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -124,8 +124,6 @@ impl IslSchema {
 #[cfg(test)]
 mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
-    use crate::isl::isl_constraint::IslLength;
-    use crate::isl::isl_constraint::IslOccurs;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue};
@@ -236,7 +234,7 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
                     { ordered_elements: [  symbol, { type: int, occurs: optional },  ] }
                 "#),
-        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(IslOccurs::Optional)])])])
+        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(Range::optional())])])])
     ),
     case::fields_constraint(
         load_anonymous_type(r#" // For a schema with fields constraint as below:
@@ -254,7 +252,7 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with container_length constraint as below:
                     { container_length: 3 }
                 "#),
-        IslType::anonymous([IslConstraint::container_length(IslLength::Int(AnyInt::I64(3)))])
+        IslType::anonymous([IslConstraint::container_length(3.into())])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -1,4 +1,4 @@
-use crate::isl::isl_constraint::IslOccurs;
+use crate::isl::isl_constraint::{IslLength, IslOccurs};
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
@@ -273,7 +273,9 @@ impl Range {
     }
 
     // helper method to which validates a non negative integer range boundary value
-    fn validate_non_negative_integer_range_boundary_value(value: &AnyInt) -> IonSchemaResult<()> {
+    pub fn validate_non_negative_integer_range_boundary_value(
+        value: &AnyInt,
+    ) -> IonSchemaResult<()> {
         match value.as_i64() {
             Some(v) => {
                 if v >= 0 {
@@ -362,6 +364,18 @@ impl TryFrom<&IslOccurs> for Range {
             IslOccurs::Range(range) => Ok(range.to_owned()),
             IslOccurs::Required => Range::required(),
             IslOccurs::Optional => Range::optional(),
+        }
+    }
+}
+
+/// Provides `Range` for given ISL length related constraint
+impl TryFrom<&IslLength> for Range {
+    type Error = IonSchemaError;
+
+    fn try_from(isl_length: &IslLength) -> IonSchemaResult<Self> {
+        match isl_length {
+            IslLength::Int(int_value) => int_value.try_into(),
+            IslLength::Range(range) => Ok(range.to_owned()),
         }
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -1,16 +1,11 @@
-use crate::isl::isl_constraint::{IslLength, IslOccurs};
-use crate::result::{
-    invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
-};
+use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::types::decimal::Decimal;
 use ion_rs::types::timestamp::Timestamp;
 use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
 use ion_rs::value::{AnyInt, Element, IntAccess, Sequence, SymbolToken};
 use ion_rs::IonType;
-use num_bigint::BigInt;
 use num_traits::Signed;
-use num_traits::Zero;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 /// Represents ISL [Range]s where some constraints can be defined by a range
 /// <RANGE<RANGE_TYPE>> ::= range::[ <EXCLUSIVITY><RANGE_TYPE>, <EXCLUSIVITY><RANGE_TYPE> ]
@@ -91,22 +86,16 @@ impl Range {
                         "Integer ranges can only have integer value for validation",
                     )
                 })?;
+
+                let non_negative_integer_value =
+                    Range::validate_non_negative_integer_range_boundary_value(value)?;
                 let is_in_lower_bound = match start {
-                    Min => match value {
-                        AnyInt::I64(int_value) => &0 <= int_value,
-                        AnyInt::BigInt(big_int_value) => &BigInt::zero() <= big_int_value,
-                    },
+                    Min => usize::MIN <= non_negative_integer_value,
                     Value(start_value, boundary_type) => match start_value {
                         IntegerNonNegative(min_value) => {
-                            match value {
-                                AnyInt::I64(int_value) => { match boundary_type {
-                                    RangeBoundaryType::Inclusive => &min_value.as_i64().unwrap() <= int_value,
-                                    RangeBoundaryType::Exclusive => &min_value.as_i64().unwrap() < int_value,
-                                }},
-                                AnyInt::BigInt(big_int_value) => { match boundary_type {
-                                    RangeBoundaryType::Inclusive => min_value.as_big_int().unwrap() <= big_int_value,
-                                    RangeBoundaryType::Exclusive => min_value.as_big_int().unwrap() < big_int_value,
-                                }}
+                            match boundary_type {
+                                RangeBoundaryType::Inclusive => min_value <= &non_negative_integer_value,
+                                RangeBoundaryType::Exclusive => min_value < &non_negative_integer_value,
                             }
                         },
                         _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
@@ -119,15 +108,9 @@ impl Range {
                     Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
                     Value(end_value, boundary_type) => match end_value {
                         IntegerNonNegative(max_value) => {
-                            match value {
-                                AnyInt::I64(int_value) => { match boundary_type {
-                                    RangeBoundaryType::Inclusive => &max_value.as_i64().unwrap() >= int_value,
-                                    RangeBoundaryType::Exclusive => &max_value.as_i64().unwrap() > int_value,
-                                }},
-                                AnyInt::BigInt(big_int_value) => { match boundary_type {
-                                    RangeBoundaryType::Inclusive => max_value.as_big_int().unwrap() >= big_int_value,
-                                    RangeBoundaryType::Exclusive => max_value.as_big_int().unwrap() > big_int_value,
-                                }}
+                            match boundary_type {
+                                RangeBoundaryType::Inclusive => max_value >= &non_negative_integer_value,
+                                RangeBoundaryType::Exclusive => max_value > &non_negative_integer_value,
                             }
                         },
                         _ => unreachable!("Integer range can only have integers as lower and upper range boundary value"),
@@ -255,6 +238,16 @@ impl Range {
     }
 
     pub fn from_ion_element(value: &OwnedElement, is_non_negative: bool) -> IonSchemaResult<Range> {
+        // if an integer value is passed here then convert it into a range
+        // eg. if `1` is passed as value then return a range [1,1]
+        if let Some(integer_value) = value.as_any_int() {
+            let non_negative_integer_value =
+                Range::validate_non_negative_integer_range_boundary_value(
+                    value.as_any_int().unwrap(),
+                )?;
+            return Ok(non_negative_integer_value.into());
+        }
+
         let range = try_to!(value.as_sequence());
         if range.len() != 2 {
             return invalid_schema_error(
@@ -275,11 +268,17 @@ impl Range {
     // helper method to which validates a non negative integer range boundary value
     pub fn validate_non_negative_integer_range_boundary_value(
         value: &AnyInt,
-    ) -> IonSchemaResult<()> {
+    ) -> IonSchemaResult<usize> {
         match value.as_i64() {
             Some(v) => {
                 if v >= 0 {
-                    Ok(())
+                    match v.try_into() {
+                        Err(_) => invalid_schema_error(format!(
+                            "Expected non negative integer for range boundary values, found {}",
+                            v
+                        )),
+                        Ok(non_negative_int_value) => Ok(non_negative_int_value),
+                    }
                 } else {
                     invalid_schema_error(format!(
                         "Expected non negative integer for range boundary values, found {}",
@@ -293,7 +292,13 @@ impl Range {
                 }
                 Some(v) => {
                     if !v.is_negative() {
-                        Ok(())
+                        match v.try_into() {
+                            Err(_) => invalid_schema_error(format!(
+                                "Expected non negative integer for range boundary values, found {}",
+                                v
+                            )),
+                            Ok(non_negative_int_value) => Ok(non_negative_int_value),
+                        }
                     } else {
                         invalid_schema_error(format!(
                             "Expected non negative integer for range boundary values, found {}",
@@ -305,78 +310,46 @@ impl Range {
         }
     }
 
+    /// Provides integer range with given min and max values
+    pub fn integer_range(min_value: AnyInt, max_value: AnyInt) -> IonSchemaResult<Range> {
+        Range::range(
+            RangeBoundaryValue::int_value(min_value, RangeBoundaryType::Inclusive),
+            RangeBoundaryValue::int_value(max_value, RangeBoundaryType::Inclusive),
+        )
+    }
+
     /// Provides required non negative integer range
     /// required range: `range::[1,1]`
-    pub fn required() -> IonSchemaResult<Range> {
-        Range::range(
-            RangeBoundaryValue::int_non_negative_value(
-                AnyInt::I64(1),
-                RangeBoundaryType::Inclusive,
-            ),
-            RangeBoundaryValue::int_non_negative_value(
-                AnyInt::I64(1),
-                RangeBoundaryType::Inclusive,
-            ),
+    pub fn required() -> Range {
+        Range::IntegerNonNegative(
+            RangeBoundaryValue::int_non_negative_value(1, RangeBoundaryType::Inclusive),
+            RangeBoundaryValue::int_non_negative_value(1, RangeBoundaryType::Inclusive),
         )
     }
 
     /// Provides optional non negative integer range
     /// optional range: `range::[0,1]`
-    pub fn optional() -> IonSchemaResult<Range> {
-        Range::range(
-            RangeBoundaryValue::int_non_negative_value(
-                AnyInt::I64(0),
-                RangeBoundaryType::Inclusive,
-            ),
-            RangeBoundaryValue::int_non_negative_value(
-                AnyInt::I64(1),
-                RangeBoundaryType::Inclusive,
-            ),
+    pub fn optional() -> Range {
+        Range::IntegerNonNegative(
+            RangeBoundaryValue::int_non_negative_value(0, RangeBoundaryType::Inclusive),
+            RangeBoundaryValue::int_non_negative_value(1, RangeBoundaryType::Inclusive),
         )
     }
 }
 
-/// Provides `Range` for given `AnyInt`
-impl TryFrom<&AnyInt> for Range {
-    type Error = IonSchemaError;
-
-    fn try_from(int_value: &AnyInt) -> IonSchemaResult<Self> {
-        Range::range(
+/// Provides `Range` for given `usize`
+impl From<usize> for Range {
+    fn from(non_negative_int_value: usize) -> Self {
+        Range::IntegerNonNegative(
             RangeBoundaryValue::int_non_negative_value(
-                int_value.to_owned(),
+                non_negative_int_value,
                 RangeBoundaryType::Inclusive,
             ),
             RangeBoundaryValue::int_non_negative_value(
-                int_value.to_owned(),
+                non_negative_int_value,
                 RangeBoundaryType::Inclusive,
             ),
         )
-    }
-}
-
-/// Provides `Range` for given ISL `occurs` constraint
-impl TryFrom<&IslOccurs> for Range {
-    type Error = IonSchemaError;
-
-    fn try_from(isl_occurs: &IslOccurs) -> IonSchemaResult<Self> {
-        match isl_occurs {
-            IslOccurs::Int(int_value) => int_value.try_into(),
-            IslOccurs::Range(range) => Ok(range.to_owned()),
-            IslOccurs::Required => Range::required(),
-            IslOccurs::Optional => Range::optional(),
-        }
-    }
-}
-
-/// Provides `Range` for given ISL length related constraint
-impl TryFrom<&IslLength> for Range {
-    type Error = IonSchemaError;
-
-    fn try_from(isl_length: &IslLength) -> IonSchemaResult<Self> {
-        match isl_length {
-            IslLength::Int(int_value) => int_value.try_into(),
-            IslLength::Range(range) => Ok(range.to_owned()),
-        }
     }
 }
 
@@ -386,7 +359,7 @@ pub enum RangeBoundaryValueType {
     Decimal(Decimal),
     Float(f64),
     Integer(AnyInt),
-    IntegerNonNegative(AnyInt),
+    IntegerNonNegative(usize),
     Timestamp(Timestamp),
 }
 
@@ -402,7 +375,7 @@ impl RangeBoundaryValue {
     pub fn int_value(value: AnyInt, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(RangeBoundaryValueType::Integer(value), range_boundary_type)
     }
-    pub fn int_non_negative_value(value: AnyInt, range_boundary_type: RangeBoundaryType) -> Self {
+    pub fn int_non_negative_value(value: usize, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(
             RangeBoundaryValueType::IntegerNonNegative(value),
             range_boundary_type,
@@ -445,11 +418,12 @@ impl RangeBoundaryValue {
             }
             IonType::Integer => {
                 if is_non_negative {
-                    Range::validate_non_negative_integer_range_boundary_value(
-                        value.as_any_int().unwrap(),
-                    )?;
+                    let non_negative_integer_value =
+                        Range::validate_non_negative_integer_range_boundary_value(
+                            value.as_any_int().unwrap(),
+                        )?;
                     Ok(RangeBoundaryValue::int_non_negative_value(
-                        value.as_any_int().unwrap().to_owned(),
+                        non_negative_integer_value,
                         range_boundary_type,
                     ))
                 } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -355,10 +355,12 @@ mod type_definition_tests {
     use super::*;
     use crate::constraint::Constraint;
     use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_constraint::IslLength;
     use crate::isl::isl_constraint::IslOccurs;
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::system::PendingTypes;
+    use ion_rs::value::AnyInt;
     use rstest::*;
 
     // TODO: Remove type ids for assertion to make tests more readable
@@ -455,6 +457,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])]),
         TypeDefinition::anonymous([Constraint::contains([true.into(), 1.into(), "hello".to_owned().into()]), Constraint::type_constraint(25)])
         ),
+    case::container_length_constraint(
+        /* For a schema with container_length constraint as below:
+            { container_length: 3 }
+        */
+        IslType::anonymous([IslConstraint::container_length(IslLength::Int(AnyInt::I64(3)))]),
+        TypeDefinition::anonymous([Constraint::container_length(IslLength::Int(AnyInt::I64(3))), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/src/types.rs
+++ b/src/types.rs
@@ -145,10 +145,7 @@ impl TypeDefinition {
     }
 
     /// Returns an occurs constraint as range if it exists in the [TypeDefinition] otherwise returns `occurs: required`
-    pub fn get_occurs_constraint(
-        &self,
-        validation_constraint_name: &str,
-    ) -> IonSchemaResult<Range> {
+    pub fn get_occurs_constraint(&self, validation_constraint_name: &str) -> Range {
         // verify if the type_def contains `occurs` constraint and fill occurs_range
         // Otherwise if there is no `occurs` constraint specified then use `occurs: required`
         if let Some(Constraint::Occurs(occurs)) = self
@@ -157,15 +154,15 @@ impl TypeDefinition {
             .filter(|c| matches!(c, Constraint::Occurs(_)))
             .next()
         {
-            return Ok(occurs.occurs_range().to_owned());
+            return occurs.occurs_range().to_owned();
         }
         // by default, if there is no `occurs` constraint for given type_def
         // then use `occurs:optional` if its `fields` constraint validation
         // otherwise, use `occurs: required` if its `ordered_elements` constraint validation
         if validation_constraint_name == "fields" {
-            return Ok(Range::optional());
+            return Range::optional();
         }
-        Ok(Range::required())
+        Range::required()
     }
 }
 

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -49,16 +49,17 @@ impl fmt::Display for Violation {
 /// Represents violation code that indicates the type of the violation
 #[derive(Debug, Clone)]
 pub enum ViolationCode {
-    NoTypesMatched,
-    InvalidNull, // if the value is a null for type references that doesn't allow null
-    MoreThanOneTypeMatched,
-    TypeMatched,
     AllTypesNotMatched,
-    TypeMismatched,
-    MissingValue, // if the ion value is missing for a particular constraint
     FieldsNotMatched,
+    InvalidLength, // this is ued for any length related constraints (e.g. container_length, byte_length, codepoint_length)
+    InvalidNull,   // if the value is a null for type references that doesn't allow null
     InvalidOpenContent, // if a container contains open content when `content: closed` is specified
+    MissingValue,  // if the ion value is missing for a particular constraint
+    MoreThanOneTypeMatched,
+    NoTypesMatched,
     TypeConstraintsUnsatisfied,
+    TypeMatched,
+    TypeMismatched,
 }
 
 impl fmt::Display for ViolationCode {
@@ -67,16 +68,17 @@ impl fmt::Display for ViolationCode {
             f,
             "{}",
             match self {
-                ViolationCode::NoTypesMatched => "no_types_matched",
-                ViolationCode::MoreThanOneTypeMatched => "more_than_one_type_matched",
-                ViolationCode::TypeMatched => "type_matched",
                 ViolationCode::AllTypesNotMatched => "all_types_not_matched",
-                ViolationCode::TypeMismatched => "type_mismatched",
-                ViolationCode::TypeConstraintsUnsatisfied => "type_constraints_unsatisfied",
-                ViolationCode::InvalidNull => "invalid_null",
-                ViolationCode::MissingValue => "missing_value",
                 ViolationCode::FieldsNotMatched => "fields_not_matched",
+                ViolationCode::InvalidLength => "invalid_length",
+                ViolationCode::InvalidNull => "invalid_null",
                 ViolationCode::InvalidOpenContent => "invalid_open_content",
+                ViolationCode::MissingValue => "missing_value",
+                ViolationCode::MoreThanOneTypeMatched => "more_than_one_type_matched",
+                ViolationCode::NoTypesMatched => "no_types_matched",
+                ViolationCode::TypeConstraintsUnsatisfied => "type_constraints_unsatisfied",
+                ViolationCode::TypeMatched => "type_matched",
+                ViolationCode::TypeMismatched => "type_mismatched",
             }
         )
     }


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `container_length` constraint.

*Grammar:*
```ANTLR
<CONTAINER_LENGTH> ::= container_length: <INT>
                     | container_length: <RANGE<INT>>

```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#container_length

*List of changes:*
* adds `IslConstraint::ContainerLength` and `Constraint::ContainerLength`
enum variants
* adds `IslLength` that can be used by `byte_length`, `codepoint_length` and
`container_length` constraints
* fixes bug for non negative integer/integer ranges in occurs constraint
* adds validation logic for `container_length` constraint in
`ContainerLengthConstraint` implementation
* adds `ViolationCode::InvalidLength` for any invalid length for constraints like `codepoint_length`, `byte_length`, `container_length`
* adds unit tests for `container_length` constraint

*Tests:*
added unit tests for `container_length` implementation.
- adds tests for programmatically creating `container_length` constraint
- adds tests for loading a schema using `container_length` constraint 
- adds validation tests for `container_length` constraint
