### PR TITLE
adds `timetstamp_precision` constraint implementation with fractional seconds related change

### DIFF
--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -30,6 +30,7 @@ pub enum IslConstraint {
     OrderedElements(Vec<IslTypeRef>),
     Precision(Range),
     Scale(Range),
+    TimestampPrecision(Range),
     Type(IslTypeRef),
 }
 
@@ -62,11 +63,17 @@ impl IslConstraint {
 
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: Range) -> IslConstraint {
+        if !matches!(precision, Range::IntegerNonNegative(_, _)) {
+            panic!("precision constraint must have a range of type IntegerNonNegative")
+        }
         IslConstraint::Precision(precision)
     }
 
     /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: Range) -> IslConstraint {
+        if !matches!(scale, Range::Integer(_, _)) {
+            panic!("scale constraint must have a range of type Integer")
+        }
         IslConstraint::Scale(scale)
     }
 
@@ -90,17 +97,31 @@ impl IslConstraint {
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("container_length constraint must have a range of type IntegerNonNegative")
+        }
         IslConstraint::ContainerLength(length)
     }
 
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("byte_length constraint must have a range of type IntegerNonNegative")
+        }
         IslConstraint::ByteLength(length)
     }
 
     /// Creates an [IslConstraint::CodePointLength] using the range specified in it
     pub fn codepoint_length(length: Range) -> IslConstraint {
+        if !matches!(length, Range::IntegerNonNegative(_, _)) {
+            panic!("codepoint_length constraint must have a range of type IntegerNonNegative")
+        }
         IslConstraint::CodepointLength(length)
+    }
+
+    /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
+    pub fn timestamp_precision(precision: Range) -> IslConstraint {
+        IslConstraint::TimestampPrecision(precision)
     }
 
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
@@ -315,12 +336,15 @@ impl IslConstraint {
             }
             "precision" => Ok(IslConstraint::Precision(Range::from_ion_element(
                 value,
-                RangeType::PrecisionRange,
+                RangeType::Precision,
             )?)),
             "scale" => Ok(IslConstraint::Scale(Range::from_ion_element(
                 value,
                 RangeType::Any,
             )?)),
+            "timestamp_precision" => Ok(IslConstraint::TimestampPrecision(
+                Range::from_ion_element(value, RangeType::TimestampPrecision)?,
+            )),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()
                     + type_name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -125,6 +125,7 @@ mod isl_tests {
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::util::TimestampPrecision;
     use crate::isl::util::{Range, RangeBoundaryType, RangeBoundaryValue, RangeType};
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
@@ -290,6 +291,12 @@ mod isl_tests {
                     "#),
         IslType::anonymous([IslConstraint::scale((&IntegerValue::I64(2)).into())])
     ),
+    case::timestamp_precision_constraint(
+        load_anonymous_type(r#" // For a schema with timestamp_precision constraint as below:
+                            { timestamp_precision: year }
+                        "#),
+        IslType::anonymous([IslConstraint::timestamp_precision("year".try_into().unwrap())])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name
@@ -303,6 +310,16 @@ mod isl_tests {
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
             RangeType::Any,
+        )
+    }
+
+    // helper function to create a timestamp precision range
+    fn load_timestamp_precision_range(text: &str) -> IonSchemaResult<Range> {
+        Range::from_ion_element(
+            &element_reader()
+                .read_one(text.as_bytes())
+                .expect("parsing failed unexpectedly"),
+            RangeType::TimestampPrecision,
         )
     }
 
@@ -356,6 +373,17 @@ mod isl_tests {
             Range::range(
                 RangeBoundaryValue::timestamp_value(Timestamp::with_year(2020).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive),
                 RangeBoundaryValue::timestamp_value(Timestamp::with_year(2021).with_month(1).with_day(1).build().unwrap(), RangeBoundaryType::Inclusive)
+            )
+        ),
+        case::range_with_timestamp_precision(
+            load_timestamp_precision_range(
+            r#"
+                        range::[year, month]
+                    "#
+            ),
+            Range::range(
+                RangeBoundaryValue::timestamp_precision_value(TimestampPrecision::Year, RangeBoundaryType::Inclusive),
+                RangeBoundaryValue::timestamp_precision_value(TimestampPrecision::Month, RangeBoundaryType::Inclusive)
             )
         )
     )]
@@ -506,13 +534,24 @@ mod isl_tests {
             elements(&[-5e5, 1e2, f64::NAN])
         ),
         case::float_range_with_exclusive(
-        load_range(
+            load_range(
             r#"
                 range::[exclusive::1e2, exclusive::5e2]
             "#
             ),
             elements(&[2e2]),
             elements(&[-1e2 ,1e1, 6e2, 1e2, 5e2, f64::NAN])
+        ),
+        case::timestamp_precision_range(
+            load_timestamp_precision_range(
+            r#"
+                range::[minute, second]
+            "#
+            ),
+            elements(&[Timestamp::with_ymd(2020, 1, 1).with_hms(0, 1, 0).build_at_offset(4 * 60).unwrap(),
+                Timestamp::with_ymd(2020, 1, 1).with_hour_and_minute(0, 1).build_at_offset(4 * 60).unwrap()]),
+            elements(&[Timestamp::with_year(2020).build().unwrap(),
+                Timestamp::with_ymd(2020, 1, 1).with_hms(0, 1, 0).with_milliseconds(678).build_at_offset(4 * 60).unwrap()])
         ),
     )]
     fn range_contains(

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -1,12 +1,16 @@
-use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
+use crate::isl::util::TimestampPrecision as TimestampPrecisionValue;
+use crate::result::{
+    invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
+};
 use ion_rs::types::decimal::Decimal;
 use ion_rs::types::integer::IntAccess;
-use ion_rs::types::timestamp::Timestamp;
+use ion_rs::types::timestamp::{Precision, Timestamp};
 use ion_rs::value::owned::{text_token, OwnedElement};
 use ion_rs::value::{Element, Sequence, SymbolToken};
 use ion_rs::{Integer as IntegerValue, IonType};
 use num_bigint::BigInt;
-use std::convert::TryInto;
+use std::cmp::Ordering;
+use std::convert::{TryFrom, TryInto};
 
 /// Represents ISL [Range]s where some constraints can be defined by a range
 /// <RANGE<RANGE_TYPE>> ::= range::[ <EXCLUSIVITY><RANGE_TYPE>, <EXCLUSIVITY><RANGE_TYPE> ]
@@ -26,6 +30,7 @@ pub enum Range {
     Integer(RangeBoundaryValue, RangeBoundaryValue),
     IntegerNonNegative(RangeBoundaryValue, RangeBoundaryValue),
     Timestamp(RangeBoundaryValue, RangeBoundaryValue),
+    TimestampPrecision(RangeBoundaryValue, RangeBoundaryValue),
 }
 
 impl Range {
@@ -188,6 +193,39 @@ impl Range {
                 // TODO: Implement this section once the timestamp comparator for ion-rust is implemented
                 todo!()
             }
+            Range::TimestampPrecision(start, end) => {
+                let value = &value.as_timestamp().ok_or_else(|| {
+                    invalid_schema_error_raw(
+                        "Timestamp Precision ranges can only have timestamp value for validation",
+                    )
+                })?;
+
+                let value = TimestampPrecisionValue::from_timestamp(value);
+                let is_in_lower_bound = match start {
+                    Min => true,
+                    Value(start_value, boundary_type) => match start_value {
+                        TimestampPrecision(min_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => min_value <= &value,
+                            RangeBoundaryType::Exclusive => min_value < &value,
+                        },
+                        _ => unreachable!("TimestampPrecision range can only have timestamp precisions as lower and upper range boundary value"),
+                    },
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
+
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        TimestampPrecision(max_value) => match boundary_type {
+                            RangeBoundaryType::Inclusive => max_value >= &value,
+                            RangeBoundaryType::Exclusive => max_value > &value,
+                        },
+                        _ => unreachable!("TimestampPrecision range can only have timestamp precisions as lower and upper range boundary value"),
+                    }
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
+            }
         }
     }
 
@@ -216,6 +254,7 @@ impl Range {
                     (Decimal(_), Decimal(_)) => {}
                     (Float(_), Float(_)) => {}
                     (Timestamp(_), Timestamp(_)) => {},
+                    (TimestampPrecision(_), TimestampPrecision(_)) => {},
                     _ => {
                         return invalid_schema_error("Both range boundary values must be of same type")
                     }
@@ -241,50 +280,67 @@ impl Range {
             Float(_) => Range::Float(start, end),
             Timestamp(_) => Range::Timestamp(start, end),
             IntegerNonNegative(_) => Range::IntegerNonNegative(start, end),
+            TimestampPrecision(_) => Range::TimestampPrecision(start, end),
         })
     }
 
     pub fn from_ion_element(value: &OwnedElement, range_type: RangeType) -> IonSchemaResult<Range> {
         // if an integer value is passed here then convert it into a range
         // eg. if `1` is passed as value then return a range [1,1]
-        if let Some(integer_value) = value.as_integer() {
-            return if range_type == RangeType::NonNegativeInteger
-                || range_type == RangeType::PrecisionRange
-            {
-                let non_negative_integer_value =
-                    Range::validate_non_negative_integer_range_boundary_value(
-                        value.as_integer().unwrap(),
-                        &range_type,
-                    )?;
-                Ok(non_negative_integer_value.into())
+        return if let Some(integer_value) = value.as_integer() {
+            match range_type {
+                RangeType::Precision | RangeType::NonNegativeInteger => {
+                    let non_negative_integer_value =
+                        Range::validate_non_negative_integer_range_boundary_value(
+                            value.as_integer().unwrap(),
+                            &range_type,
+                        )?;
+                    Ok(non_negative_integer_value.into())
+                }
+                RangeType::TimestampPrecision => invalid_schema_error(format!(
+                    "Timestamp precision ranges can not be constructed from value of type {}",
+                    value.ion_type()
+                )),
+                RangeType::Any => Ok(integer_value.into()),
+            }
+        } else if let Some(timestamp_precision) = value.as_str() {
+            if range_type == RangeType::TimestampPrecision {
+                timestamp_precision.try_into()
             } else {
-                Ok(integer_value.into())
-            };
-        }
+                invalid_schema_error(format!(
+                    "{:?} ranges can not be constructed from value of type {}",
+                    range_type,
+                    value.ion_type()
+                ))
+            }
+        } else if let Some(range) = value.as_sequence() {
+            // verify if the value has annotation range
+            if !value.annotations().any(|a| a == &text_token("range")) {
+                return invalid_schema_error(
+                    "An element representing range must have annotation `range::` with it.",
+                );
+            }
 
-        let range = try_to!(value.as_sequence());
+            if range.len() != 2 {
+                return invalid_schema_error(
+                    "Ranges must contain two values representing minimum and maximum ends of range.",
+                );
+            }
 
-        // verify if the value has annotation range
-        if !value.annotations().any(|a| a == &text_token("range")) {
-            return invalid_schema_error(
-                "An element representing range must have annotation `range::` with it.",
-            );
-        }
+            // set start of the range
+            let start = RangeBoundaryValue::from_ion_element(try_to!(range.get(0)), &range_type)?;
 
-        if range.len() != 2 {
-            return invalid_schema_error(
-                "Ranges must contain two values representing minimum and maximum ends of range.",
-            );
-        }
+            // set end of the range
+            let end = RangeBoundaryValue::from_ion_element(try_to!(range.get(1)), &range_type)?;
 
-        // set start of the range
-        let start = RangeBoundaryValue::from_ion_element(try_to!(range.get(0)), &range_type)?;
-
-        // set end of the range
-        let end = RangeBoundaryValue::from_ion_element(try_to!(range.get(1)), &range_type)?;
-
-        // validate both range boundary values and returns created `Range`
-        Range::range(start, end)
+            // validate both range boundary values and returns created `Range`
+            Range::range(start, end)
+        } else {
+            invalid_schema_error(format!(
+                "Ranges can not be constructed for type {}",
+                value.ion_type()
+            ))
+        };
     }
 
     // helper method to which validates a non negative integer range boundary value
@@ -294,7 +350,7 @@ impl Range {
     ) -> IonSchemaResult<usize> {
         // minimum precision must be greater than or equal to 1
         // for more information: https://amzn.github.io/ion-schema/docs/spec.html#precision
-        let min_value = if range_type == &RangeType::PrecisionRange {
+        let min_value = if range_type == &RangeType::Precision {
             1
         } else {
             0
@@ -386,13 +442,47 @@ impl From<usize> for Range {
     }
 }
 
-/// Provides `Range` for given `usize`
+/// Provides `Range` for given `Integer`
 impl From<&IntegerValue> for Range {
     fn from(int_value: &IntegerValue) -> Self {
         Range::Integer(
             RangeBoundaryValue::int_value(int_value.to_owned(), RangeBoundaryType::Inclusive),
             RangeBoundaryValue::int_value(int_value.to_owned(), RangeBoundaryType::Inclusive),
         )
+    }
+}
+
+/// Provides `Range` for given `&str`
+impl TryFrom<&str> for Range {
+    type Error = IonSchemaError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let timestamp_precision = match value {
+            "year" => TimestampPrecision::Year,
+            "month" => TimestampPrecision::Month,
+            "day" => TimestampPrecision::Day,
+            "minute" | "hour" => TimestampPrecision::Minute,
+            "second" => TimestampPrecision::Second,
+            "millisecond" => TimestampPrecision::Millisecond,
+            "microsecond" => TimestampPrecision::Microsecond,
+            "nanosecond" => TimestampPrecision::Nanosecond,
+            _ => {
+                return invalid_schema_error(format!(
+                    "Timestamp precision value: {} is not allowed",
+                    value
+                ))
+            }
+        };
+        Ok(Range::TimestampPrecision(
+            RangeBoundaryValue::timestamp_precision_value(
+                timestamp_precision.to_owned(),
+                RangeBoundaryType::Inclusive,
+            ),
+            RangeBoundaryValue::timestamp_precision_value(
+                timestamp_precision,
+                RangeBoundaryType::Inclusive,
+            ),
+        ))
     }
 }
 
@@ -404,6 +494,7 @@ pub enum RangeBoundaryValueType {
     Integer(IntegerValue),
     IntegerNonNegative(usize),
     Timestamp(Timestamp),
+    TimestampPrecision(TimestampPrecision),
 }
 
 /// Represents a range boundary value (i.e. min, max or a value in terms of [RangeBoundaryValueType])
@@ -418,21 +509,35 @@ impl RangeBoundaryValue {
     pub fn int_value(value: IntegerValue, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(RangeBoundaryValueType::Integer(value), range_boundary_type)
     }
+
     pub fn int_non_negative_value(value: usize, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(
             RangeBoundaryValueType::IntegerNonNegative(value),
             range_boundary_type,
         )
     }
+
     pub fn float_value(value: f64, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(RangeBoundaryValueType::Float(value), range_boundary_type)
     }
+
     pub fn timestamp_value(value: Timestamp, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(
             RangeBoundaryValueType::Timestamp(value),
             range_boundary_type,
         )
     }
+
+    pub fn timestamp_precision_value(
+        value: TimestampPrecision,
+        range_boundary_type: RangeBoundaryType,
+    ) -> Self {
+        RangeBoundaryValue::Value(
+            RangeBoundaryValueType::TimestampPrecision(value),
+            range_boundary_type,
+        )
+    }
+
     pub fn decimal_value(value: Decimal, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(RangeBoundaryValueType::Decimal(value), range_boundary_type)
     }
@@ -446,10 +551,43 @@ impl RangeBoundaryValue {
 
         match value.ion_type() {
             IonType::Symbol => {
+                use TimestampPrecision::*;
                 let sym = try_to!(try_to!(value.as_sym()).text());
                 match sym {
                     "min" => Ok(RangeBoundaryValue::Min),
                     "max" => Ok(RangeBoundaryValue::Max),
+                    "year" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Year),
+                        range_boundary_type,
+                    )),
+                    "month" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Month),
+                        range_boundary_type,
+                    )),
+                    "day" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Day),
+                        range_boundary_type,
+                    )),
+                    "minute" | "hour" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Minute),
+                        range_boundary_type,
+                    )),
+                    "second" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Second),
+                        range_boundary_type,
+                    )),
+                    "millisecond" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Millisecond),
+                        range_boundary_type,
+                    )),
+                    "microsecond" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Microsecond),
+                        range_boundary_type,
+                    )),
+                    "nanosecond" => Ok(RangeBoundaryValue::Value(
+                        RangeBoundaryValueType::TimestampPrecision(Nanosecond),
+                        range_boundary_type,
+                    )),
                     _ => {
                         return invalid_schema_error(format!(
                             "Range boundary value: {} is not supported",
@@ -459,7 +597,7 @@ impl RangeBoundaryValue {
                 }
             }
             IonType::Integer => match range_type {
-                RangeType::PrecisionRange | RangeType::NonNegativeInteger => {
+                RangeType::Precision | RangeType::NonNegativeInteger => {
                     let non_negative_integer_value =
                         Range::validate_non_negative_integer_range_boundary_value(
                             value.as_integer().unwrap(),
@@ -474,6 +612,9 @@ impl RangeBoundaryValue {
                     value.as_integer().unwrap().to_owned(),
                     range_boundary_type,
                 )),
+                RangeType::TimestampPrecision => invalid_schema_error(
+                    "Timestamp precision ranges can not be constructed for integer boundary values",
+                ),
             },
             IonType::Decimal => Ok(RangeBoundaryValue::decimal_value(
                 value.as_decimal().unwrap().to_owned(),
@@ -504,9 +645,10 @@ pub enum RangeBoundaryType {
 /// to explicitly state if its non negative or not
 #[derive(Debug, Clone, PartialEq)]
 pub enum RangeType {
-    PrecisionRange, // used by precision constraint to specify non negative integer precision with minimum value as `1`
+    Precision, // used by precision constraint to specify non negative integer precision with minimum value as `1`
     NonNegativeInteger, // used by byte_length, container_length and codepoint_length to specify non negative integer range
-    Any,                // used for any other range types (e.g. Integer, Float, Timestamp, Decimal)
+    TimestampPrecision, //used by timestamp_precision to specify timestamp precision range
+    Any,                // used for any range types (e.g. Integer, Float, Timestamp, Decimal)
 }
 
 /// Represents an annotation for [annotations] constraint.
@@ -544,5 +686,71 @@ impl Annotation {
             // for any value the default annotation is `optional`
             false
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TimestampPrecision {
+    Year,
+    Month,
+    Day,
+    Minute,
+    Second,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
+    OtherFractionalSeconds(i64),
+}
+
+impl TimestampPrecision {
+    pub fn from_timestamp(timestamp_value: &Timestamp) -> TimestampPrecision {
+        use TimestampPrecision::*;
+        let precision_value = timestamp_value.precision();
+        match precision_value {
+            Precision::Year => Year,
+            Precision::Month => Month,
+            Precision::Day => Day,
+            Precision::HourAndMinute => Minute,
+            Precision::Second => Second,
+            Precision::FractionalSeconds => {
+                match timestamp_value.fractional_seconds_scale().unwrap() {
+                    3 => Millisecond,
+                    6 => Microsecond,
+                    9 => Nanosecond,
+                    scale => OtherFractionalSeconds(scale),
+                }
+            }
+        }
+    }
+}
+
+impl PartialOrd for TimestampPrecision {
+    fn partial_cmp(&self, other: &TimestampPrecision) -> Option<Ordering> {
+        use TimestampPrecision::*;
+        let self_value = match self {
+            Year => -4,
+            Month => -3,
+            Day => -2,
+            Minute => -1,
+            Second => 0,
+            Millisecond => 3,
+            Microsecond => 6,
+            Nanosecond => 9,
+            OtherFractionalSeconds(scale) => *scale,
+        };
+
+        let other_value = match other {
+            Year => -4,
+            Month => -3,
+            Day => -2,
+            Minute => -1,
+            Second => 0,
+            Millisecond => 3,
+            Microsecond => 6,
+            Nanosecond => 9,
+            OtherFractionalSeconds(scale) => *scale,
+        };
+
+        Some(self_value.cmp(&other_value))
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -711,15 +711,13 @@ impl TimestampPrecision {
             Precision::Month => Month,
             Precision::Day => Day,
             Precision::HourAndMinute => Minute,
-            Precision::Second => Second,
-            Precision::FractionalSeconds => {
-                match timestamp_value.fractional_seconds_scale().unwrap() {
-                    3 => Millisecond,
-                    6 => Microsecond,
-                    9 => Nanosecond,
-                    scale => OtherFractionalSeconds(scale),
-                }
-            }
+            Precision::Second => match timestamp_value.fractional_seconds_scale().unwrap_or(0) {
+                0 => Second,
+                3 => Millisecond,
+                6 => Microsecond,
+                9 => Nanosecond,
+                scale => OtherFractionalSeconds(scale),
+            },
         }
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -711,6 +711,9 @@ impl TimestampPrecision {
             Precision::Month => Month,
             Precision::Day => Day,
             Precision::HourAndMinute => Minute,
+            // `unwrap_or(0)` is a default to set second as timestamp precision.
+            // currently `fractional_seconds_scale` doesn't return 0 for Precision::Second,
+            // once that is fixed in ion-rust we can remove unwrap_or from here
             Precision::Second => match timestamp_value.fractional_seconds_scale().unwrap_or(0) {
                 0 => Second,
                 3 => Millisecond,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -250,6 +250,12 @@ mod schema_tests {
                     type:: { name: scale_type, scale: 2 }
                  "#).into_iter(),
         1 // this includes named type scale_type
+    ),
+    case::timestamp_precision_constraint(
+        load(r#" // For a schema with timestamp_precision constraint as below:
+                    type:: { name: timestamp_precision_type, timestamp_precision: month }
+                 "#).into_iter(),
+        1 // this includes named type timestamp_precision_type
     )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
@@ -669,6 +675,25 @@ mod schema_tests {
                                 type::{ name: scale_type, scale: range::[min, 4] }
                         "#),
             "scale_type"
+        ),
+        case::timestamp_precision_constraint(
+            load(r#"
+                          2000-01T
+                          2000-01-01T
+                          2000-01-01T00:00Z
+                          2000-01-01T00:00:00Z
+                        "#),
+            load(r#"
+                          2000T
+                          2000-01-01T00:00:00.0Z
+                          null
+                          null.timestamp
+                          null.symbol
+                        "#),
+            load_schema_from_text(r#" // For a schema with timestamp precision constraint as below:
+                                type::{ name: timestamp_precision_type, timestamp_precision: range::[month, second] }
+                        "#),
+            "timestamp_precision_type"
         ),
     )]
     fn type_validation(

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,6 +351,7 @@ mod type_definition_tests {
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::system::PendingTypes;
+    use ion_rs::Integer;
     use rstest::*;
 
     // TODO: Remove type ids for assertion to make tests more readable
@@ -493,8 +494,15 @@ mod type_definition_tests {
         /* For a schema with scale constraint as below:
             { scale: 2 }
         */
-        IslType::anonymous([IslConstraint::scale(2.into())]),
-        TypeDefinition::anonymous([Constraint::scale(2.into()), Constraint::type_constraint(25)])
+        IslType::anonymous([IslConstraint::scale((&Integer::I64(2)).into())]),
+        TypeDefinition::anonymous([Constraint::scale((&Integer::I64(2)).into()), Constraint::type_constraint(25)])
+    ),
+    case::timestamp_precision_constraint(
+        /* For a schema with timestamp_precision constraint as below:
+            { timestamp_precision: month }
+        */
+        IslType::anonymous([IslConstraint::timestamp_precision("month".try_into().unwrap())]),
+        TypeDefinition::anonymous([Constraint::timestamp_precision("month".try_into().unwrap()), Constraint::type_constraint(25)])
     ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -52,6 +52,8 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/precision/validation.isl",
     "ion-schema-tests/constraints/scale/validation.isl",
     "ion-schema-tests/constraints/scale/invalid.isl",
+    "ion-schema-tests/constraints/timestamp_precision/validation.isl",
+    "ion-schema-tests/constraints/timestamp_precision/invalid.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -69,6 +71,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/annotations/*.isl")]
 #[test_resources("ion-schema-tests/constraints/precision/*.isl")]
 #[test_resources("ion-schema-tests/constraints/scale/*.isl")]
+#[test_resources("ion-schema-tests/constraints/timestamp_precision/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Description of changes:*
This PR adds the reverted change for timestamp_precision constraint implementation and adds fractional seconds related changes.

*Changes:*
The second commit is the fractional seconds related change (https://github.com/amzn/ion-schema-rust/pull/90/commits/37797f2219bb13a267e0d4e18d2fd1f23462e521)
First commit is just the same as reverted commit  (#87)

*Test:*
Ran all unit tests for this change.