### PR TITLE
adds implementation of `scale` constraint

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1355,7 +1355,7 @@ impl ConstraintValidator for PrecisionConstraint {
 }
 
 /// Implements Ion Schema's `scale` constraint
-/// [precision]: https://amzn.github.io/ion-schema/docs/spec.html#scale
+/// [scale]: https://amzn.github.io/ion-schema/docs/spec.html#scale
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScaleConstraint {
     scale_range: Range,
@@ -1375,13 +1375,7 @@ impl ConstraintValidator for ScaleConstraint {
     fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
         // get the scale of given decimal
         let value_scale = match value.as_decimal() {
-            Some(decimal_value) => {
-                if decimal_value.scale() > 0 {
-                    decimal_value.scale()
-                } else {
-                    0
-                }
-            }
+            Some(decimal_value) => decimal_value.scale(),
             _ => {
                 // return Violation if value is not decimal
                 let error_message = if value.is_null() {

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -39,6 +39,7 @@ pub enum Constraint {
     OrderedElements(OrderedElementsConstraint),
     Occurs(OccursConstraint),
     Precision(PrecisionConstraint),
+    Scale(ScaleConstraint),
     Type(TypeConstraint),
 }
 
@@ -130,6 +131,11 @@ impl Constraint {
     /// Creates a [Constraint::Precision] from a [Range] specifying a precision range.
     pub fn precision(precision: Range) -> Constraint {
         Constraint::Precision(PrecisionConstraint::new(precision))
+    }
+
+    /// Creates a [Constraint::Scale] from a [Range] specifying a precision range.
+    pub fn scale(scale: Range) -> Constraint {
+        Constraint::Scale(ScaleConstraint::new(scale))
     }
 
     /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
@@ -246,6 +252,9 @@ impl Constraint {
             IslConstraint::Precision(precision_range) => Ok(Constraint::Precision(
                 PrecisionConstraint::new(precision_range.to_owned()),
             )),
+            IslConstraint::Scale(scale_range) => Ok(Constraint::Scale(ScaleConstraint::new(
+                scale_range.to_owned(),
+            ))),
         }
     }
 
@@ -279,6 +288,7 @@ impl Constraint {
                 ordered_elements.validate(value, type_store)
             }
             Constraint::Precision(precision) => precision.validate(value, type_store),
+            Constraint::Scale(scale) => scale.validate(value, type_store),
         }
     }
 }
@@ -1293,10 +1303,8 @@ pub struct PrecisionConstraint {
 }
 
 impl PrecisionConstraint {
-    pub fn new(length_range: Range) -> Self {
-        Self {
-            precision_range: length_range,
-        }
+    pub fn new(precision_range: Range) -> Self {
+        Self { precision_range }
     }
 
     pub fn precision(&self) -> &Range {
@@ -1339,6 +1347,65 @@ impl ConstraintValidator for PrecisionConstraint {
                     "expected precision {:?} found {}",
                     precision_range, value_precision
                 ),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Implements Ion Schema's `scale` constraint
+/// [precision]: https://amzn.github.io/ion-schema/docs/spec.html#scale
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScaleConstraint {
+    scale_range: Range,
+}
+
+impl ScaleConstraint {
+    pub fn new(scale_range: Range) -> Self {
+        Self { scale_range }
+    }
+
+    pub fn scale(&self) -> &Range {
+        &self.scale_range
+    }
+}
+
+impl ConstraintValidator for ScaleConstraint {
+    fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
+        // get the scale of given decimal
+        let value_scale = match value.as_decimal() {
+            Some(decimal_value) => {
+                if decimal_value.scale() > 0 {
+                    decimal_value.scale()
+                } else {
+                    0
+                }
+            }
+            _ => {
+                // return Violation if value is not decimal
+                let error_message = if value.is_null() {
+                    format!("expected a decimal but found {:?}", value)
+                } else {
+                    format!("expected a decimal but found {}", value.ion_type())
+                };
+                return Err(Violation::new(
+                    "scale",
+                    ViolationCode::TypeMismatched,
+                    &error_message,
+                ));
+            }
+        };
+
+        // get isl decimal scale as a range
+        let scale_range: &Range = self.scale();
+
+        // return a Violation if the value didn't follow scale constraint
+        if !scale_range.contains(&(value_scale).into()).unwrap() {
+            return Err(Violation::new(
+                "scale",
+                ViolationCode::InvalidLength,
+                &format!("expected scale {:?} found {}", scale_range, value_scale),
             ));
         }
 

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -34,43 +34,43 @@ pub enum IslConstraint {
 }
 
 impl IslConstraint {
-    /// Creates a [IslConstraint::Type] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::Type] using the [IslTypeRef] referenced inside it
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::Type(isl_type)
     }
 
-    /// Creates a [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
     pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::AllOf(isl_types.into())
     }
 
-    /// Creates a [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
     pub fn any_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::AnyOf(isl_types.into())
     }
 
-    /// Creates a [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
     pub fn one_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::OneOf(isl_types.into())
     }
 
-    /// Creates a [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::OrderedElements(isl_types.into())
     }
 
-    /// Creates a [IslConstraint::Precision] using the range specified in it
+    /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: Range) -> IslConstraint {
         IslConstraint::Precision(precision)
     }
 
-    /// Creates a [IslConstraint::Scale] using the range specified in it
+    /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: Range) -> IslConstraint {
         IslConstraint::Scale(scale)
     }
 
-    /// Creates a [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
+    /// Creates an [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
     pub fn fields<I>(fields: I) -> IslConstraint
     where
         I: Iterator<Item = (String, IslTypeRef)>,
@@ -78,7 +78,7 @@ impl IslConstraint {
         IslConstraint::Fields(fields.collect())
     }
 
-    /// Creates a [IslConstraint::Not] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::Not] using the [IslTypeRef] referenced inside it
     pub fn not(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::Not(isl_type)
     }
@@ -88,27 +88,27 @@ impl IslConstraint {
         IslConstraint::Contains(values.into())
     }
 
-    /// Creates a [IslConstraint::ContainerLength] using the range specified in it
+    /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: Range) -> IslConstraint {
         IslConstraint::ContainerLength(length)
     }
 
-    /// Creates a [IslConstraint::ByteLength] using the range specified in it
+    /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: Range) -> IslConstraint {
         IslConstraint::ByteLength(length)
     }
 
-    /// Creates a [IslConstraint::CodePointLength] using the range specified in it
+    /// Creates an [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
         IslConstraint::CodepointLength(length)
     }
 
-    /// Creates a [IslConstraint::Element] using the [IslTypeRef] referenced inside it
+    /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
     pub fn element(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::Element(isl_type)
     }
 
-    /// Creates a [IslConstraint::Annotations] using [str]s and [OwnedElement]s specified inside it
+    /// Creates an [IslConstraint::Annotations] using [str]s and [OwnedElement]s specified inside it
     pub fn annotations<
         'a,
         A: IntoIterator<Item = &'a str>,
@@ -319,7 +319,7 @@ impl IslConstraint {
             )?)),
             "scale" => Ok(IslConstraint::Scale(Range::from_ion_element(
                 value,
-                RangeType::NonNegativeInteger,
+                RangeType::Any,
             )?)),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -29,6 +29,7 @@ pub enum IslConstraint {
     OneOf(Vec<IslTypeRef>),
     OrderedElements(Vec<IslTypeRef>),
     Precision(Range),
+    Scale(Range),
     Type(IslTypeRef),
 }
 
@@ -58,9 +59,15 @@ impl IslConstraint {
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::OrderedElements(isl_types.into())
     }
+
     /// Creates a [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: Range) -> IslConstraint {
         IslConstraint::Precision(precision)
+    }
+
+    /// Creates a [IslConstraint::Scale] using the range specified in it
+    pub fn scale(scale: Range) -> IslConstraint {
+        IslConstraint::Scale(scale)
     }
 
     /// Creates a [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
@@ -310,7 +317,10 @@ impl IslConstraint {
                 value,
                 RangeType::PrecisionRange,
             )?)),
-
+            "scale" => Ok(IslConstraint::Scale(Range::from_ion_element(
+                value,
+                RangeType::NonNegativeInteger,
+            )?)),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()
                     + type_name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -288,7 +288,7 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with scale constraint as below:
                         { scale: 2 }
                     "#),
-        IslType::anonymous([IslConstraint::scale(2.into())])
+        IslType::anonymous([IslConstraint::scale((&IntegerValue::I64(2)).into())])
     ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -284,6 +284,12 @@ mod isl_tests {
                     "#),
         IslType::anonymous([IslConstraint::precision(2.into())])
     ),
+    case::scale_constraint(
+        load_anonymous_type(r#" // For a schema with scale constraint as below:
+                        { scale: 2 }
+                    "#),
+        IslType::anonymous([IslConstraint::scale(2.into())])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -257,6 +257,14 @@ impl Range {
         }
 
         let range = try_to!(value.as_sequence());
+
+        // verify if the value has annotation range
+        if !value.annotations().any(|a| a == &text_token("range")) {
+            return invalid_schema_error(
+                "An element representing range must have annotation `range::` with it.",
+            );
+        }
+
         if range.len() != 2 {
             return invalid_schema_error(
                 "Ranges must contain two values representing minimum and maximum ends of range.",

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -248,12 +248,18 @@ impl Range {
         // if an integer value is passed here then convert it into a range
         // eg. if `1` is passed as value then return a range [1,1]
         if let Some(integer_value) = value.as_integer() {
-            let non_negative_integer_value =
-                Range::validate_non_negative_integer_range_boundary_value(
-                    value.as_integer().unwrap(),
-                    &range_type,
-                )?;
-            return Ok(non_negative_integer_value.into());
+            return if range_type == RangeType::NonNegativeInteger
+                || range_type == RangeType::PrecisionRange
+            {
+                let non_negative_integer_value =
+                    Range::validate_non_negative_integer_range_boundary_value(
+                        value.as_integer().unwrap(),
+                        &range_type,
+                    )?;
+                Ok(non_negative_integer_value.into())
+            } else {
+                Ok(integer_value.into())
+            };
         }
 
         let range = try_to!(value.as_sequence());
@@ -376,6 +382,16 @@ impl From<usize> for Range {
                 non_negative_int_value,
                 RangeBoundaryType::Inclusive,
             ),
+        )
+    }
+}
+
+/// Provides `Range` for given `usize`
+impl From<&IntegerValue> for Range {
+    fn from(int_value: &IntegerValue) -> Self {
+        Range::Integer(
+            RangeBoundaryValue::int_value(int_value.to_owned(), RangeBoundaryType::Inclusive),
+            RangeBoundaryValue::int_value(int_value.to_owned(), RangeBoundaryType::Inclusive),
         )
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -656,6 +656,7 @@ mod schema_tests {
                           0.432
                           0.4321
                           43d3
+                          0d0
                         "#),
             load(r#"
                           null
@@ -665,7 +666,7 @@ mod schema_tests {
                           0.43210
                         "#),
             load_schema_from_text(r#" // For a schema with scale constraint as below:
-                                type::{ name: scale_type, scale: range::[0, 4] }
+                                type::{ name: scale_type, scale: range::[min, 4] }
                         "#),
             "scale_type"
         ),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -234,11 +234,23 @@ mod schema_tests {
         1 // this includes named type element_type
     ),
     case::annotations_constraint(
-    load(r#" // For a schema with annotations constraint as below:
+        load(r#" // For a schema with annotations constraint as below:
                     type:: { name: annotations_type, annotations: closed::[red, blue, green] }
                  "#).into_iter(),
-    1 // this includes named type annotations_type
+        1 // this includes named type annotations_type
     ),
+    case::precision_constraint(
+        load(r#" // For a schema with precision constraint as below:
+                        type:: { name: precision_type, precision: 2 }
+                     "#).into_iter(),
+        1 // this includes named type precision_type
+    ),
+    case::scale_constraint(
+        load(r#" // For a schema with scale constraint as below:
+                    type:: { name: scale_type, scale: 2 }
+                 "#).into_iter(),
+        1 // this includes named type scale_type
+    )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
         owned_elements: I,
@@ -636,6 +648,26 @@ mod schema_tests {
                                 type::{ name: precision_type, precision: 2 }
                         "#),
             "precision_type"
+        ),
+        case::scale_constraint(
+            load(r#"
+                          0.4
+                          0.42
+                          0.432
+                          0.4321
+                          43d3
+                        "#),
+            load(r#"
+                          null
+                          null.null
+                          null.decimal
+                          null.symbol
+                          0.43210
+                        "#),
+            load_schema_from_text(r#" // For a schema with scale constraint as below:
+                                type::{ name: scale_type, scale: range::[0, 4] }
+                        "#),
+            "scale_type"
         ),
     )]
     fn type_validation(

--- a/src/types.rs
+++ b/src/types.rs
@@ -489,6 +489,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::precision(3.into())]),
         TypeDefinition::anonymous([Constraint::precision(3.into()), Constraint::type_constraint(25)])
     ),
+    case::scale_constraint(
+        /* For a schema with scale constraint as below:
+            { scale: 2 }
+        */
+        IslType::anonymous([IslConstraint::scale(2.into())]),
+        TypeDefinition::anonymous([Constraint::scale(2.into()), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -50,6 +50,8 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/element/validation_int.isl",
     "ion-schema-tests/constraints/element/validation_named_type.isl",
     "ion-schema-tests/constraints/precision/validation.isl",
+    "ion-schema-tests/constraints/scale/validation.isl",
+    "ion-schema-tests/constraints/scale/invalid.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -66,6 +68,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/element/*.isl")]
 #[test_resources("ion-schema-tests/constraints/annotations/*.isl")]
 #[test_resources("ion-schema-tests/constraints/precision/*.isl")]
+#[test_resources("ion-schema-tests/constraints/scale/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `scale` constraint.

*Grammar:*
```ANTLR
<SCALE> ::= scale: <INT>
              | scale: <RANGE<INT>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#scale

*List of changes:*
* adds changes in range construction to check for annotation `range`.
* adds `Scale` enum variants for `IslConstraint` and `Constraint`
* adds `ScaleConstraint` implementations
* adds validation logic for `scale` constraint

*Tests:*
added unit tests for `scale` implementation.
- adds tests for programmatically creating `scale` constraint
- adds tests for loading a schema using `scale` constraint 
- adds validation tests for `scale` constraint
