### PR TITLE
adds changes for `element` constraint implementation

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -994,7 +994,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
     }
 }
 
-/// Implements a `element` constraint
+/// Implements the `element` constraint
 /// [element]: https://amzn.github.io/ion-schema/docs/spec.html#element
 #[derive(Debug, Clone, PartialEq)]
 pub struct ElementConstraint {
@@ -1027,10 +1027,11 @@ impl ConstraintValidator for ElementConstraint {
             return Err(Violation::new(
                 "element",
                 ViolationCode::TypeMismatched,
-                &format!("expected a container found {:?}", value),
+                &format!("expected a container but found {:?}", value),
             ));
         }
 
+        // this type_id was validated while creating `ElementConstraint` hence the unwrap here is safe
         let type_def = type_store.get_type_by_id(self.type_id).unwrap();
 
         // validate each element of the given value container

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -31,6 +31,7 @@ pub enum Constraint {
     Contains(ContainsConstraint),
     ContentClosed,
     ContainerLength(ContainerLengthConstraint),
+    Element(ElementConstraint),
     Fields(FieldsConstraint),
     Not(NotConstraint),
     OneOf(OneOfConstraint),
@@ -90,6 +91,11 @@ impl Constraint {
         Constraint::CodepointLength(CodepointLengthConstraint::new(length))
     }
 
+    /// Creates a [Constraint::Element] referring to the type represented by the provided [TypeId].
+    pub fn element(type_id: TypeId) -> Constraint {
+        Constraint::Element(ElementConstraint::new(type_id))
+    }
+
     /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
     /// By default, fields created using this method will allow open content
     pub fn fields<I>(fields: I) -> Constraint
@@ -139,6 +145,15 @@ impl Constraint {
             IslConstraint::ContainerLength(isl_length) => Ok(Constraint::ContainerLength(
                 ContainerLengthConstraint::new(isl_length.to_owned()),
             )),
+            IslConstraint::Element(type_reference) => {
+                let element_constraint: ElementConstraint =
+                    ElementConstraint::resolve_from_isl_constraint(
+                        type_reference,
+                        type_store,
+                        pending_types,
+                    )?;
+                Ok(Constraint::Element(element_constraint))
+            }
             IslConstraint::Fields(fields) => {
                 let fields_constraint: FieldsConstraint =
                     FieldsConstraint::resolve_from_isl_constraint(
@@ -207,6 +222,7 @@ impl Constraint {
             Constraint::ContainerLength(container_length) => {
                 container_length.validate(value, type_store)
             }
+            Constraint::Element(element) => element.validate(value, type_store),
             Constraint::Fields(fields) => fields.validate(value, type_store),
             Constraint::Not(not) => not.validate(value, type_store),
             Constraint::OneOf(one_of) => one_of.validate(value, type_store),
@@ -974,6 +990,86 @@ impl ConstraintValidator for CodepointLengthConstraint {
             ));
         }
 
+        Ok(())
+    }
+}
+
+/// Implements a `element` constraint
+/// [element]: https://amzn.github.io/ion-schema/docs/spec.html#element
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElementConstraint {
+    type_id: TypeId,
+}
+
+impl ElementConstraint {
+    pub fn new(type_id: TypeId) -> Self {
+        Self { type_id }
+    }
+
+    /// Tries to create an element constraint from the given OwnedElement
+    pub fn resolve_from_isl_constraint(
+        type_reference: &IslTypeRef,
+        type_store: &mut TypeStore,
+        pending_types: &mut PendingTypes,
+    ) -> IonSchemaResult<Self> {
+        let type_id =
+            IslTypeRef::resolve_type_reference(type_reference, type_store, pending_types)?;
+        Ok(ElementConstraint::new(type_id))
+    }
+}
+
+impl ConstraintValidator for ElementConstraint {
+    fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
+        let mut violations: Vec<Violation> = vec![];
+
+        // Check for null container
+        if value.is_null() {
+            return Err(Violation::new(
+                "element",
+                ViolationCode::TypeMismatched,
+                &format!("expected a container found {:?}", value),
+            ));
+        }
+
+        let type_def = type_store.get_type_by_id(self.type_id).unwrap();
+
+        // validate each element of the given value container
+        match value.ion_type() {
+            IonType::List | IonType::SExpression => {
+                for val in value.as_sequence().unwrap().iter() {
+                    if let Err(violation) = type_def.validate(val, type_store) {
+                        violations.push(violation);
+                    }
+                }
+            }
+            IonType::Struct => {
+                for (field_name, val) in value.as_struct().unwrap().iter() {
+                    if let Err(violation) = type_def.validate(val, type_store) {
+                        violations.push(violation);
+                    }
+                }
+            }
+            _ => {
+                // return Violation if value is not an Ion container
+                return Err(Violation::new(
+                    "element",
+                    ViolationCode::TypeMismatched,
+                    &format!(
+                        "expected a container (a list/sexp/struct) but found {}",
+                        value.ion_type()
+                    ),
+                ));
+            }
+        }
+
+        if !violations.is_empty() {
+            return Err(Violation::with_violations(
+                "element",
+                ViolationCode::ElementMismatched,
+                "one or more elements don't satisfy element constraint",
+                violations,
+            ));
+        }
         Ok(())
     }
 }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -178,12 +178,6 @@ impl IslConstraint {
                 RangeType::NonNegativeInteger,
             )?)),
             "element" => {
-                if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
-                    return Err(invalid_schema_error_raw(format!(
-                        "element constraint was a {:?} instead of a symbol/struct",
-                        value.ion_type()
-                    )));
-                }
                 let type_reference: IslTypeRef =
                     IslTypeRef::from_ion_element(value, inline_imported_types)?;
                 Ok(IslConstraint::Element(type_reference))
@@ -208,23 +202,11 @@ impl IslConstraint {
                 Ok(IslConstraint::OneOf(types))
             }
             "not" => {
-                if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
-                    return Err(invalid_schema_error_raw(format!(
-                        "type constraint was a {:?} instead of a symbol/struct",
-                        value.ion_type()
-                    )));
-                }
                 let type_reference: IslTypeRef =
                     IslTypeRef::from_ion_element(value, inline_imported_types)?;
                 Ok(IslConstraint::Not(type_reference))
             }
             "type" => {
-                if value.ion_type() != IonType::Symbol && value.ion_type() != IonType::Struct {
-                    return Err(invalid_schema_error_raw(format!(
-                        "type constraint was a {:?} instead of a symbol/struct",
-                        value.ion_type()
-                    )));
-                }
                 let type_reference: IslTypeRef =
                     IslTypeRef::from_ion_element(value, inline_imported_types)?;
                 Ok(IslConstraint::Type(type_reference))

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -265,6 +265,12 @@ mod isl_tests {
                 "#),
         IslType::anonymous([IslConstraint::codepoint_length(3.into())])
     ),
+    case::element_constraint(
+        load_anonymous_type(r#" // For a schema with element constraint as below:
+                    { element: int }
+                "#),
+        IslType::anonymous([IslConstraint::element(IslTypeRef::named("int"))])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -227,6 +227,12 @@ mod schema_tests {
                     "#).into_iter(),
         1 // this includes named type codepoint_length_type
     ),
+    case::element_constraint(
+        load(r#" // For a schema with element constraint as below:
+                    type:: { name: element_type, element: int }
+                 "#).into_iter(),
+        1 // this includes named type element_type
+    ),
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
         owned_elements: I,
@@ -555,6 +561,30 @@ mod schema_tests {
                                 type::{ name: codepoint_length_type, codepoint_length: 5 }
                         "#),
                 "codepoint_length_type"
+        ),
+        case::element_constraint(
+                load(r#"
+                          []
+                          [1]
+                          [1, 2, 3]
+                          ()
+                          (1)
+                          (1 2 3)
+                          { a: 1, b: 2, c: 3 }
+                        "#),
+                load(r#"
+                          null.list
+                          [1.]
+                          [1e0]
+                          [1, 2, null.int]
+                          (1 2 3 true 4)
+                          { a: 1, b: 2, c: true }
+                          { a: 1, b: 2, c: null.int }
+                        "#),
+                load_schema_from_text(r#" // For a schema with element constraint as below:
+                                type::{ name: element_type, element: int }
+                        "#),
+                "element_type"
         ),
     )]
     fn type_validation(

--- a/src/types.rs
+++ b/src/types.rs
@@ -468,6 +468,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::codepoint_length(3.into())]),
         TypeDefinition::anonymous([Constraint::codepoint_length(3.into()), Constraint::type_constraint(25)])
     ),
+    case::element_constraint(
+        /* For a schema with element constraint as below:
+            { element: int }
+        */
+        IslType::anonymous([IslConstraint::element(IslTypeRef::named("int"))]),
+        TypeDefinition::anonymous([Constraint::element(0), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -50,6 +50,7 @@ impl fmt::Display for Violation {
 #[derive(Debug, Clone)]
 pub enum ViolationCode {
     AllTypesNotMatched,
+    ElementMismatched, // this is used for mismatched elements in containers
     FieldsNotMatched,
     InvalidLength, // this is ued for any length related constraints (e.g. container_length, byte_length, codepoint_length)
     InvalidNull,   // if the value is a null for type references that doesn't allow null
@@ -69,6 +70,7 @@ impl fmt::Display for ViolationCode {
             "{}",
             match self {
                 ViolationCode::AllTypesNotMatched => "all_types_not_matched",
+                ViolationCode::ElementMismatched => "element_mismatched",
                 ViolationCode::FieldsNotMatched => "fields_not_matched",
                 ViolationCode::InvalidLength => "invalid_length",
                 ViolationCode::InvalidNull => "invalid_null",

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -42,6 +42,13 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/contains/nulls.isl",
     "ion-schema-tests/constraints/contains/validation.isl",
     "ion-schema-tests/constraints/contains/various_values.isl",
+    "ion-schema-tests/constraints/element/empty_type.isl",
+    "ion-schema-tests/constraints/element/inlined_type_import.isl",
+    "ion-schema-tests/constraints/element/int.isl",
+    "ion-schema-tests/constraints/element/nullable_int.isl",
+    "ion-schema-tests/constraints/element/validation_inline_import.isl",
+    "ion-schema-tests/constraints/element/validation_int.isl",
+    "ion-schema-tests/constraints/element/validation_named_type.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -55,6 +62,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/type/*.isl")]
 #[test_resources("ion-schema-tests/constraints/content/*.isl")]
 #[test_resources("ion-schema-tests/constraints/contains/*.isl")]
+#[test_resources("ion-schema-tests/constraints/element/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION

*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `element` constraint.

*Grammar:*
```ANTLR
<ELEMENT> ::= element: <TYPE_REFERENCE>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#element

*List of changes:*
* adds `Elemnt` enum variants for `IslConstraint` and `Constraint`
* adds `ElementConstraint` implementations
* adds validation logic for element
* adds `ViolationCode::ElementMismatched` enum variant
* adds unit tests for element

*Tests:*
added unit tests for `element` implementation.
- adds tests for programmatically creating `element` constraint
- adds tests for loading a schema using `element` constraint 
- adds validation test for `element` constraint
