### PR TITLE
adds implementation of `valid_values` constraint

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -173,8 +173,8 @@ impl Constraint {
         Constraint::Fields(FieldsConstraint::new(fields.collect(), true))
     }
 
-    /// Creates a [Constraint::ValidValues] using the [OwnedElements] specified inside it
-    /// Returns an IonSchemaError if the OwnedElement contains annotation except `range` annotation
+    /// Creates a [Constraint::ValidValues] using the [OwnedElement]s specified inside it
+    /// Returns an IonSchemaError if any of the OwnedElements have an annotation other than `range`
     pub fn valid_values_with_values(values: Vec<OwnedElement>) -> IonSchemaResult<Constraint> {
         let valid_values: IonSchemaResult<Vec<ValidValue>> =
             values.iter().map(|e| e.try_into()).collect();

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -517,7 +517,7 @@ impl TryFrom<&OwnedElement> for IslValidValuesConstraint {
     fn try_from(value: &OwnedElement) -> IonSchemaResult<Self> {
         if value.annotations().any(|a| a == &text_token("range")) {
             return IslValidValuesConstraint::new(vec![ValidValue::Range(
-                Range::from_ion_element(value, RangeType::Number)?,
+                Range::from_ion_element(value, RangeType::NumberOrTimestamp)?,
             )]);
         }
         if let Some(values) = value.as_sequence() {

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -516,9 +516,9 @@ impl TryFrom<&OwnedElement> for IslValidValuesConstraint {
 
     fn try_from(value: &OwnedElement) -> IonSchemaResult<Self> {
         if value.annotations().any(|a| a == &text_token("range")) {
-            return Ok(IslValidValuesConstraint::new(vec![ValidValue::Range(
+            return IslValidValuesConstraint::new(vec![ValidValue::Range(
                 Range::from_ion_element(value, RangeType::Number)?,
-            )])?);
+            )]);
         }
         if let Some(values) = value.as_sequence() {
             if value.ion_type() == IonType::List {

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_import::IslImportType;
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::isl::util::{Annotation, Range, RangeType};
+use crate::isl::util::{Annotation, Range, RangeType, ValidValue};
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
@@ -160,13 +160,19 @@ impl IslConstraint {
     }
 
     /// Creates a [IslConstraint::ValidValues] using the [OwnedElements] specified inside it
-    pub fn valid_values_with_values(values: Vec<OwnedElement>) -> IslConstraint {
-        IslConstraint::ValidValues(IslValidValuesConstraint::Values(values))
+    pub fn valid_values_with_values(values: Vec<OwnedElement>) -> IonSchemaResult<IslConstraint> {
+        let valid_values: IonSchemaResult<Vec<ValidValue>> =
+            values.iter().map(|e| e.try_into()).collect();
+        Ok(IslConstraint::ValidValues(IslValidValuesConstraint {
+            valid_values: valid_values?,
+        }))
     }
 
     /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
     pub fn valid_values_with_range(values: Range) -> IslConstraint {
-        IslConstraint::ValidValues(IslValidValuesConstraint::Range(values))
+        IslConstraint::ValidValues(IslValidValuesConstraint {
+            valid_values: vec![ValidValue::Range(values)],
+        })
     }
 
     /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
@@ -479,9 +485,30 @@ impl TryFrom<&OwnedElement> for IslAnnotationsConstraint {
 /// Represents the `valid_values` constraint
 /// [valid_Values]: https://amzn.github.io/ion-schema/docs/spec.html#annotations
 #[derive(Debug, Clone, PartialEq)]
-pub enum IslValidValuesConstraint {
-    Range(Range),
-    Values(Vec<OwnedElement>),
+pub struct IslValidValuesConstraint {
+    valid_values: Vec<ValidValue>,
+}
+
+impl IslValidValuesConstraint {
+    /// Provides a way to programmatically construct valid_values constraint
+    /// Returns IonSchemaError whenever annotations are provided within ValidValue::Element
+    /// only `range` annotations are accepted for ValidValue::Element
+    pub fn new(valid_values: Vec<ValidValue>) -> IonSchemaResult<Self> {
+        let valid_values: IonSchemaResult<Vec<ValidValue>> = valid_values
+            .iter()
+            .map(|v| match v {
+                ValidValue::Range(r) => Ok(v.to_owned()),
+                ValidValue::Element(e) => e.try_into(),
+            })
+            .collect();
+        Ok(Self {
+            valid_values: valid_values?,
+        })
+    }
+
+    pub fn values(&self) -> &Vec<ValidValue> {
+        &self.valid_values
+    }
 }
 
 impl TryFrom<&OwnedElement> for IslValidValuesConstraint {
@@ -489,25 +516,22 @@ impl TryFrom<&OwnedElement> for IslValidValuesConstraint {
 
     fn try_from(value: &OwnedElement) -> IonSchemaResult<Self> {
         if value.annotations().any(|a| a == &text_token("range")) {
-            return Ok(IslValidValuesConstraint::Range(Range::from_ion_element(
-                value,
-                RangeType::Number,
-            )?));
+            return Ok(IslValidValuesConstraint::new(vec![ValidValue::Range(
+                Range::from_ion_element(value, RangeType::Number)?,
+            )])?);
         }
         if let Some(values) = value.as_sequence() {
             if value.ion_type() == IonType::List {
-                let values: IonSchemaResult<Vec<OwnedElement>> = values
+                let mut valid_values = vec![];
+                let values: IonSchemaResult<Vec<()>> = values
                     .iter()
                     .map(|e| {
-                        if e.annotations().next().is_some() {
-                            return invalid_schema_error(
-                                "Annotations are not allowed for valid_values constraint",
-                            );
-                        }
-                        Ok(e.to_owned())
+                        valid_values.push(e.try_into()?);
+                        Ok(())
                     })
                     .collect();
-                return Ok(IslValidValuesConstraint::Values(values?));
+                values?;
+                return Ok(IslValidValuesConstraint { valid_values });
             }
         }
         invalid_schema_error(format!(

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -4,7 +4,7 @@ use crate::isl::util::{Annotation, Range, RangeType};
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
-use ion_rs::value::owned::OwnedElement;
+use ion_rs::value::owned::{text_token, OwnedElement};
 use ion_rs::value::{Element, Sequence};
 use ion_rs::value::{Struct, SymbolToken};
 use ion_rs::IonType;
@@ -32,6 +32,7 @@ pub enum IslConstraint {
     Scale(Range),
     TimestampPrecision(Range),
     Type(IslTypeRef),
+    ValidValues(IslValidValuesConstraint),
 }
 
 impl IslConstraint {
@@ -156,6 +157,16 @@ impl IslConstraint {
             annotations_modifiers.contains(&"ordered"),
             annotations,
         ))
+    }
+
+    /// Creates a [IslConstraint::ValidValues] using the [OwnedElements] specified inside it
+    pub fn valid_values_with_values(values: Vec<OwnedElement>) -> IslConstraint {
+        IslConstraint::ValidValues(IslValidValuesConstraint::Values(values))
+    }
+
+    /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
+    pub fn valid_values_with_range(values: Range) -> IslConstraint {
+        IslConstraint::ValidValues(IslValidValuesConstraint::Range(values))
     }
 
     /// Parse constraints inside an [OwnedElement] to an [IslConstraint]
@@ -345,6 +356,7 @@ impl IslConstraint {
             "timestamp_precision" => Ok(IslConstraint::TimestampPrecision(
                 Range::from_ion_element(value, RangeType::TimestampPrecision)?,
             )),
+            "valid_values" => Ok(IslConstraint::ValidValues(value.try_into()?)),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()
                     + type_name
@@ -460,6 +472,47 @@ impl TryFrom<&OwnedElement> for IslAnnotationsConstraint {
             annotation_modifiers.contains(&"closed"),
             annotation_modifiers.contains(&"ordered"),
             annotations,
+        ))
+    }
+}
+
+/// Represents the `valid_values` constraint
+/// [valid_Values]: https://amzn.github.io/ion-schema/docs/spec.html#annotations
+#[derive(Debug, Clone, PartialEq)]
+pub enum IslValidValuesConstraint {
+    Range(Range),
+    Values(Vec<OwnedElement>),
+}
+
+impl TryFrom<&OwnedElement> for IslValidValuesConstraint {
+    type Error = IonSchemaError;
+
+    fn try_from(value: &OwnedElement) -> IonSchemaResult<Self> {
+        if value.annotations().any(|a| a == &text_token("range")) {
+            return Ok(IslValidValuesConstraint::Range(Range::from_ion_element(
+                value,
+                RangeType::Number,
+            )?));
+        }
+        if let Some(values) = value.as_sequence() {
+            if value.ion_type() == IonType::List {
+                let values: IonSchemaResult<Vec<OwnedElement>> = values
+                    .iter()
+                    .map(|e| {
+                        if e.annotations().next().is_some() {
+                            return invalid_schema_error(
+                                "Annotations are not allowed for valid_values constraint",
+                            );
+                        }
+                        Ok(e.to_owned())
+                    })
+                    .collect();
+                return Ok(IslValidValuesConstraint::Values(values?));
+            }
+        }
+        invalid_schema_error(format!(
+            "Expected valid_values to be a range or a list of valid values, found {}",
+            value.ion_type()
         ))
     }
 }

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -297,6 +297,24 @@ mod isl_tests {
                         "#),
         IslType::anonymous([IslConstraint::timestamp_precision("year".try_into().unwrap())])
     ),
+    case::valid_values_constraint(
+        load_anonymous_type(r#" // For a schema with valid_values constraint as below:
+                        { valid_values: [2, 3.5, 5e7, "hello", hi] }
+                    "#),
+        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()])])
+    ),
+    case::valid_values_wiht_range_constraint(
+        load_anonymous_type(r#" // For a schema with valid_values constraint as below:
+                        { valid_values: range::[1, 5.5] }
+                    "#),
+        IslType::anonymous(
+            [IslConstraint::valid_values_with_range(
+                Range::range(
+                    RangeBoundaryValue::number_value((&IntegerValue::I64(1)).into(), RangeBoundaryType::Inclusive),
+                    RangeBoundaryValue::number_value((&Decimal::new(55, -1)).try_into().unwrap(), RangeBoundaryType::Inclusive)
+                ).unwrap())
+            ])
+        ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -301,9 +301,9 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: [2, 3.5, 5e7, "hello", hi] }
                     "#),
-        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()])])
+        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
     ),
-    case::valid_values_wiht_range_constraint(
+    case::valid_values_with_range_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: range::[1, 5.5] }
                     "#),

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -347,7 +347,7 @@ mod isl_tests {
             &element_reader()
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
-            RangeType::Number,
+            RangeType::NumberOrTimestamp,
         )
     }
 

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -917,9 +917,9 @@ impl TryFrom<&OwnedElement> for ValidValue {
                 RangeType::Number,
             )?))
         } else if annotations.any(|a| a != &text_token("range")) {
-            return invalid_schema_error(
+            invalid_schema_error(
                 "Annotations are not allowed for valid_values constraint except `range` annotation",
-            );
+            )
         } else {
             Ok(ValidValue::Element(value.to_owned()))
         }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -1,7 +1,10 @@
+use crate::external::ion_rs::Integer;
+use crate::isl::util::Number as NumberValue;
 use crate::isl::util::TimestampPrecision as TimestampPrecisionValue;
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
+use ion_rs::external::bigdecimal::BigDecimal;
 use ion_rs::types::decimal::Decimal;
 use ion_rs::types::integer::IntAccess;
 use ion_rs::types::timestamp::{Precision, Timestamp};
@@ -11,6 +14,7 @@ use ion_rs::{Integer as IntegerValue, IonType};
 use num_bigint::BigInt;
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
+use std::str::FromStr;
 
 /// Represents ISL [Range]s where some constraints can be defined by a range
 /// <RANGE<RANGE_TYPE>> ::= range::[ <EXCLUSIVITY><RANGE_TYPE>, <EXCLUSIVITY><RANGE_TYPE> ]
@@ -25,6 +29,7 @@ use std::convert::{TryFrom, TryInto};
 /// For more information on [Range]: <https://amzn.github.io/ion-schema/docs/spec.html#constraints>
 #[derive(Debug, Clone, PartialEq)]
 pub enum Range {
+    Number(RangeBoundaryValue, RangeBoundaryValue),
     Decimal(RangeBoundaryValue, RangeBoundaryValue),
     Float(RangeBoundaryValue, RangeBoundaryValue),
     Integer(RangeBoundaryValue, RangeBoundaryValue),
@@ -226,6 +231,47 @@ impl Range {
                 };
                 Ok(is_in_upper_bound && is_in_lower_bound)
             }
+            Range::Number(start, end) => {
+                let value: NumberValue = match value.ion_type() {
+                    IonType::Integer => value.as_integer().unwrap().into(),
+                    IonType::Float => value.as_f64().unwrap().try_into()?,
+                    IonType::Decimal => value.as_decimal().unwrap().try_into()?,
+                    _ => {
+                        return invalid_schema_error(
+                            "Number ranges can only have number value for validation",
+                        );
+                    }
+                };
+
+                let is_in_lower_bound = match start {
+                    Min => true,
+                    Value(start_value, boundary_type) => match start_value {
+                        Number(min_value) => {
+                            match boundary_type {
+                            RangeBoundaryType::Inclusive => min_value.big_decimal_value() <= value.big_decimal_value(),
+                            RangeBoundaryType::Exclusive => min_value.big_decimal_value() < value.big_decimal_value(),
+                        }
+                        },
+                        _ => unreachable!("Number range can only have numbers as lower and upper range boundary value"),
+                    },
+                    Max => unreachable!("Cannot have 'Max' as the lower range boundary")
+                };
+
+                let is_in_upper_bound = match end {
+                    Max => true,
+                    Min => unreachable!("Cannot have 'Min' as the upper range boundary"),
+                    Value(end_value, boundary_type) => match end_value {
+                        Number(max_value) => {
+                                match boundary_type {
+                                    RangeBoundaryType::Inclusive => max_value.big_decimal_value() >= value.big_decimal_value(),
+                                    RangeBoundaryType::Exclusive => max_value.big_decimal_value() > value.big_decimal_value(),
+                                }
+                            }
+                        _ => unreachable!("Number range can only have numbers as lower and upper range boundary value"),
+                    }
+                };
+                Ok(is_in_upper_bound && is_in_lower_bound)
+            }
         }
     }
 
@@ -255,6 +301,7 @@ impl Range {
                     (Float(_), Float(_)) => {}
                     (Timestamp(_), Timestamp(_)) => {},
                     (TimestampPrecision(_), TimestampPrecision(_)) => {},
+                    (Number(_), Number(_))=> {},
                     _ => {
                         return invalid_schema_error("Both range boundary values must be of same type")
                     }
@@ -281,6 +328,7 @@ impl Range {
             Timestamp(_) => Range::Timestamp(start, end),
             IntegerNonNegative(_) => Range::IntegerNonNegative(start, end),
             TimestampPrecision(_) => Range::TimestampPrecision(start, end),
+            Number(_) => Range::Number(start, end),
         })
     }
 
@@ -302,6 +350,9 @@ impl Range {
                     value.ion_type()
                 )),
                 RangeType::Any => Ok(integer_value.into()),
+                RangeType::Number => {
+                    Range::number_range(integer_value.into(), integer_value.into())
+                }
             }
         } else if let Some(timestamp_precision) = value.as_str() {
             if range_type == RangeType::TimestampPrecision {
@@ -394,6 +445,14 @@ impl Range {
                 }
             },
         }
+    }
+
+    /// Provides number range with given min and max values
+    pub fn number_range(min_value: Number, max_value: Number) -> IonSchemaResult<Range> {
+        Range::range(
+            RangeBoundaryValue::number_value(min_value, RangeBoundaryType::Inclusive),
+            RangeBoundaryValue::number_value(max_value, RangeBoundaryType::Inclusive),
+        )
     }
 
     /// Provides integer range with given min and max values
@@ -493,8 +552,66 @@ pub enum RangeBoundaryValueType {
     Float(f64),
     Integer(IntegerValue),
     IntegerNonNegative(usize),
+    Number(Number),
     Timestamp(Timestamp),
     TimestampPrecision(TimestampPrecision),
+}
+
+/// Represents number boundary values
+/// A number can be float, integer or decimal
+#[derive(Debug, Clone, PartialEq)]
+pub struct Number {
+    big_decimal_value: BigDecimal,
+}
+
+impl Number {
+    pub fn new(big_decimal_value: BigDecimal) -> Self {
+        Self { big_decimal_value }
+    }
+
+    pub fn big_decimal_value(&self) -> &BigDecimal {
+        &self.big_decimal_value
+    }
+}
+
+impl TryFrom<f64> for Number {
+    type Error = IonSchemaError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        // Note: could not use BigDecimal's `try_from` method here as that uses `DIGITS` instead of `MANTISSA_DIGITS`.
+        // `DIGITS` gives an approximate number of significant digits, which failed a test from ion-schema-tests test suite
+        Ok(Number {
+            big_decimal_value: BigDecimal::from_str(&format!(
+                "{:.PRECISION$e}",
+                value,
+                PRECISION = f64::MANTISSA_DIGITS as usize
+            ))
+            .map_err(|err| {
+                invalid_schema_error_raw(format!("Cannot convert f64 to BigDecimal for {}", value))
+            })?,
+        })
+    }
+}
+
+impl TryFrom<&Decimal> for Number {
+    type Error = IonSchemaError;
+
+    fn try_from(value: &Decimal) -> Result<Self, Self::Error> {
+        Ok(Number {
+            big_decimal_value: value.to_owned().try_into()?,
+        })
+    }
+}
+
+impl From<&IntegerValue> for Number {
+    fn from(value: &IntegerValue) -> Self {
+        Number {
+            big_decimal_value: match value {
+                Integer::I64(int_val) => int_val.to_owned().into(),
+                Integer::BigInt(big_int_val) => big_int_val.to_owned().into(),
+            },
+        }
+    }
 }
 
 /// Represents a range boundary value (i.e. min, max or a value in terms of [RangeBoundaryValueType])
@@ -506,6 +623,10 @@ pub enum RangeBoundaryValue {
 }
 
 impl RangeBoundaryValue {
+    pub fn number_value(value: Number, range_boundary_type: RangeBoundaryType) -> Self {
+        RangeBoundaryValue::Value(RangeBoundaryValueType::Number(value), range_boundary_type)
+    }
+
     pub fn int_value(value: IntegerValue, range_boundary_type: RangeBoundaryType) -> Self {
         RangeBoundaryValue::Value(RangeBoundaryValueType::Integer(value), range_boundary_type)
     }
@@ -615,15 +736,31 @@ impl RangeBoundaryValue {
                 RangeType::TimestampPrecision => invalid_schema_error(
                     "Timestamp precision ranges can not be constructed for integer boundary values",
                 ),
+                RangeType::Number => Ok(RangeBoundaryValue::number_value(
+                    value.as_integer().unwrap().into(),
+                    range_boundary_type,
+                )),
             },
-            IonType::Decimal => Ok(RangeBoundaryValue::decimal_value(
-                value.as_decimal().unwrap().to_owned(),
-                range_boundary_type,
-            )),
-            IonType::Float => Ok(RangeBoundaryValue::float_value(
-                value.as_f64().unwrap(),
-                range_boundary_type,
-            )),
+            IonType::Decimal => match range_type {
+                RangeType::Number => Ok(RangeBoundaryValue::number_value(
+                    value.as_decimal().unwrap().try_into()?,
+                    range_boundary_type,
+                )),
+                _ => Ok(RangeBoundaryValue::decimal_value(
+                    value.as_decimal().unwrap().to_owned(),
+                    range_boundary_type,
+                )),
+            },
+            IonType::Float => match range_type {
+                RangeType::Number => Ok(RangeBoundaryValue::number_value(
+                    value.as_f64().unwrap().try_into()?,
+                    range_boundary_type,
+                )),
+                _ => Ok(RangeBoundaryValue::float_value(
+                    value.as_f64().unwrap(),
+                    range_boundary_type,
+                )),
+            },
             IonType::Timestamp => Ok(RangeBoundaryValue::timestamp_value(
                 value.as_timestamp().unwrap().to_owned(),
                 range_boundary_type,
@@ -647,7 +784,8 @@ pub enum RangeBoundaryType {
 pub enum RangeType {
     Precision, // used by precision constraint to specify non negative integer precision with minimum value as `1`
     NonNegativeInteger, // used by byte_length, container_length and codepoint_length to specify non negative integer range
-    TimestampPrecision, //used by timestamp_precision to specify timestamp precision range
+    TimestampPrecision, // used by timestamp_precision to specify timestamp precision range
+    Number,             // used by valid_values constraint
     Any,                // used for any range types (e.g. Integer, Float, Timestamp, Decimal)
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -256,6 +256,12 @@ mod schema_tests {
                     type:: { name: timestamp_precision_type, timestamp_precision: month }
                  "#).into_iter(),
         1 // this includes named type timestamp_precision_type
+    ),
+    case::valid_values_constraint(
+        load(r#" // For a schema with valid_values constraint as below:
+                    type:: { name: valid_values_type, valid_values: range::[1, 3] }
+                 "#).into_iter(),
+        1 // this includes named type valid_values_type
     )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
@@ -695,6 +701,49 @@ mod schema_tests {
                         "#),
             "timestamp_precision_type"
         ),
+        case::valid_values_constraint(
+            load(r#"
+                          2
+                          3
+                          5.5  
+                          "hello"
+                        "#),
+            load(r#"
+                          5.6
+                          1
+                          [1, 2 ,3]
+                          { greetings: "hello" }
+                          {{"hello"}}
+                          null
+                        "#),
+            load_schema_from_text(r#" // For a schema with valid values constraint as below:
+                                type::{ name: valid_values_type, valid_values: [2, 3, 5.5, "hello"] }
+                        "#),
+            "valid_values_type"
+        ),
+        case::valid_values_with_range_constraint(
+            load(r#"
+                      1
+                      2
+                      3
+                      4
+                      5  
+                      4.5
+                      2d0
+                      30e-1
+                    "#),
+            load(r#"
+                      0
+                      -2
+                      5.6
+                      6
+                      null
+                    "#),
+            load_schema_from_text(r#" // For a schema with valid values constraint as below:
+                            type::{ name: valid_values_type, valid_values: range::[1, 5.5] }
+                    "#),
+            "valid_values_type"
+    ),
     )]
     fn type_validation(
         valid_values: Vec<OwnedElement>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -350,7 +350,9 @@ mod type_definition_tests {
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::util::{RangeBoundaryType, RangeBoundaryValue};
     use crate::system::PendingTypes;
+    use ion_rs::Decimal;
     use ion_rs::Integer;
     use rstest::*;
 
@@ -504,6 +506,34 @@ mod type_definition_tests {
         IslType::anonymous([IslConstraint::timestamp_precision("month".try_into().unwrap())]),
         TypeDefinition::anonymous([Constraint::timestamp_precision("month".try_into().unwrap()), Constraint::type_constraint(25)])
     ),
+    case::valid_values_constraint(
+        /* For a schema with valid_values constraint as below:
+            { valid_values: [2, 3.5, 5e7, "hello", hi] }        
+        */
+        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()])]),
+        TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]), Constraint::type_constraint(25)])
+    ),
+    case::valid_values_wiht_range_constraint(
+        /* For a schema with valid_values constraint as below:
+            { valid_values: range::[1, 5.5] }        
+        */
+        IslType::anonymous(
+            [IslConstraint::valid_values_with_range(
+                Range::range(
+                    RangeBoundaryValue::number_value((&Integer::I64(1)).into(), RangeBoundaryType::Inclusive),
+                    RangeBoundaryValue::number_value((&Decimal::new(55, -1)).try_into().unwrap(), RangeBoundaryType::Inclusive)
+                ).unwrap())
+            ]
+        ),
+        TypeDefinition::anonymous([
+            Constraint::valid_values_with_range(
+                Range::range(
+                    RangeBoundaryValue::number_value((&Integer::I64(1)).into(), RangeBoundaryType::Inclusive),
+                    RangeBoundaryValue::number_value((&Decimal::new(55, -1)).try_into().unwrap(), RangeBoundaryType::Inclusive)
+            ).unwrap()),
+            Constraint::type_constraint(25)
+        ])
+    )
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {
         // assert if both the TypeDefinition are same in terms of constraints and name

--- a/src/types.rs
+++ b/src/types.rs
@@ -510,8 +510,8 @@ mod type_definition_tests {
         /* For a schema with valid_values constraint as below:
             { valid_values: [2, 3.5, 5e7, "hello", hi] }        
         */
-        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()])]),
-        TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]), Constraint::type_constraint(25)])
+        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()]),
+        TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap(), Constraint::type_constraint(25)])
     ),
     case::valid_values_wiht_range_constraint(
         /* For a schema with valid_values constraint as below:

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -56,6 +56,7 @@ pub enum ViolationCode {
     InvalidLength, // this is ued for any length related constraints (e.g. container_length, byte_length, codepoint_length)
     InvalidNull,   // if the value is a null for type references that doesn't allow null
     InvalidOpenContent, // if a container contains open content when `content: closed` is specified
+    InvalidValue,  // this is used for valid_values constraint
     MissingAnnotation, // if the annotation is missing for annotations constraint
     MissingValue,  // if the ion value is missing for a particular constraint
     MoreThanOneTypeMatched,
@@ -79,6 +80,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::InvalidLength => "invalid_length",
                 ViolationCode::InvalidNull => "invalid_null",
                 ViolationCode::InvalidOpenContent => "invalid_open_content",
+                ViolationCode::InvalidValue => "invalid_value",
                 ViolationCode::MissingAnnotation => "missing_annotation",
                 ViolationCode::MissingValue => "missing_value",
                 ViolationCode::MoreThanOneTypeMatched => "more_than_one_type_matched",

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -54,6 +54,19 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/scale/invalid.isl",
     "ion-schema-tests/constraints/timestamp_precision/validation.isl",
     "ion-schema-tests/constraints/timestamp_precision/invalid.isl",
+    "ion-schema-tests/constraints/valid_values/all_types.isl",
+    "ion-schema-tests/constraints/valid_values/invalid.isl",
+    "ion-schema-tests/constraints/valid_values/range_timestamp.isl",
+    "ion-schema-tests/constraints/valid_values/range_timestamp_exclusive.isl",
+    "ion-schema-tests/constraints/valid_values/range_timestamp_invalid.isl",
+    "ion-schema-tests/constraints/valid_values/range_timestamp_max.isl",
+    "ion-schema-tests/constraints/valid_values/range_timestamp_min.isl",
+    "ion-schema-tests/constraints/valid_values/validation_list.isl",
+    "ion-schema-tests/constraints/valid_values/validation_int_range.isl",
+    "ion-schema-tests/constraints/valid_values/validation_list_mix_types_ranges.isl",
+    "ion-schema-tests/constraints/valid_values/validation_list_timestamp_ranges.isl",
+    "ion-schema-tests/constraints/valid_values/validation_ranges.isl",
+    "ion-schema-tests/constraints/valid_values/validation_timestamp_range.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -72,6 +85,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/precision/*.isl")]
 #[test_resources("ion-schema-tests/constraints/scale/*.isl")]
 #[test_resources("ion-schema-tests/constraints/timestamp_precision/*.isl")]
+#[test_resources("ion-schema-tests/constraints/valid_values/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `valid_values` constraint.

*Grammar:*
```ANTLR
<VALID_VALUES> ::= valid_values: [ <VALUE>... ]
                 | valid_values: <RANGE<NUMBER>>
                 | valid_values: <RANGE<TIMESTAMP>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#valid_values

*List of changes:*
* adds changes for `Number` range implementation (https://github.com/amzn/ion-schema-rust/pull/92/commits/d184e29462a756524e68c98d1a46767a7a1ace63)
(_Note: `Timestamp` ranges are not completely implemented yet, refer #91_) 
* adds `ValidValues` enum variants for `IslConstraint` and `Constraint`
* adds `ValidValuesConstraint` implementations
* adds validation logic for `valid_values` 

*Tests:*
added unit tests for `valid_values` implementation.
- adds tests for programmatically creating `valid_values` constraint
- adds tests for loading a schema using `valid_values` constraint 
- adds validation tests for `valid_values` constraint

*Question:*
Should there be a `Violation` returned when an `OwnedElement` with annotation is passed to validate with `valid_values` constraint or silently ignore the annotation? (_Note: current implementation ignores the annotation_)