### PR TITLE
adds changes for `byte_length` and `codepoint_length` constraint

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -855,14 +855,17 @@ impl ConstraintValidator for ContainerLengthConstraint {
         };
 
         // get isl length as a range
-        let length: &Range = self.length();
+        let length_range: &Range = self.length();
 
         // return a Violation if the container size didn't follow container_length constraint
-        if !length.contains(&(size as i64).into()).unwrap() {
+        if !length_range.contains(&(size as i64).into()).unwrap() {
             return Err(Violation::new(
                 "container_length",
                 ViolationCode::InvalidLength,
-                &format!("expected container length {:?} found {}", length, size),
+                &format!(
+                    "expected container length {:?} found {}",
+                    length_range, size
+                ),
             ));
         }
 
@@ -870,7 +873,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
     }
 }
 
-/// Implements an `byte_length` constraint of Ion Schema
+/// Implements Ion Schema's `byte_length` constraint
 /// [byte_length]: https://amzn.github.io/ion-schema/docs/spec.html#byte_length
 #[derive(Debug, Clone, PartialEq)]
 pub struct ByteLengthConstraint {
@@ -912,14 +915,14 @@ impl ConstraintValidator for ByteLengthConstraint {
         };
 
         // get isl length as a range
-        let length: &Range = self.length();
+        let length_range: &Range = self.length();
 
         // return a Violation if the clob/blob size didn't follow byte_length constraint
-        if !length.contains(&(size as i64).into()).unwrap() {
+        if !length_range.contains(&(size as i64).into()).unwrap() {
             return Err(Violation::new(
                 "byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected byte length {:?} found {}", length, size),
+                &format!("expected byte length {:?} found {}", length_range, size),
             ));
         }
 
@@ -957,8 +960,8 @@ impl ConstraintValidator for CodePointLengthConstraint {
 
         // get the size of given string/symbol Unicode codepoints
         let size = match value.ion_type() {
-            IonType::String => value.as_str().unwrap().len(),
-            IonType::Symbol => value.as_sym().unwrap().text().unwrap().len(),
+            IonType::String => value.as_str().unwrap().chars().count(),
+            IonType::Symbol => value.as_sym().unwrap().text().unwrap().chars().count(),
             _ => {
                 // return Violation if value is not string/symbol
                 return Err(Violation::new(
@@ -970,14 +973,17 @@ impl ConstraintValidator for CodePointLengthConstraint {
         };
 
         // get isl length as a range
-        let length: &Range = self.length();
+        let length_range: &Range = self.length();
 
         // return a Violation if the string/symbol codepoint size didn't follow codepoint_length constraint
-        if !length.contains(&(size as i64).into()).unwrap() {
+        if !length_range.contains(&(size as i64).into()).unwrap() {
             return Err(Violation::new(
                 "codepoint_length",
                 ViolationCode::InvalidLength,
-                &format!("expected codepoint length {:?} found {}", length, size),
+                &format!(
+                    "expected codepoint length {:?} found {}",
+                    length_range, size
+                ),
             ));
         }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -571,23 +571,20 @@ impl ConstraintValidator for OrderedElementsConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
         let violations: Vec<Violation> = vec![];
 
-        // Check for null sequence
-        if value.is_null() {
-            return Err(Violation::with_violations(
-                "ordered_elements",
-                ViolationCode::TypeMismatched,
-                "Null list/sexp not allowed for ordered_elements constraint",
-                violations,
-            ));
-        }
-
         // Create a peekable iterator for given sequence
         let mut values_iter = match value.as_sequence() {
             None => {
                 return Err(Violation::with_violations(
                     "ordered_elements",
                     ViolationCode::TypeMismatched,
-                    &format!("expected list/sexp ion found {}", value.ion_type()),
+                    &format!(
+                        "expected list/sexp ion found {}",
+                        if value.is_null() {
+                            format!("{:?}", value)
+                        } else {
+                            format!("{}", value.ion_type())
+                        }
+                    ),
                     violations,
                 ));
             }
@@ -662,23 +659,20 @@ impl ConstraintValidator for FieldsConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
 
-        // Check for null struct
-        if value.is_null() {
-            return Err(Violation::with_violations(
-                "fields",
-                ViolationCode::TypeMismatched,
-                "Null struct not allowed for fields constraint",
-                violations,
-            ));
-        }
-
         // Create a peekable iterator for given struct
         let ion_struct = match value.as_struct() {
             None => {
                 return Err(Violation::with_violations(
                     "fields",
                     ViolationCode::TypeMismatched,
-                    &format!("expected struct ion found {}", value.ion_type()),
+                    &format!(
+                        "expected struct ion found {}",
+                        if value.is_null() {
+                            format!("{:?}", value)
+                        } else {
+                            format!("{}", value.ion_type())
+                        }
+                    ),
                     violations,
                 ));
             }
@@ -764,22 +758,20 @@ impl ContainsConstraint {
 
 impl ConstraintValidator for ContainsConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
-        // Check for null sequence
-        if value.is_null() {
-            return Err(Violation::new(
-                "contains",
-                ViolationCode::TypeMismatched,
-                &format!("expected a sequence found {:?}", value),
-            ));
-        }
-
         match value.as_sequence() {
             None => {
                 // return Violation if value is not an Ion sequence
                 return Err(Violation::new(
                     "contains",
                     ViolationCode::TypeMismatched,
-                    &format!("expected list/sexp found {}", value.ion_type()),
+                    &format!(
+                        "expected list/sexp found {}",
+                        if value.is_null() {
+                            format!("{:?}", value)
+                        } else {
+                            format!("{}", value.ion_type())
+                        }
+                    ),
                 ));
             }
             Some(ion_sequence) => {
@@ -892,15 +884,6 @@ impl ByteLengthConstraint {
 
 impl ConstraintValidator for ByteLengthConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
-        // Check for null value
-        if value.is_null() {
-            return Err(Violation::new(
-                "byte_length",
-                ViolationCode::TypeMismatched,
-                &format!("expected a clob/blob found {:?}", value),
-            ));
-        }
-
         // get the size of given bytes
         let size = match value.as_bytes() {
             Some(bytes) => bytes.len(),
@@ -909,7 +892,14 @@ impl ConstraintValidator for ByteLengthConstraint {
                 return Err(Violation::new(
                     "byte_length",
                     ViolationCode::TypeMismatched,
-                    &format!("expected a clob/blob but found {}", value.ion_type()),
+                    &format!(
+                        "expected a clob/blob but found {}",
+                        if value.is_null() {
+                            format!("{:?}", value)
+                        } else {
+                            format!("{}", value.ion_type())
+                        }
+                    ),
                 ));
             }
         };
@@ -949,15 +939,6 @@ impl CodepointLengthConstraint {
 
 impl ConstraintValidator for CodepointLengthConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
-        // Check for null value
-        if value.is_null() {
-            return Err(Violation::new(
-                "codepoint_length",
-                ViolationCode::TypeMismatched,
-                &format!("expected a string/symbol found {:?}", value),
-            ));
-        }
-
         // get the size of given string/symbol Unicode codepoints
         let size = match value.as_str() {
             Some(text) => text.chars().count(),
@@ -966,7 +947,14 @@ impl ConstraintValidator for CodepointLengthConstraint {
                 return Err(Violation::new(
                     "codepoint_length",
                     ViolationCode::TypeMismatched,
-                    &format!("expected a string/symbol but found {}", value.ion_type()),
+                    &format!(
+                        "expected a clob/blob but found {}",
+                        if value.is_null() {
+                            format!("{:?}", value)
+                        } else {
+                            format!("{}", value.ion_type())
+                        }
+                    ),
                 ));
             }
         };

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -948,7 +948,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
                     "codepoint_length",
                     ViolationCode::TypeMismatched,
                     &format!(
-                        "expected a clob/blob but found {}",
+                        "expected a string/symbol but found {}",
                         if value.is_null() {
                             format!("{:?}", value)
                         } else {

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -122,7 +122,7 @@ impl IslConstraint {
             "contains" => {
                 if value.is_null() {
                     return Err(invalid_schema_error_raw(
-                        "contains constraint was a null instead of a list".to_string(),
+                        "contains constraint was a null instead of a list",
                     ));
                 }
 
@@ -144,7 +144,7 @@ impl IslConstraint {
             "content" => {
                 if value.is_null() {
                     return Err(invalid_schema_error_raw(
-                        "content constraint was a null instead of a symbol `closed`".to_string(),
+                        "content constraint was a null instead of a symbol `closed`",
                     ));
                 }
 

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_import::IslImportType;
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::isl::util::Range;
+use crate::isl::util::{Range, RangeType};
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, Sequence};
@@ -112,10 +112,12 @@ impl IslConstraint {
                 Ok(IslConstraint::AnyOf(types))
             }
             "byte_length" => Ok(IslConstraint::ByteLength(Range::from_ion_element(
-                value, true, // Pass true as byte_length will have non negative range
+                value,
+                RangeType::NonNegativeInteger,
             )?)),
             "codepoint_length" => Ok(IslConstraint::CodePointLength(Range::from_ion_element(
-                value, true, // Pass true as codepoint_length will have non negative range
+                value,
+                RangeType::NonNegativeInteger,
             )?)),
             "contains" => {
                 if value.is_null() {
@@ -166,7 +168,8 @@ impl IslConstraint {
             }
 
             "container_length" => Ok(IslConstraint::ContainerLength(Range::from_ion_element(
-                value, true, // Pass true as container_length will have non negative range
+                value,
+                RangeType::NonNegativeInteger,
             )?)),
             "fields" => {
                 let fields: HashMap<String, IslTypeRef> =
@@ -231,7 +234,7 @@ impl IslConstraint {
                         }
                     }
                     Integer | List => {
-                        Range::from_ion_element(value, true)? // Pass true as occurs will have non negative range
+                        Range::from_ion_element(value, RangeType::NonNegativeInteger)?
                     }
                     _ => {
                         return invalid_schema_error(format!(

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -14,7 +14,7 @@ pub enum IslConstraint {
     AllOf(Vec<IslTypeRef>),
     AnyOf(Vec<IslTypeRef>),
     ByteLength(Range),
-    CodePointLength(Range),
+    CodepointLength(Range),
     Contains(Vec<OwnedElement>),
     ContentClosed,
     ContainerLength(Range),
@@ -83,7 +83,7 @@ impl IslConstraint {
 
     /// Creates a [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
-        IslConstraint::CodePointLength(length)
+        IslConstraint::CodepointLength(length)
     }
 
     /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
@@ -115,7 +115,7 @@ impl IslConstraint {
                 value,
                 RangeType::NonNegativeInteger,
             )?)),
-            "codepoint_length" => Ok(IslConstraint::CodePointLength(Range::from_ion_element(
+            "codepoint_length" => Ok(IslConstraint::CodepointLength(Range::from_ion_element(
                 value,
                 RangeType::NonNegativeInteger,
             )?)),

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 pub enum IslConstraint {
     AllOf(Vec<IslTypeRef>),
     AnyOf(Vec<IslTypeRef>),
+    ByteLength(Range),
+    CodePointLength(Range),
     Contains(Vec<OwnedElement>),
     ContentClosed,
     ContainerLength(Range),
@@ -74,6 +76,16 @@ impl IslConstraint {
         IslConstraint::ContainerLength(length)
     }
 
+    /// Creates a [IslConstraint::ByteLength] using the range specified in it
+    pub fn byte_length(length: Range) -> IslConstraint {
+        IslConstraint::ByteLength(length)
+    }
+
+    /// Creates a [IslConstraint::CodePointLength] using the range specified in it
+    pub fn codepoint_length(length: Range) -> IslConstraint {
+        IslConstraint::CodePointLength(length)
+    }
+
     /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
     pub fn from_ion_element(
         constraint_name: &str,
@@ -99,6 +111,12 @@ impl IslConstraint {
                 )?;
                 Ok(IslConstraint::AnyOf(types))
             }
+            "byte_length" => Ok(IslConstraint::ByteLength(Range::from_ion_element(
+                value, true, // Pass true as byte_length will have non negative range
+            )?)),
+            "codepoint_length" => Ok(IslConstraint::CodePointLength(Range::from_ion_element(
+                value, true, // Pass true as codepoint_length will have non negative range
+            )?)),
             "contains" => {
                 if value.is_null() {
                     return Err(invalid_schema_error_raw(

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -125,7 +125,7 @@ mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
-    use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue};
+    use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue, RangeType};
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
     use ion_rs::types::timestamp::Timestamp;
@@ -277,7 +277,7 @@ mod isl_tests {
             &element_reader()
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
-            false,
+            RangeType::Other,
         )
     }
 

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -253,6 +253,18 @@ mod isl_tests {
                 "#),
         IslType::anonymous([IslConstraint::container_length(3.into())])
     ),
+    case::byte_length_constraint(
+        load_anonymous_type(r#" // For a schema with byte_length constraint as below:
+                    { byte_length: 3 }
+                "#),
+        IslType::anonymous([IslConstraint::byte_length(3.into())])
+    ),
+    case::codepoint_length_constraint(
+        load_anonymous_type(r#" // For a schema with codepoint_length constraint as below:
+                    { codepoint_length: 3 }
+                "#),
+        IslType::anonymous([IslConstraint::codepoint_length(3.into())])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -277,7 +277,7 @@ mod isl_tests {
             &element_reader()
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
-            RangeType::Other,
+            RangeType::Any,
         )
     }
 

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -429,7 +429,7 @@ impl RangeBoundaryValue {
                         range_boundary_type,
                     ))
                 }
-                RangeType::Other => Ok(RangeBoundaryValue::int_value(
+                RangeType::Any => Ok(RangeBoundaryValue::int_value(
                     value.as_any_int().unwrap().to_owned(),
                     range_boundary_type,
                 )),
@@ -463,5 +463,5 @@ pub enum RangeBoundaryType {
 /// to explicitly state if its non negative or not
 pub enum RangeType {
     NonNegativeInteger, // used by byte_length, container_length and codepoint_length to specify non negative integer range
-    Other,              // used for any other range types (e.g. Integer, Float, Timestamp, Decimal)
+    Any,                // used for any other range types (e.g. Integer, Float, Timestamp, Decimal)
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -215,6 +215,18 @@ mod schema_tests {
                 "#).into_iter(),
         1 // this includes named type container_length_type
     ),
+    case::byte_length_constraint(
+        load(r#" // For a schema with byte_length constraint as below:
+                    type:: { name: byte_length_type, byte_length: 3 }
+                "#).into_iter(),
+        1 // this includes named type byte_length_type
+    ),
+    case::codepoint_length_constraint(
+        load(r#" // For a schema with codepoint_length constraint as below:
+                        type:: { name: codepoint_length_type, codepoint_length: 3 }
+                    "#).into_iter(),
+        1 // this includes named type codepoint_length_type
+    ),
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
         owned_elements: I,
@@ -500,6 +512,46 @@ mod schema_tests {
                                 type::{ name: container_length_type, container_length: 3 }
                         "#),
                 "container_length_type"
+        ),
+        case::byte_length_constraint(
+                load(r#"
+                            {{"12345"}}
+                            {{ aGVsbG8= }}
+                        "#),
+                load(r#"
+                            null
+                            null.bool
+                            null.null
+                            null.clob
+                            null.blob
+                            {{}}
+                            {{"1234"}}
+                            {{"123456"}}
+                        "#),
+                load_schema_from_text(r#" // For a schema with byte_length constraint as below:
+                                type::{ name: byte_length_type, byte_length: 5 }
+                        "#),
+                "byte_length_type"
+        ),
+        case::codepoint_length_constraint(
+                load(r#"
+                            '12345'
+                            "12345"
+                        "#),
+                load(r#"
+                            null
+                            null.bool
+                            null.null
+                            null.string
+                            null.symbol
+                            ""
+                            '1234'
+                            "123456"
+                        "#),
+                load_schema_from_text(r#" // For a schema with codepoint_length constraint as below:
+                                type::{ name: codepoint_length_type, codepoint_length: 5 }
+                        "#),
+                "codepoint_length_type"
         ),
     )]
     fn type_validation(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -537,6 +537,8 @@ mod schema_tests {
                 load(r#"
                             '12345'
                             "12345"
+                            "1234😎"
+                            "हैलो!"
                         "#),
                 load(r#"
                             null
@@ -545,6 +547,7 @@ mod schema_tests {
                             null.string
                             null.symbol
                             ""
+                            "😎"
                             '1234'
                             "123456"
                         "#),

--- a/src/types.rs
+++ b/src/types.rs
@@ -454,6 +454,20 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::container_length(3.into())]),
         TypeDefinition::anonymous([Constraint::container_length(3.into()), Constraint::type_constraint(25)])
     ),
+    case::byte_length_constraint(
+        /* For a schema with byte_length constraint as below:
+            { byte_length: 3 }
+        */
+        IslType::anonymous([IslConstraint::byte_length(3.into())]),
+        TypeDefinition::anonymous([Constraint::byte_length(3.into()), Constraint::type_constraint(25)])
+    ),
+    case::codepoint_length_constraint(
+        /* For a schema with codepoint_length constraint as below:
+            { codepoint_length: 3 }
+        */
+        IslType::anonymous([IslConstraint::codepoint_length(3.into())]),
+        TypeDefinition::anonymous([Constraint::codepoint_length(3.into()), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `byte_length` and `codepoint_length` constraint.

*Grammar:*
```ANTLR
<BYTE_LENGTH> ::= byte_length: <INT>
                | byte_length: <RANGE<INT>>

<CODEPOINT_LENGTH> ::= codepoint_length: <INT>
                     | codepoint_length: <RANGE<INT>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#byte_length
https://amzn.github.io/ion-schema/docs/spec.html#codepoint_length

*List of changes:*
* adds `IslConstraint::CodePointLength` and`IslConstraint::ByteLength` enum variants
*  adds `Constraint::CodePointLength` and `Constraint::ByteLength`
enum variants
* adds validation logic for `byte_length` and `codepoint_length` constraint
* adds unit tests for `byte_length` and `codepoint_length` constraint

*Tests:*
added unit tests for `byte_length` and `codepoint_length` implementation.
- adds tests for programmatically creating `byte_length` and `codepoint_length` constraint
- adds tests for loading a schema using `byte_length` and `codepoint_length` constraint 
- adds validation tests for `byte_length` and `codepoint_length` constraint
