### PR TITLE
Version bump to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
*Issue #75*

*Description of changes:*
This PR works on a version bump to `0.2.0` for` ion-schema` crate.
