### PR TITLE
Updated dependency on ion-rs to v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.10.0"
+ion-rs = "0.11.0"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"


### PR DESCRIPTION
This change eliminates transitive dependencies on `ion-c`,
`ion-c-sys`, `cmake`, and `clang`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
