### PR TITLE
adds implementation of `precision` constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.7.0"
+ion-rs = "0.10.0"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate clap;
 use clap::{App, ArgMatches};
-use ion_rs::text::writer::TextWriter;
 use ion_rs::value::reader::element_reader;
 use ion_rs::value::reader::ElementReader;
 use ion_rs::value::writer::{ElementWriter, Format, TextKind};
 use ion_rs::IonType;
+use ion_rs::{RawTextWriter, Writer};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::result::IonSchemaResult;
 use ion_schema::system::SchemaSystem;
@@ -91,7 +91,7 @@ fn validate(command_args: &ArgMatches) -> IonSchemaResult<()> {
 
     // create a text writer to make the output
     let mut output = vec![];
-    let mut writer = TextWriter::new(&mut output);
+    let mut writer = RawTextWriter::new(&mut output);
 
     // validate owned_elements according to type_ref
     for owned_element in owned_elements {

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1285,7 +1285,7 @@ impl ConstraintValidator for AnnotationsConstraint {
     }
 }
 
-/// Implements an `precision` constraint of Ion Schema
+/// Implements Ion Schema's `precision` constraint
 /// [precision]: https://amzn.github.io/ion-schema/docs/spec.html#precision
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrecisionConstraint {
@@ -1311,17 +1311,15 @@ impl ConstraintValidator for PrecisionConstraint {
             Some(decimal_value) => decimal_value.precision(),
             _ => {
                 // return Violation if value is not decimal
+                let error_message = if value.is_null() {
+                    format!("expected a decimal but found {:?}", value)
+                } else {
+                    format!("expected a decimal but found {}", value.ion_type())
+                };
                 return Err(Violation::new(
                     "precision",
                     ViolationCode::TypeMismatched,
-                    &format!(
-                        "expected a decimal but found {}",
-                        if value.is_null() {
-                            format!("{:?}", value)
-                        } else {
-                            format!("{}", value.ion_type())
-                        }
-                    ),
+                    &error_message,
                 ));
             }
         };

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -306,12 +306,10 @@ impl IslConstraint {
                 )?;
                 Ok(IslConstraint::OrderedElements(types))
             }
-            "precision" => {
-                let mut precision_range =
-                    Range::from_ion_element(value, RangeType::NonNegativeInteger)?;
-                precision_range = Range::validate_precision_range(&precision_range)?;
-                Ok(IslConstraint::Precision(precision_range))
-            }
+            "precision" => Ok(IslConstraint::Precision(Range::from_ion_element(
+                value,
+                RangeType::PrecisionRange,
+            )?)),
 
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -28,6 +28,7 @@ pub enum IslConstraint {
     Occurs(Range),
     OneOf(Vec<IslTypeRef>),
     OrderedElements(Vec<IslTypeRef>),
+    Precision(Range),
     Type(IslTypeRef),
 }
 
@@ -56,6 +57,10 @@ impl IslConstraint {
     /// Creates a [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::OrderedElements(isl_types.into())
+    }
+    /// Creates a [IslConstraint::Precision] using the range specified in it
+    pub fn precision(precision: Range) -> IslConstraint {
+        IslConstraint::Precision(precision)
     }
 
     /// Creates a [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
@@ -301,6 +306,13 @@ impl IslConstraint {
                 )?;
                 Ok(IslConstraint::OrderedElements(types))
             }
+            "precision" => {
+                let mut precision_range =
+                    Range::from_ion_element(value, RangeType::NonNegativeInteger)?;
+                precision_range = Range::validate_precision_range(&precision_range)?;
+                Ok(IslConstraint::Precision(precision_range))
+            }
+
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()
                     + type_name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -128,12 +128,12 @@ mod isl_tests {
     use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue, RangeType};
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
+    use ion_rs::types::integer::Integer as IntegerValue;
     use ion_rs::types::timestamp::Timestamp;
     use ion_rs::value::owned::text_token;
     use ion_rs::value::owned::OwnedElement;
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
-    use ion_rs::value::AnyInt;
     use rstest::*;
 
     // helper function to create NamedIslType for isl tests
@@ -310,7 +310,7 @@ mod isl_tests {
             ),
             Range::range(
                 RangeBoundaryValue::Min,
-                RangeBoundaryValue::int_value(AnyInt::I64(5), RangeBoundaryType::Inclusive)
+                RangeBoundaryValue::int_value(IntegerValue::I64(5), RangeBoundaryType::Inclusive)
             )
         ),
         case::range_with_float(

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -278,6 +278,12 @@ mod isl_tests {
                     "#),
         IslType::anonymous([IslConstraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
     ),
+    case::precision_constraint(
+        load_anonymous_type(r#" // For a schema with precision constraint as below:
+                        { precision: 2 }
+                    "#),
+        IslType::anonymous([IslConstraint::precision(2.into())])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -243,7 +243,7 @@ impl Range {
     }
 
     pub fn validate_precision_range(precision_range: &Range) -> IonSchemaResult<Range> {
-        // minimum precision must be greater than or equal to 0
+        // minimum precision must be greater than or equal to 1
         // for more information: https://amzn.github.io/ion-schema/docs/spec.html#precision
         match precision_range {
             Range::IntegerNonNegative(min_value, max_value) => match min_value {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -616,6 +616,27 @@ mod schema_tests {
                         "#),
                 "annotations_type"
         ),
+        case::precision_constraint(
+            load(r#"
+                          42.
+                          42d0
+                          42d-0
+                          4.2d1
+                          0.42d2
+                        "#),
+            load(r#"
+                          null
+                          null.null
+                          null.decimal
+                          null.string
+                          4.
+                          42.0
+                        "#),
+            load_schema_from_text(r#" // For a schema with precision constraint as below:
+                                type::{ name: precision_type, precision: 2 }
+                        "#),
+            "precision_type"
+        ),
     )]
     fn type_validation(
         valid_values: Vec<OwnedElement>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -482,6 +482,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])]),
         TypeDefinition::anonymous([Constraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()]), Constraint::type_constraint(25)])
     ),
+    case::precision_constraint(
+        /* For a schema with precision constraint as below:
+            { precision: 3 }
+        */
+        IslType::anonymous([IslConstraint::precision(3.into())]),
+        TypeDefinition::anonymous([Constraint::precision(3.into()), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -49,6 +49,8 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/element/validation_inline_import.isl",
     "ion-schema-tests/constraints/element/validation_int.isl",
     "ion-schema-tests/constraints/element/validation_named_type.isl",
+    "ion-schema-tests/constraints/precision/invalid.isl",
+    "ion-schema-tests/constraints/precision/validation.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -64,6 +66,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/contains/*.isl")]
 #[test_resources("ion-schema-tests/constraints/element/*.isl")]
 #[test_resources("ion-schema-tests/constraints/annotations/*.isl")]
+#[test_resources("ion-schema-tests/constraints/precision/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -49,7 +49,6 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/element/validation_inline_import.isl",
     "ion-schema-tests/constraints/element/validation_int.isl",
     "ion-schema-tests/constraints/element/validation_named_type.isl",
-    "ion-schema-tests/constraints/precision/invalid.isl",
     "ion-schema-tests/constraints/precision/validation.isl",
 ];
 


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `precision` constraint.

*Grammar:*
```ANTLR
<PRECISION> ::= precision: <INT>
              | precision: <RANGE<INT>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#precision

*List of changes:*
* adds changes to upgrade to v0.10.0 for `ion-rs`.
* adds `Precision` enum variants for `IslConstraint` and `Constraint`
* adds `PrecisionConstraint` implementations
* adds changes for validating precision range (_Note: precision range must be equal to or greater than 1_)
* adds validation logic for precision

*Tests:*
added unit tests for `precision` implementation.
- adds tests for programmatically creating `precision` constraint
- adds tests for loading a schema using `precision` constraint 
- adds validation tests for `precision` constraint
