### PR TITLE
adds usage examples for documentation of `system` and `authority`

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,8 @@
+//! Represents the `IonSchemaResult` type for error handling.
+//!
+//! [`IonSchemaResult<T, E>`][`IonSchemaResult`]  is the type used for returning and propagating errors.
+//! It is an enum with the variants, Ok(T), representing success and containing a value,and Err(E), representing an [`IonSchemaError`].
+
 use crate::violation::Violation;
 use ion_rs::result::IonError;
 use std::io;


### PR DESCRIPTION
*Issue #80*

*Description of changes:*
This PR adds more documentation around usage of `system` and `authority` modules.

*List of changes:*
- adds example for `SchemaSystem` usage.
- adds example for `DocumentAuthority` usage.
- makes `TypeStore` and `PendingTypes` method `pub(crate)`.  These structs are only used for internal implementation.
- adds document comments for `result` module.
- changed incorrect document type links to struct/trait definitions.