### PR TITLE
adds implementation of `timestamp_precision` constraint

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -83,7 +83,7 @@ impl Constraint {
     /// Creates a [Constraint::ContainerLength] from a [Range] specifying a length range.
     pub fn container_length(length: Range) -> Constraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("container_length constraint  must have a range of type IntegerNonNegative")
+            panic!("container_length constraint must have a range of type IntegerNonNegative")
         }
         Constraint::ContainerLength(ContainerLengthConstraint::new(length))
     }
@@ -91,7 +91,7 @@ impl Constraint {
     /// Creates a [Constraint::ByteLength] from a [Range] specifying a length range.
     pub fn byte_length(length: Range) -> Constraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("byte_length constraint  must have a range of type IntegerNonNegative")
+            panic!("byte_length constraint must have a range of type IntegerNonNegative")
         }
         Constraint::ByteLength(ByteLengthConstraint::new(length))
     }
@@ -99,7 +99,7 @@ impl Constraint {
     /// Creates a [Constraint::CodePointLength] from a [Range] specifying a length range.
     pub fn codepoint_length(length: Range) -> Constraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("codepoint_length constraint  must have a range of type IntegerNonNegative")
+            panic!("codepoint_length constraint must have a range of type IntegerNonNegative")
         }
         Constraint::CodepointLength(CodepointLengthConstraint::new(length))
     }
@@ -141,7 +141,7 @@ impl Constraint {
     /// Creates a [Constraint::Precision] from a [Range] specifying a precision range.
     pub fn precision(precision: Range) -> Constraint {
         if !matches!(precision, Range::IntegerNonNegative(_, _)) {
-            panic!("precision constraint  must have a range of type IntegerNonNegative")
+            panic!("precision constraint must have a range of type IntegerNonNegative")
         }
         Constraint::Precision(PrecisionConstraint::new(precision))
     }
@@ -149,7 +149,7 @@ impl Constraint {
     /// Creates a [Constraint::Scale] from a [Range] specifying a precision range.
     pub fn scale(scale: Range) -> Constraint {
         if !matches!(scale, Range::Integer(_, _)) {
-            panic!("scale constraint  must have a range of type Integer")
+            panic!("scale constraint must have a range of type Integer")
         }
         Constraint::Scale(ScaleConstraint::new(scale))
     }
@@ -157,7 +157,7 @@ impl Constraint {
     /// Creates a [Constraint::TimestampPrecision] from a [Range] specifying a precision range.
     pub fn timestamp_precision(precision: Range) -> Constraint {
         if !matches!(precision, Range::TimestampPrecision(_, _)) {
-            panic!("timestamp_precision constraint  must have a range of type TimestampPrecision")
+            panic!("timestamp_precision constraint must have a range of type TimestampPrecision")
         }
         Constraint::TimestampPrecision(TimestampPrecisionConstraint::new(precision))
     }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::isl::util::{Annotation, Range, TimestampPrecisionValue};
+use crate::isl::util::{Annotation, Range, TimestampPrecision};
 use crate::result::{IonSchemaResult, ValidationResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::types::{TypeDefinition, TypeValidator};
@@ -82,16 +82,25 @@ impl Constraint {
 
     /// Creates a [Constraint::ContainerLength] from a [Range] specifying a length range.
     pub fn container_length(length: Range) -> Constraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("container_length constraint  must have a range of type IntegerNonNegative")
+        }
         Constraint::ContainerLength(ContainerLengthConstraint::new(length))
     }
 
     /// Creates a [Constraint::ByteLength] from a [Range] specifying a length range.
     pub fn byte_length(length: Range) -> Constraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("byte_length constraint  must have a range of type IntegerNonNegative")
+        }
         Constraint::ByteLength(ByteLengthConstraint::new(length))
     }
 
     /// Creates a [Constraint::CodePointLength] from a [Range] specifying a length range.
     pub fn codepoint_length(length: Range) -> Constraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("codepoint_length constraint  must have a range of type IntegerNonNegative")
+        }
         Constraint::CodepointLength(CodepointLengthConstraint::new(length))
     }
 
@@ -131,16 +140,25 @@ impl Constraint {
 
     /// Creates a [Constraint::Precision] from a [Range] specifying a precision range.
     pub fn precision(precision: Range) -> Constraint {
+        if !matches!(precision, Range::IntegerNonNegative(_, _)) {
+            panic!("precision constraint  must have a range of type IntegerNonNegative")
+        }
         Constraint::Precision(PrecisionConstraint::new(precision))
     }
 
     /// Creates a [Constraint::Scale] from a [Range] specifying a precision range.
     pub fn scale(scale: Range) -> Constraint {
+        if !matches!(scale, Range::Integer(_, _)) {
+            panic!("scale constraint  must have a range of type Integer")
+        }
         Constraint::Scale(ScaleConstraint::new(scale))
     }
 
     /// Creates a [Constraint::TimestampPrecision] from a [Range] specifying a precision range.
     pub fn timestamp_precision(precision: Range) -> Constraint {
+        if !matches!(precision, Range::TimestampPrecision(_, _)) {
+            panic!("timestamp_precision constraint  must have a range of type TimestampPrecision")
+        }
         Constraint::TimestampPrecision(TimestampPrecisionConstraint::new(precision))
     }
 
@@ -1422,7 +1440,7 @@ impl ConstraintValidator for ScaleConstraint {
 }
 
 /// Implements Ion Schema's `timestamp_precision` constraint
-/// [scale]: https://amzn.github.io/ion-schema/docs/spec.html#timestamp_precision
+/// [timestamp_precision]: https://amzn.github.io/ion-schema/docs/spec.html#timestamp_precision
 #[derive(Debug, Clone, PartialEq)]
 pub struct TimestampPrecisionConstraint {
     timestamp_precision_range: Range,
@@ -1460,7 +1478,7 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
             }
         };
 
-        let value_precision = TimestampPrecisionValue::from_timestamp(&timestamp_value);
+        let value_precision = TimestampPrecision::scale(timestamp_value);
 
         // get isl timestamp precision as a range
         let precision_range: &Range = self.timestamp_precision();

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -40,6 +40,7 @@ pub enum Constraint {
     Occurs(OccursConstraint),
     Precision(PrecisionConstraint),
     Scale(ScaleConstraint),
+    TimestampPrecision(TimestampPrecisionConstraint),
     Type(TypeConstraint),
 }
 
@@ -136,6 +137,11 @@ impl Constraint {
     /// Creates a [Constraint::Scale] from a [Range] specifying a precision range.
     pub fn scale(scale: Range) -> Constraint {
         Constraint::Scale(ScaleConstraint::new(scale))
+    }
+
+    /// Creates a [Constraint::TimestampPrecision] from a [Range] specifying a precision range.
+    pub fn timestamp_precision(precision: Range) -> Constraint {
+        Constraint::TimestampPrecision(TimestampPrecisionConstraint::new(precision))
     }
 
     /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
@@ -255,6 +261,11 @@ impl Constraint {
             IslConstraint::Scale(scale_range) => Ok(Constraint::Scale(ScaleConstraint::new(
                 scale_range.to_owned(),
             ))),
+            IslConstraint::TimestampPrecision(timestamp_precision_range) => {
+                Ok(Constraint::TimestampPrecision(
+                    TimestampPrecisionConstraint::new(timestamp_precision_range.to_owned()),
+                ))
+            }
         }
     }
 
@@ -289,6 +300,9 @@ impl Constraint {
             }
             Constraint::Precision(precision) => precision.validate(value, type_store),
             Constraint::Scale(scale) => scale.validate(value, type_store),
+            Constraint::TimestampPrecision(timestamp_precision) => {
+                timestamp_precision.validate(value, type_store)
+            }
         }
     }
 }
@@ -1404,5 +1418,30 @@ impl ConstraintValidator for ScaleConstraint {
         }
 
         Ok(())
+    }
+}
+
+/// Implements Ion Schema's `timestamp_precision` constraint
+/// [scale]: https://amzn.github.io/ion-schema/docs/spec.html#timestamp_precision
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimestampPrecisionConstraint {
+    timestamp_precision_range: Range,
+}
+
+impl TimestampPrecisionConstraint {
+    pub fn new(scale_range: Range) -> Self {
+        Self {
+            timestamp_precision_range: scale_range,
+        }
+    }
+
+    pub fn timestamp_precision(&self) -> &Range {
+        &self.timestamp_precision_range
+    }
+}
+
+impl ConstraintValidator for TimestampPrecisionConstraint {
+    fn validate(&self, value: &OwnedElement, type_store: &TypeStore) -> ValidationResult {
+        todo!()
     }
 }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::isl::util::{Annotation, Range, TimestampPrecision};
+use crate::isl::util::{Annotation, Range};
 use crate::result::{IonSchemaResult, ValidationResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::types::{TypeDefinition, TypeValidator};
@@ -1477,8 +1477,6 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
                 ));
             }
         };
-
-        let value_precision = TimestampPrecision::scale(timestamp_value);
 
         // get isl timestamp precision as a range
         let precision_range: &Range = self.timestamp_precision();

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -64,7 +64,7 @@ impl IslConstraint {
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: Range) -> IslConstraint {
         if !matches!(precision, Range::IntegerNonNegative(_, _)) {
-            panic!("precision constraint  must have a range of type IntegerNonNegative")
+            panic!("precision constraint must have a range of type IntegerNonNegative")
         }
         IslConstraint::Precision(precision)
     }
@@ -72,7 +72,7 @@ impl IslConstraint {
     /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: Range) -> IslConstraint {
         if !matches!(scale, Range::Integer(_, _)) {
-            panic!("scale constraint  must have a range of type Integer")
+            panic!("scale constraint must have a range of type Integer")
         }
         IslConstraint::Scale(scale)
     }
@@ -98,7 +98,7 @@ impl IslConstraint {
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: Range) -> IslConstraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("container_length constraint  must have a range of type IntegerNonNegative")
+            panic!("container_length constraint must have a range of type IntegerNonNegative")
         }
         IslConstraint::ContainerLength(length)
     }
@@ -106,7 +106,7 @@ impl IslConstraint {
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: Range) -> IslConstraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("byte_length constraint  must have a range of type IntegerNonNegative")
+            panic!("byte_length constraint must have a range of type IntegerNonNegative")
         }
         IslConstraint::ByteLength(length)
     }
@@ -114,7 +114,7 @@ impl IslConstraint {
     /// Creates an [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
         if !matches!(length, Range::IntegerNonNegative(_, _)) {
-            panic!("codepoint_length constraint  must have a range of type IntegerNonNegative")
+            panic!("codepoint_length constraint must have a range of type IntegerNonNegative")
         }
         IslConstraint::CodepointLength(length)
     }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -63,11 +63,17 @@ impl IslConstraint {
 
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: Range) -> IslConstraint {
+        if !matches!(precision, Range::IntegerNonNegative(_, _)) {
+            panic!("precision constraint  must have a range of type IntegerNonNegative")
+        }
         IslConstraint::Precision(precision)
     }
 
     /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: Range) -> IslConstraint {
+        if !matches!(scale, Range::Integer(_, _)) {
+            panic!("scale constraint  must have a range of type Integer")
+        }
         IslConstraint::Scale(scale)
     }
 
@@ -91,16 +97,25 @@ impl IslConstraint {
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("container_length constraint  must have a range of type IntegerNonNegative")
+        }
         IslConstraint::ContainerLength(length)
     }
 
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("byte_length constraint  must have a range of type IntegerNonNegative")
+        }
         IslConstraint::ByteLength(length)
     }
 
     /// Creates an [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("codepoint_length constraint  must have a range of type IntegerNonNegative")
+        }
         IslConstraint::CodepointLength(length)
     }
 

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -30,6 +30,7 @@ pub enum IslConstraint {
     OrderedElements(Vec<IslTypeRef>),
     Precision(Range),
     Scale(Range),
+    TimestampPrecision(Range),
     Type(IslTypeRef),
 }
 
@@ -101,6 +102,11 @@ impl IslConstraint {
     /// Creates an [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
         IslConstraint::CodepointLength(length)
+    }
+
+    /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
+    pub fn timestamp_precision(precision: Range) -> IslConstraint {
+        IslConstraint::TimestampPrecision(precision)
     }
 
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
@@ -315,12 +321,15 @@ impl IslConstraint {
             }
             "precision" => Ok(IslConstraint::Precision(Range::from_ion_element(
                 value,
-                RangeType::PrecisionRange,
+                RangeType::Precision,
             )?)),
             "scale" => Ok(IslConstraint::Scale(Range::from_ion_element(
                 value,
                 RangeType::Any,
             )?)),
+            "timestamp_precision" => Ok(IslConstraint::TimestampPrecision(
+                Range::from_ion_element(value, RangeType::TimestampPrecision)?,
+            )),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()
                     + type_name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -125,7 +125,7 @@ mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
-    use crate::isl::util::TimestampPrecisionValue;
+    use crate::isl::util::TimestampPrecision;
     use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue, RangeType};
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
@@ -382,8 +382,8 @@ mod isl_tests {
                     "#
             ),
             Range::range(
-                RangeBoundaryValue::timestamp_precision_value(TimestampPrecisionValue::Year, RangeBoundaryType::Inclusive),
-                RangeBoundaryValue::timestamp_precision_value(TimestampPrecisionValue::Month, RangeBoundaryType::Inclusive)
+                RangeBoundaryValue::timestamp_precision_value(TimestampPrecision::Year, RangeBoundaryType::Inclusive),
+                RangeBoundaryValue::timestamp_precision_value(TimestampPrecision::Month, RangeBoundaryType::Inclusive)
             )
         )
     )]

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -291,6 +291,12 @@ mod isl_tests {
                     "#),
         IslType::anonymous([IslConstraint::scale((&IntegerValue::I64(2)).into())])
     ),
+    case::timestamp_precision_constraint(
+        load_anonymous_type(r#" // For a schema with timestamp_precision constraint as below:
+                            { timestamp_precision: year }
+                        "#),
+        IslType::anonymous([IslConstraint::timestamp_precision("year".try_into().unwrap())])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name
@@ -304,6 +310,16 @@ mod isl_tests {
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
             RangeType::Any,
+        )
+    }
+
+    // helper function to create a timestamp precision range
+    fn load_timestamp_precision_range(text: &str) -> IonSchemaResult<Range> {
+        Range::from_ion_element(
+            &element_reader()
+                .read_one(text.as_bytes())
+                .expect("parsing failed unexpectedly"),
+            RangeType::TimestampPrecision,
         )
     }
 
@@ -360,7 +376,7 @@ mod isl_tests {
             )
         ),
         case::range_with_timestamp_precision(
-            load_range(
+            load_timestamp_precision_range(
             r#"
                         range::[year, month]
                     "#
@@ -527,7 +543,7 @@ mod isl_tests {
             elements(&[-1e2 ,1e1, 6e2, 1e2, 5e2, f64::NAN])
         ),
         case::timestamp_precision_range(
-            load_range(
+            load_timestamp_precision_range(
             r#"
                 range::[minute, second]
             "#

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -727,57 +727,30 @@ impl TimestampPrecision {
 impl PartialOrd for TimestampPrecision {
     fn partial_cmp(&self, other: &TimestampPrecision) -> Option<Ordering> {
         use TimestampPrecision::*;
-        Some(match self {
-            Year => match other {
-                Year => Ordering::Equal,
-                _ => Ordering::Less,
-            },
-            Month => match other {
-                Year => Ordering::Greater,
-                Month => Ordering::Equal,
-                _ => Ordering::Less,
-            },
-            Day => match other {
-                Year | Month => Ordering::Greater,
-                Day => Ordering::Equal,
-                _ => Ordering::Less,
-            },
-            Minute => match other {
-                Year | Month | Day => Ordering::Greater,
-                Minute => Ordering::Equal,
-                _ => Ordering::Less,
-            },
-            Second => match other {
-                Second => Ordering::Equal,
-                Millisecond | Microsecond | Nanosecond | OtherFractionalSeconds(_) => {
-                    Ordering::Less
-                }
-                _ => Ordering::Greater,
-            },
-            Millisecond => match other {
-                Millisecond => Ordering::Equal,
-                Microsecond | Nanosecond => Ordering::Less,
-                OtherFractionalSeconds(other_scale) => return 3.partial_cmp(other_scale),
-                _ => Ordering::Greater,
-            },
-            Microsecond => match other {
-                Microsecond => Ordering::Equal,
-                Nanosecond => Ordering::Less,
-                OtherFractionalSeconds(other_scale) => return 6.partial_cmp(other_scale),
-                _ => Ordering::Greater,
-            },
-            Nanosecond => match other {
-                Nanosecond => Ordering::Equal,
-                OtherFractionalSeconds(other_scale) => return 9.partial_cmp(other_scale),
-                _ => Ordering::Greater,
-            },
-            OtherFractionalSeconds(scale) => match other {
-                OtherFractionalSeconds(other_scale) => return scale.partial_cmp(other_scale),
-                Millisecond => return scale.partial_cmp(&3),
-                Microsecond => return scale.partial_cmp(&6),
-                Nanosecond => return scale.partial_cmp(&9),
-                _ => Ordering::Greater,
-            },
-        })
+        let self_value = match self {
+            Year => -4,
+            Month => -3,
+            Day => -2,
+            Minute => -1,
+            Second => 0,
+            Millisecond => 3,
+            Microsecond => 6,
+            Nanosecond => 9,
+            OtherFractionalSeconds(scale) => *scale,
+        };
+
+        let other_value = match other {
+            Year => -4,
+            Month => -3,
+            Day => -2,
+            Minute => -1,
+            Second => 0,
+            Millisecond => 3,
+            Microsecond => 6,
+            Nanosecond => 9,
+            OtherFractionalSeconds(scale) => *scale,
+        };
+
+        Some(self_value.cmp(&other_value))
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -532,7 +532,7 @@ impl RangeBoundaryValue {
         range_boundary_type: RangeBoundaryType,
     ) -> Self {
         RangeBoundaryValue::Value(
-            RangeBoundaryValueType::TimestampPrecision(value as i64),
+            RangeBoundaryValueType::TimestampPrecision(value.into()),
             range_boundary_type,
         )
     }
@@ -556,35 +556,35 @@ impl RangeBoundaryValue {
                     "min" => Ok(RangeBoundaryValue::Min),
                     "max" => Ok(RangeBoundaryValue::Max),
                     "year" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Year as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Year.into()),
                         range_boundary_type,
                     )),
                     "month" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Month as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Month.into()),
                         range_boundary_type,
                     )),
                     "day" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Day as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Day.into()),
                         range_boundary_type,
                     )),
                     "minute" | "hour" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Minute as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Minute.into()),
                         range_boundary_type,
                     )),
                     "second" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Second as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Second.into()),
                         range_boundary_type,
                     )),
                     "millisecond" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Millisecond as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Millisecond.into()),
                         range_boundary_type,
                     )),
                     "microsecond" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Microsecond as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Microsecond.into()),
                         range_boundary_type,
                     )),
                     "nanosecond" => Ok(RangeBoundaryValue::Value(
-                        RangeBoundaryValueType::TimestampPrecision(Nanosecond as i64),
+                        RangeBoundaryValueType::TimestampPrecision(Nanosecond.into()),
                         range_boundary_type,
                     )),
                     _ => {
@@ -688,29 +688,43 @@ impl Annotation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TimestampPrecision {
-    Year = -4,
-    Month = -3,
-    Day = -2,
-    Minute = -1,
-    Second = 0,
-    Millisecond = 3,
-    Microsecond = 6,
-    Nanosecond = 9,
+    Year,
+    Month,
+    Day,
+    Minute,
+    Second,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
 }
 
 impl TimestampPrecision {
     pub fn scale(timestamp_value: &Timestamp) -> i64 {
-        use TimestampPrecision::*;
         let precision_value = timestamp_value.precision();
         match precision_value {
-            Precision::Year => Year as i64,
-            Precision::Month => Month as i64,
-            Precision::Day => Day as i64,
-            Precision::HourAndMinute => Minute as i64,
-            Precision::Second => Second as i64,
+            Precision::Year => -4,
+            Precision::Month => -3,
+            Precision::Day => -2,
+            Precision::HourAndMinute => -1,
+            Precision::Second => 0,
             Precision::FractionalSeconds => timestamp_value.fractional_seconds_scale().unwrap(),
+        }
+    }
+}
+
+impl Into<i64> for TimestampPrecision {
+    fn into(self) -> i64 {
+        match self {
+            TimestampPrecision::Year => -4,
+            TimestampPrecision::Month => -3,
+            TimestampPrecision::Day => -2,
+            TimestampPrecision::Minute => -1,
+            TimestampPrecision::Second => 0,
+            TimestampPrecision::Millisecond => 3,
+            TimestampPrecision::Microsecond => 6,
+            TimestampPrecision::Nanosecond => 9,
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -676,6 +676,25 @@ mod schema_tests {
                         "#),
             "scale_type"
         ),
+        case::timestamp_precision_constraint(
+            load(r#"
+                          2000-01T
+                          2000-01-01T
+                          2000-01-01T00:00Z
+                          2000-01-01T00:00:00Z
+                        "#),
+            load(r#"
+                          2000T
+                          2000-01-01T00:00:00.0Z
+                          null
+                          null.timestamp
+                          null.symbol
+                        "#),
+            load_schema_from_text(r#" // For a schema with timestamp precision constraint as below:
+                                type::{ name: timestamp_precision_type, timestamp_precision: range::[month, second] }
+                        "#),
+            "timestamp_precision_type"
+        ),
     )]
     fn type_validation(
         valid_values: Vec<OwnedElement>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -250,6 +250,12 @@ mod schema_tests {
                     type:: { name: scale_type, scale: 2 }
                  "#).into_iter(),
         1 // this includes named type scale_type
+    ),
+    case::timestamp_precision_constraint(
+        load(r#" // For a schema with timestamp_precision constraint as below:
+                    type:: { name: timestamp_precision_type, timestamp_precision: month }
+                 "#).into_iter(),
+        1 // this includes named type timestamp_precision_type
     )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(

--- a/src/types.rs
+++ b/src/types.rs
@@ -496,6 +496,13 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::scale(2.into())]),
         TypeDefinition::anonymous([Constraint::scale(2.into()), Constraint::type_constraint(25)])
     ),
+    case::timestamp_precision_constraint(
+        /* For a schema with timestamp_precision constraint as below:
+            { timestamp_precision: month }
+        */
+        IslType::anonymous([IslConstraint::timestamp_precision("month".try_into().unwrap())]),
+        TypeDefinition::anonymous([Constraint::timestamp_precision("month".try_into().unwrap()), Constraint::type_constraint(25)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,6 +351,7 @@ mod type_definition_tests {
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::system::PendingTypes;
+    use ion_rs::Integer;
     use rstest::*;
 
     // TODO: Remove type ids for assertion to make tests more readable
@@ -493,8 +494,8 @@ mod type_definition_tests {
         /* For a schema with scale constraint as below:
             { scale: 2 }
         */
-        IslType::anonymous([IslConstraint::scale(2.into())]),
-        TypeDefinition::anonymous([Constraint::scale(2.into()), Constraint::type_constraint(25)])
+        IslType::anonymous([IslConstraint::scale((&Integer::I64(2)).into())]),
+        TypeDefinition::anonymous([Constraint::scale((&Integer::I64(2)).into()), Constraint::type_constraint(25)])
     ),
     case::timestamp_precision_constraint(
         /* For a schema with timestamp_precision constraint as below:

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -52,6 +52,8 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/precision/validation.isl",
     "ion-schema-tests/constraints/scale/validation.isl",
     "ion-schema-tests/constraints/scale/invalid.isl",
+    "ion-schema-tests/constraints/timestamp_precision/validation.isl",
+    "ion-schema-tests/constraints/timestamp_precision/invalid.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -69,6 +71,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/annotations/*.isl")]
 #[test_resources("ion-schema-tests/constraints/precision/*.isl")]
 #[test_resources("ion-schema-tests/constraints/scale/*.isl")]
+#[test_resources("ion-schema-tests/constraints/timestamp_precision/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `timestamp_precision` constraint.

*Grammar:*
```ANTLR
<TIMESTAMP_PRECISION_VALUE> ::= year
                              | month
                              | day
                              | minute
                              | second
                              | millisecond
                              | microsecond
                              | nanosecond

<TIMESTAMP_PRECISION> ::= timestamp_precision: <TIMESTAMP_PRECISION_VALUE>
                        | timestamp_precision: <RANGE<TIMESTAMP_PRECISION_VALUE>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#timestamp_precision

*List of changes:*
* adds `TimestampPrecison` range implementation
* adds `TimestampPrecison` enum variants for `IslConstraint` and `Constraint`
* adds `TimestampPrecisonConstraint` implementations
* adds changes for validating timestamp precision range (_Note: timestamp precision range must be equal to or greater than 1_)
* adds validation logic for timestamp precision

*Tests:*
added unit tests for `timestamp_precision` implementation.
- adds tests for programmatically creating `timestamp_precision` constraint
- adds tests for loading a schema using `timestamp_precision` constraint 
- adds validation tests for `timestamp_precision` constraint

