### PR TITLE
adds changes for clippy fixes and suggestions

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -69,13 +69,12 @@ impl DocumentAuthority for MapDocumentAuthority {
     /// Returns a vector of [OwnedElement]s based on given schema id using ion_content_by_id map
     fn elements(&self, id: &str) -> IonSchemaResult<Vec<OwnedElement>> {
         // if ion content exists for the given id  in the map then return ion content as OwnedElements
-        let ion_content = self
-            .ion_content_by_id
-            .get(id)
-            .ok_or(unresolvable_schema_error_raw(format!(
+        let ion_content = self.ion_content_by_id.get(id).ok_or_else(|| {
+            unresolvable_schema_error_raw(format!(
                 "MapDocumentAuthority does not contain schema with id: {}",
                 id
-            )))?;
+            ))
+        })?;
         let iterator = element_reader().iterate_over(ion_content.as_bytes())?;
         let schema_content = iterator.collect::<Result<Vec<OwnedElement>, IonError>>()?;
         Ok(schema_content)

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -246,7 +246,7 @@ impl ConstraintValidator for AllOfConstraint {
                 violations,
             ));
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -296,7 +296,7 @@ impl ConstraintValidator for AnyOfConstraint {
                 violations,
             ));
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -452,7 +452,7 @@ impl ConstraintValidator for OccursConstraint {
         // `occurs` does not work as a constraint by its own, it needs to be used with other constraints
         // e.g. `ordered_elements`, `fields`, etc.
         // the validation for occurs is done within these other constraints
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -554,7 +554,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
             return Err(Violation::with_violations(
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
-                &format!("Null list/sexp not allowed for ordered_elements constraint"),
+                "Null list/sexp not allowed for ordered_elements constraint",
                 violations,
             ));
         }
@@ -629,7 +629,7 @@ impl FieldsConstraint {
             .iter()
             .map(|(f, t)| {
                 IslTypeRef::resolve_type_reference(t, type_store, pending_types)
-                    .and_then(|type_id| Ok((f.to_owned(), type_id)))
+                    .map(|type_id| (f.to_owned(), type_id))
             })
             .collect::<IonSchemaResult<HashMap<String, TypeId>>>()?;
         Ok(FieldsConstraint::new(resolved_fields, open_content))
@@ -645,7 +645,7 @@ impl ConstraintValidator for FieldsConstraint {
             return Err(Violation::with_violations(
                 "fields",
                 ViolationCode::TypeMismatched,
-                &format!("Null struct not allowed for fields constraint"),
+                "Null struct not allowed for fields constraint",
                 violations,
             ));
         }
@@ -717,7 +717,7 @@ impl ConstraintValidator for FieldsConstraint {
             return Err(Violation::with_violations(
                 "fields",
                 ViolationCode::FieldsNotMatched,
-                &format!("value didn't satisfy fields constraint"),
+                "value didn't satisfy fields constraint",
                 violations,
             ));
         }
@@ -767,7 +767,7 @@ impl ConstraintValidator for ContainsConstraint {
                 // for each value in expected values if it does not exist in ion sequence
                 // then add it to missing_values to keep track of missing values
                 for expected_value in self.values.iter() {
-                    if ion_sequence.iter().find(|v| v == &expected_value).is_none() {
+                    if !ion_sequence.iter().any(|v| v == expected_value) {
                         missing_values.push(expected_value);
                     }
                 }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -101,9 +101,7 @@ impl IslConstraint {
             }
             "contains" => {
                 if value.is_null() {
-                    return Err(invalid_schema_error_raw(format!(
-                        "contains constraint was a null instead of a list"
-                    )));
+                    return Err(invalid_schema_error_raw("contains constraint was a null instead of a list".to_string()));
                 }
 
                 if value.ion_type() != IonType::List {
@@ -123,9 +121,7 @@ impl IslConstraint {
             }
             "content" => {
                 if value.is_null() {
-                    return Err(invalid_schema_error_raw(format!(
-                        "content constraint was a null instead of a symbol `closed`"
-                    )));
+                    return Err(invalid_schema_error_raw("content constraint was a null instead of a symbol `closed`".to_string()));
                 }
 
                 if value.ion_type() != IonType::Symbol {
@@ -233,7 +229,7 @@ impl IslConstraint {
                 Ok(IslConstraint::OrderedElements(types))
             }
             _ => {
-                return Err(invalid_schema_error_raw(
+                Err(invalid_schema_error_raw(
                     "Type: ".to_owned()
                         + type_name
                         + " can not be built as constraint: "
@@ -264,12 +260,12 @@ impl IslConstraint {
                 value.ion_type()
             )));
         }
-        Ok(value
+        value
             .as_sequence()
             .unwrap()
             .iter()
             .map(|e| IslTypeRef::from_ion_element(e, inline_imported_types))
-            .collect::<IonSchemaResult<Vec<IslTypeRef>>>()?)
+            .collect::<IonSchemaResult<Vec<IslTypeRef>>>()
     }
 
     // helper method for from_ion_element to get isl fields from given ion element
@@ -290,14 +286,13 @@ impl IslConstraint {
             )));
         }
 
-        Ok(value
+        value
             .as_struct()
             .unwrap()
             .iter()
             .map(|(f, v)| {
-                IslTypeRef::from_ion_element(v, inline_imported_types)
-                    .and_then(|t| Ok((f.text().unwrap().to_owned(), t)))
+                IslTypeRef::from_ion_element(v, inline_imported_types).map(|t| (f.text().unwrap().to_owned(), t))
             })
-            .collect::<IonSchemaResult<HashMap<String, IslTypeRef>>>()?)
+            .collect::<IonSchemaResult<HashMap<String, IslTypeRef>>>()
     }
 }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -101,7 +101,9 @@ impl IslConstraint {
             }
             "contains" => {
                 if value.is_null() {
-                    return Err(invalid_schema_error_raw("contains constraint was a null instead of a list".to_string()));
+                    return Err(invalid_schema_error_raw(
+                        "contains constraint was a null instead of a list".to_string(),
+                    ));
                 }
 
                 if value.ion_type() != IonType::List {
@@ -121,7 +123,9 @@ impl IslConstraint {
             }
             "content" => {
                 if value.is_null() {
-                    return Err(invalid_schema_error_raw("content constraint was a null instead of a symbol `closed`".to_string()));
+                    return Err(invalid_schema_error_raw(
+                        "content constraint was a null instead of a symbol `closed`".to_string(),
+                    ));
                 }
 
                 if value.ion_type() != IonType::Symbol {
@@ -228,15 +232,13 @@ impl IslConstraint {
                 )?;
                 Ok(IslConstraint::OrderedElements(types))
             }
-            _ => {
-                Err(invalid_schema_error_raw(
-                    "Type: ".to_owned()
-                        + type_name
-                        + " can not be built as constraint: "
-                        + constraint_name
-                        + " does not exist",
-                ))
-            }
+            _ => Err(invalid_schema_error_raw(
+                "Type: ".to_owned()
+                    + type_name
+                    + " can not be built as constraint: "
+                    + constraint_name
+                    + " does not exist",
+            )),
         }
     }
 
@@ -291,7 +293,8 @@ impl IslConstraint {
             .unwrap()
             .iter()
             .map(|(f, v)| {
-                IslTypeRef::from_ion_element(v, inline_imported_types).map(|t| (f.text().unwrap().to_owned(), t))
+                IslTypeRef::from_ion_element(v, inline_imported_types)
+                    .map(|t| (f.text().unwrap().to_owned(), t))
             })
             .collect::<IonSchemaResult<HashMap<String, IslTypeRef>>>()
     }

--- a/src/isl/isl_import.rs
+++ b/src/isl/isl_import.rs
@@ -38,7 +38,7 @@ impl IslImport {
         };
 
         let alias = match import.get("as") {
-            Some(alias) => alias.as_str().and_then(|a| Some(a.to_owned())),
+            Some(alias) => alias.as_str().map(|a| a.to_owned()),
             None => {
                 return Ok(IslImport::Type(IslImportType::new(
                     id.to_owned(),

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -141,8 +141,7 @@ impl PartialEq for IslTypeImpl {
                 other
                     .constraints
                     .iter()
-                    .find(|other_constraint| &constraint == other_constraint)
-                    .is_some()
+                    .any(|other_constraint| constraint == other_constraint)
             })
     }
 }

--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -1,7 +1,7 @@
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_import::IslImportType;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
-use ion_rs::value::owned::{text_token, OwnedElement, OwnedSymbolToken};
+use ion_rs::value::owned::{text_token, OwnedElement};
 use ion_rs::value::{Element, Struct, SymbolToken};
 
 /// Represents a type in an ISL schema.
@@ -75,9 +75,7 @@ impl IslTypeImpl {
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
-        let annotations: Vec<&OwnedSymbolToken> = ion.annotations().collect();
-
-        let contains_annotations = annotations.contains(&&text_token("type"));
+        let contains_annotations = ion.annotations().any(|x| x == &text_token("type"));
 
         let ion_struct = try_to!(ion.as_struct());
 

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -53,10 +53,7 @@ impl IslTypeRef {
                         invalid_schema_error_raw(
                             "a base or alias type reference symbol doesn't have text",
                         )
-                    })
-                    .and_then(|type_name| {
-                        Ok(IslTypeRef::Named(type_name.to_owned()))
-                    })
+                    }).map(|type_name| IslTypeRef::Named(type_name.to_owned()))
             }
             IonType::Struct => {
                 if value.is_null() {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -57,8 +57,10 @@
 //! let schema_system = SchemaSystem::new(vec![]); // no authorities added
 //! let schema = schema_system.schema_from_isl_types("my_schema", [isl_type.to_owned()]);
 //!
-//! // TODO: add an assert statement for get_types method of this schema
 //! assert!(schema.is_ok());
+//!
+//! // verify if the generated schema contains the correct type
+//! assert!(schema.unwrap().get_type("my_type_name").is_some())
 //! ```
 
 // The given schema is loaded with a two phase approach:

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -17,51 +17,48 @@
 //!
 //! ## Example usage of `isl` module to create an [IslType]:
 //! ```
-//! use ion_rs::IonType;
-//! use ion_schema::isl::{isl_type::*, isl_constraint::*, isl_type_reference::*};
+//! use ion_schema::isl::{isl_type::IslType, isl_constraint::IslConstraint, isl_type_reference::IslTypeRef};
 //! use ion_schema::schema::Schema;
 //! use ion_schema::system::SchemaSystem;
 //! use std::path::Path;
 //!
-//! fn main() {
-//!     // below code represents an ISL type:
-//!     // type:: {
-//!     //      name:my_type_name,
-//!     //      type: int,
-//!     //      all_of: [
-//!     //          { type: bool }
-//!     //      ]
-//!     //  }
-//!     let isl_type = IslType::named(
-//!         // represents the `name` of the defined type
-//!         "my_type_name".to_owned(),
-//!         vec![
-//!             // represents the `type: int` constraint
-//!             IslConstraint::type_constraint(
-//!                 IslTypeRef::named("int")
-//!             ),
-//!             // represents `all_of` with anonymous type `{ type: bool }` constraint
-//!             IslConstraint::all_of(
-//!                 vec![
-//!                     IslTypeRef::anonymous(
-//!                         vec![
-//!                             IslConstraint::type_constraint(
-//!                                 IslTypeRef::named("bool")
-//!                             )
-//!                         ]
-//!                     )
-//!                 ]
-//!             )
-//!         ]
-//!     );
+//! // below code represents an ISL type:
+//! // type:: {
+//! //      name:my_type_name,
+//! //      type: int,
+//! //      all_of: [
+//! //          { type: bool }
+//! //      ]
+//! //  }
+//! let isl_type = IslType::named(
+//!     // represents the `name` of the defined type
+//!     "my_type_name".to_owned(),
+//!     vec![
+//!         // represents the `type: int` constraint
+//!         IslConstraint::type_constraint(
+//!             IslTypeRef::named("int")
+//!         ),
+//!         // represents `all_of` with anonymous type `{ type: bool }` constraint
+//!         IslConstraint::all_of(
+//!             vec![
+//!                 IslTypeRef::anonymous(
+//!                     vec![
+//!                         IslConstraint::type_constraint(
+//!                             IslTypeRef::named("bool")
+//!                         )
+//!                     ]
+//!                 )
+//!             ]
+//!         )
+//!     ]
+//! );
 //!
-//!     // create a schema from given IslType using SchemaSystem
-//!     let schema_system = SchemaSystem::new(vec![]); // no authorities added
-//!     let schema = schema_system.schema_from_isl_types("my_schema", [isl_type.to_owned()]);
+//! // create a schema from given IslType using SchemaSystem
+//! let schema_system = SchemaSystem::new(vec![]); // no authorities added
+//! let schema = schema_system.schema_from_isl_types("my_schema", [isl_type.to_owned()]);
 //!
-//!     // TODO: add an assert statement for get_types method of this schema
-//!     assert_eq!(schema.is_ok(), true);
-//! }
+//! // TODO: add an assert statement for get_types method of this schema
+//! assert!(schema.is_ok());
 //! ```
 
 // The given schema is loaded with a two phase approach:
@@ -325,8 +322,8 @@ mod isl_tests {
     )]
     fn owned_struct_to_range(range1: IonSchemaResult<Range>, range2: IonSchemaResult<Range>) {
         // determine that both the ranges are created with no errors
-        assert_eq!(range1.is_ok(), true);
-        assert_eq!(range2.is_ok(), true);
+        assert!(range1.is_ok());
+        assert!(range2.is_ok());
 
         // assert if both the ranges are same
         assert_eq!(range1.unwrap(), range2.unwrap());
@@ -363,7 +360,7 @@ mod isl_tests {
     )]
     fn invalid_ranges(range: IonSchemaResult<Range>) {
         // determine that the range is created with an error for an invalid range
-        assert_eq!(range.is_err(), true);
+        assert!(range.is_err());
     }
 
     #[rstest(
@@ -487,13 +484,13 @@ mod isl_tests {
         // verify if the range contains given valid values
         for valid_value in valid_values {
             let range_contains_result = range.as_ref().unwrap().contains(&valid_value).unwrap();
-            assert_eq!(range_contains_result, true)
+            assert!(range_contains_result)
         }
 
         // verify that range doesn't contain the invalid values
         for invalid_value in invalid_values {
             let range_contains_result = range.as_ref().unwrap().contains(&invalid_value).unwrap();
-            assert_eq!(range_contains_result, false)
+            assert!(!range_contains_result)
         }
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -445,7 +445,7 @@ impl RangeBoundaryValue {
                 value.as_timestamp().unwrap().to_owned(),
                 range_boundary_type,
             )),
-            _ => return invalid_schema_error("Unsupported range type specified"),
+            _ => invalid_schema_error("Unsupported range type specified"),
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -117,12 +117,12 @@ mod schema_tests {
     fn load_schema_from_text(text: &str) -> Rc<Schema> {
         let owned_elements = load(text).into_iter();
         // create a type_store and resolver instance to be used for loading OwnedElements as schema
-        let type_store = &mut TypeStore::new();
+        let type_store = &mut TypeStore::default();
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and create a schema from isl
         let isl = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
-        
+
         resolver
             .schema_from_isl_schema(isl.unwrap(), "my_schema.isl", type_store, None)
             .unwrap()
@@ -216,26 +216,25 @@ mod schema_tests {
         1 // this includes named type container_length_type
     ),
     )]
-    fn owned_elements_to_schema<'a, I: Iterator<Item = OwnedElement>>(
+    fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
         owned_elements: I,
         total_types: usize,
     ) {
         // create a type_store and resolver instance to be used for loading OwnedElements as schema
-        let type_store = &mut TypeStore::new();
+        let type_store = &mut TypeStore::default();
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`
         let isl = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
-        assert_eq!(isl.is_ok(), true);
+        assert!(isl.is_ok());
 
         // create a schema from isl and verifies if the result is `ok`
         let schema =
             resolver.schema_from_isl_schema(isl.unwrap(), "my_schema.isl", type_store, None);
-        assert_eq!(schema.is_ok(), true);
+        assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case
-        let types: Vec<TypeRef> = schema.unwrap().get_types().collect();
-        assert_eq!(types.len(), total_types);
+        assert_eq!(schema.unwrap().get_types().count(), total_types);
     }
 
     #[rstest(
@@ -514,13 +513,13 @@ mod schema_tests {
         for valid_value in valid_values.iter() {
             // there is only a single type in each schema defined above hence validate with that type
             let validation_result = type_ref.validate(valid_value);
-            assert_eq!(validation_result.is_ok(), true);
+            assert!(validation_result.is_ok());
         }
         // check for violations due to invalid values
         for invalid_value in invalid_values.iter() {
             // there is only a single type in each schema defined above hence validate with that type
             let validation_result = type_ref.validate(invalid_value);
-            assert_eq!(validation_result.is_err(), true);
+            assert!(validation_result.is_err());
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -89,7 +89,7 @@ impl Iterator for SchemaTypeIterator {
         if self.index >= self.types.len() {
             return None;
         }
-        self.index = self.index + 1;
+        self.index += 1;
         Some(TypeRef::new(
             self.types[self.index - 1],
             Rc::clone(&self.type_store),
@@ -122,10 +122,10 @@ mod schema_tests {
 
         // create a isl from owned_elements and create a schema from isl
         let isl = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
-        let schema = resolver
+        
+        resolver
             .schema_from_isl_schema(isl.unwrap(), "my_schema.isl", type_store, None)
-            .unwrap();
-        schema
+            .unwrap()
     }
 
     #[rstest(

--- a/src/system.rs
+++ b/src/system.rs
@@ -605,6 +605,8 @@ impl Resolver {
                 ),
             };
         }
+        // add all types from pending_types to type_store
+        pending_types.update_type_store(type_store, None)?;
         Ok(Schema::new(id, Rc::new(type_store.to_owned())))
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,7 +150,8 @@ impl TypeDefinition {
         // Otherwise if there is no `occurs` constraint specified then use `occurs: required`
         if let Some(Constraint::Occurs(occurs)) = self
             .constraints()
-            .iter().find(|c| matches!(c, Constraint::Occurs(_)))
+            .iter()
+            .find(|c| matches!(c, Constraint::Occurs(_)))
         {
             return occurs.occurs_range().to_owned();
         }
@@ -249,12 +250,10 @@ impl TypeDefinitionImpl {
         // convert IslConstraint to Constraint
         let mut found_type_constraint = false;
         for isl_constraint in isl_type.constraints() {
-            match isl_constraint {
-                IslConstraint::Type(_) => {
-                    found_type_constraint = true;
-                }
-                _ => {}
+            if let IslConstraint::Type(_) = isl_constraint {
+                found_type_constraint = true;
             }
+
             let constraint = Constraint::resolve_from_isl_constraint(
                 isl_constraint,
                 type_store,
@@ -458,8 +457,8 @@ mod type_definition_tests {
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name
-        let type_store = &mut TypeStore::new();
-        let pending_types = &mut PendingTypes::new();
+        let type_store = &mut TypeStore::default();
+        let pending_types = &mut PendingTypes::default();
         let this_type_def = match isl_type {
             IslType::Named(named_isl_type) => TypeDefinition::Named(
                 TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,7 @@ impl TypeRef {
                 violations.push(violation);
             }
         }
-        if violations.len() == 0 {
+        if violations.is_empty() {
             return Ok(());
         }
         Err(Violation::with_violations(
@@ -150,9 +150,7 @@ impl TypeDefinition {
         // Otherwise if there is no `occurs` constraint specified then use `occurs: required`
         if let Some(Constraint::Occurs(occurs)) = self
             .constraints()
-            .iter()
-            .filter(|c| matches!(c, Constraint::Occurs(_)))
-            .next()
+            .iter().find(|c| matches!(c, Constraint::Occurs(_)))
         {
             return occurs.occurs_range().to_owned();
         }
@@ -192,7 +190,7 @@ impl TypeValidator for TypeDefinition {
                             &format!("expected type {:?}, found {:?}", ion_type, value.ion_type()),
                         ));
                     }
-                    return Ok(());
+                    Ok(())
                 }
                 BuiltInTypeDefinition::Derived(other_type) => {
                     other_type.validate(value, type_store)
@@ -334,7 +332,7 @@ impl TypeValidator for TypeDefinitionImpl {
                 violations.push(violation);
             }
         }
-        if violations.len() == 0 {
+        if violations.is_empty() {
             return Ok(());
         }
         Err(Violation::with_violations(

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -89,13 +89,14 @@ fn validation_tests(path: &str) {
     let mut schema_system = SchemaSystem::new(vec![Box::new(authority)]);
 
     // get the schema content from given schema file path
-    let ion_content = fs::read(path).unwrap_or_else(|_| panic!("Could not read from given file {}", path));
-    let iterator = element_reader().iterate_over(&ion_content).unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}",
-        path));
+    let ion_content =
+        fs::read(path).unwrap_or_else(|_| panic!("Could not read from given file {}", path));
+    let iterator = element_reader()
+        .iterate_over(&ion_content)
+        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}", path));
     let schema_content = iterator
         .collect::<Result<Vec<OwnedElement>, IonError>>()
-        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}",
-            path));
+        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}", path));
 
     let type_store = &mut TypeStore::default();
     let mut invalid_values: Vec<OwnedElement> = vec![];
@@ -134,8 +135,9 @@ fn validation_tests(path: &str) {
             type_def = Some(
                 schema_system
                     .schema_type_from_element(&element, type_store)
-                    .unwrap_or_else(|_| panic!("Could not get schema type from owned element {:?}",
-                        element)),
+                    .unwrap_or_else(|_| {
+                        panic!("Could not get schema type from owned element {:?}", element)
+                    }),
             );
         } else {
             continue;

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -89,17 +89,13 @@ fn validation_tests(path: &str) {
     let mut schema_system = SchemaSystem::new(vec![Box::new(authority)]);
 
     // get the schema content from given schema file path
-    let ion_content = fs::read(path).expect(&format!("Could not read from given file {}", path));
-    let iterator = element_reader().iterate_over(&ion_content).expect(&format!(
-        "Could not get owned elements from scehma file: {}",
-        path
-    ));
+    let ion_content = fs::read(path).unwrap_or_else(|_| panic!("Could not read from given file {}", path));
+    let iterator = element_reader().iterate_over(&ion_content).unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}",
+        path));
     let schema_content = iterator
         .collect::<Result<Vec<OwnedElement>, IonError>>()
-        .expect(&format!(
-            "Could not get owned elements from scehma file: {}",
-            path
-        ));
+        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}",
+            path));
 
     let type_store = &mut TypeStore::new();
     let mut invalid_values: Vec<OwnedElement> = vec![];
@@ -138,10 +134,8 @@ fn validation_tests(path: &str) {
             type_def = Some(
                 schema_system
                     .schema_type_from_element(&element, type_store)
-                    .expect(&format!(
-                        "Could not get schema type from owned element {:?}",
-                        element
-                    )),
+                    .unwrap_or_else(|_| panic!("Could not get schema type from owned element {:?}",
+                        element)),
             );
         } else {
             continue;

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -97,7 +97,7 @@ fn validation_tests(path: &str) {
         .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}",
             path));
 
-    let type_store = &mut TypeStore::new();
+    let type_store = &mut TypeStore::default();
     let mut invalid_values: Vec<OwnedElement> = vec![];
     let mut valid_values: Vec<OwnedElement> = vec![];
     let mut type_def: Option<TypeDefinitionImpl> = None;


### PR DESCRIPTION
*Issue: #69*

*Description of changes:*
 This PR works on adding all the changes suggested by Clippy (Rust linter).

*Changes:*
The changes are incorporated in 3 separate commits:
- Phase 1: clippy automated fixes for ion-schema crate
- Phase 2: clippy automated changes for tests folder
- Phase 3: manually added clippy suggestions
  * uses `ok_or_else` instead of `ok_or`
  * removes unnecessary `collect()` usage
  * remove `fn main()` from doctests
  * removes unnecessary lifetime usage
  * uses `assert!` instead of `assert_eq!` for `bool` comparison
  * uses `if let` instead of `unwrap`
  * `default()` implementations for TypeStore and PendingTypes
  * (Overridden clippy suggestion) uses self named constructors for `Range`
- Bug Fix: while loading a schema tested as per a doc test in `isl` module