### PR TITLE
adds changes for `regex` constraint implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"
 chrono = "0.4"
+regex = "1.5.6"
 
 [dev-dependencies]
 rstest = "0.9"

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -324,6 +324,19 @@ mod isl_tests {
             ]
         )
     ),
+    case::regex_constraint(
+        load_anonymous_type(r#" // For a schema with regex constraint as below:
+                            { regex: "[abc]" }
+                        "#),
+        IslType::anonymous(
+            [IslConstraint::regex(
+                false, // case insensitive
+                false, // multiline
+                "[abc]".to_string()
+            )
+            ]
+        )
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -262,6 +262,12 @@ mod schema_tests {
                     type:: { name: valid_values_type, valid_values: range::[1, 3] }
                  "#).into_iter(),
         1 // this includes named type valid_values_type
+    ),
+    case::regex_constraint(
+        load(r#" // For a schema with regex constraint as below:
+                    type:: { name: regex_type, regex: "[abc]" }
+                 "#).into_iter(),
+        1 // this includes named type regex_type
     )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = OwnedElement>>(
@@ -783,7 +789,24 @@ mod schema_tests {
                             type::{ name: valid_values_type, valid_values: range::[1, 5.5] }
                     "#),
             "valid_values_type"
-    ),
+        ),
+        case::regex_constraint(
+            load(r#"
+                      "ab"
+                      "cd"
+                      "ef"
+                    "#),
+            load(r#"
+                      "a"
+                      "ac"
+                      "ace"
+                      "bdf"
+                    "#),
+            load_schema_from_text(r#" // For a schema with regex constraint as below:
+                            type::{ name: regex_type, regex: "ab|cd|ef" }
+                    "#),
+            "regex_type"
+        ),
     )]
     fn type_validation(
         valid_values: Vec<OwnedElement>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -534,6 +534,26 @@ mod type_definition_tests {
             ).unwrap().into()),
             Constraint::type_constraint(25)
         ])
+    ),
+    case::regex_constraint(
+        /* For a schema with regex constraint as below:
+            { regex: "[abc]" }        
+        */
+        IslType::anonymous(
+            [IslConstraint::regex(
+                false, // case insensitive
+                false, // multiline
+                "[abc]".to_string()
+            )]
+        ),
+        TypeDefinition::anonymous([
+            Constraint::regex(
+                false, // case insensitive
+                false, // multiline
+                "[abc]".to_string()
+            ).unwrap(),
+            Constraint::type_constraint(25)
+        ])
     )
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -61,6 +61,7 @@ pub enum ViolationCode {
     MissingValue,  // if the ion value is missing for a particular constraint
     MoreThanOneTypeMatched,
     NoTypesMatched,
+    RegexMismatched, // this is used for regex constraint
     TypeConstraintsUnsatisfied,
     TypeMatched,
     TypeMismatched,
@@ -85,6 +86,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::MissingValue => "missing_value",
                 ViolationCode::MoreThanOneTypeMatched => "more_than_one_type_matched",
                 ViolationCode::NoTypesMatched => "no_types_matched",
+                ViolationCode::RegexMismatched => "regex_mismatched",
                 ViolationCode::TypeConstraintsUnsatisfied => "type_constraints_unsatisfied",
                 ViolationCode::TypeMatched => "type_matched",
                 ViolationCode::TypeMismatched => "type_mismatched",

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -84,6 +84,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/scale/*.isl")]
 #[test_resources("ion-schema-tests/constraints/timestamp_precision/*.isl")]
 #[test_resources("ion-schema-tests/constraints/valid_values/*.isl")]
+#[test_resources("ion-schema-tests/constraints/regex/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11
@@ -127,10 +128,10 @@ fn validation_tests(path: &str) {
         fs::read(path).unwrap_or_else(|_| panic!("Could not read from given file {}", path));
     let iterator = element_reader()
         .iterate_over(&ion_content)
-        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}", path));
+        .unwrap_or_else(|_| panic!("Could not get owned elements from schema file: {}", path));
     let schema_content = iterator
         .collect::<Result<Vec<OwnedElement>, IonError>>()
-        .unwrap_or_else(|_| panic!("Could not get owned elements from scehma file: {}", path));
+        .unwrap_or_else(|_| panic!("Could not get owned elements from schema file: {}", path));
 
     let type_store = &mut TypeStore::default();
     let mut invalid_values: Vec<OwnedElement> = vec![];


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `regex` constraint.

*Grammar:*
```ANTLR
<REGEX> ::= regex: <STRING>
          | regex: i::<STRING>
          | regex: m::<STRING>
          | regex: i::m::<STRING>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#regex

*List of changes:*
* adds `regex` crate dependency
* adds `Regex` enum variants for `IslConstraint` and `Constraint`
* adds `RegexConstraint` implementations 
(_Note: Not all features of regex are supported as per Ion schema specification hence there is a preprocessing done on the regex to allow only the supported features_)
* reference for preprocessing regex is as per `ion-schema-kotlin` implementation.
* adds validation logic for `regex`
* adds `ViolationCode` for `RegexMismatched`

*Tests:*
added unit tests for `regex` implementation.
* adds tests for programmatically creating `regex` constraint
* adds tests for loading a schema using `regex` constraint
* adds validation tests for `regex` constraint


