### PR TITLE
adds changes for 'nullable' annotated type references

### DIFF
--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -6,7 +6,8 @@ use crate::result::{
 };
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::types::TypeDefinitionImpl;
-use ion_rs::value::owned::OwnedElement;
+use ion_rs::value::owned::{text_token, OwnedElement};
+use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::{Element, Struct, SymbolToken};
 use ion_rs::IonType;
 
@@ -23,7 +24,6 @@ pub enum IslTypeRef {
     Anonymous(IslTypeImpl),
 }
 
-// TODO: add a check for nullable type reference
 impl IslTypeRef {
     /// Creates a [IslTypeRef::Named] using the [IonType] referenced inside it
     pub fn named<A: Into<String>>(name: A) -> IslTypeRef {
@@ -33,6 +33,31 @@ impl IslTypeRef {
     /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
     pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
         IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints.into()))
+    }
+
+    /// Provides a string representing a definition of a nullable built in type reference
+    // these are the built types that rae annotated with `nullable`
+    fn get_nullable_type_reference_definition(type_ref_name: &str) -> IonSchemaResult<&str> {
+        Ok(match type_ref_name {
+            "int" => "{ type: $any, any_of: [$null, $int] }",
+            "float" => "{ type: $any, any_of: [$null, $float] }",
+            "bool" => "{ type: $any, any_of: [$null, $bool] }",
+            "decimal" => "{ type: $any, any_of: [$null, $decimal] }",
+            "string" => "{ type: $any, any_of: [$null, $string] }",
+            "symbol" => "{ type: $any, any_of: [$null, $symbol] }",
+            "blob" => "{ type: $any, any_of: [$null, $blob] }",
+            "clob" => "{ type: $any, any_of: [$null, $clob] }",
+            "timestamp" => "{ type: $any, any_of: [$null, $timestamp] }",
+            "struct" => "{ type: $any, any_of: [$null, $struct] }",
+            "sexp" => "{ type: $any, any_of: [$null, $sexp] }",
+            "list" => "{ type: $any, any_of: [$null, $list] }",
+            // TODO: currently it only allows for built in types to be defined with `nullable` annotation for all other type references it return an error
+            _ => {
+                return invalid_schema_error(
+                    "nullable type reference is only allowed for built in types",
+                )
+            }
+        })
     }
 
     /// Tries to create an [IslTypeRef] from the given OwnedElement
@@ -47,13 +72,25 @@ impl IslTypeRef {
                         "a base or alias type reference can not be null.symbol",
                     )
                 }
-                value.as_sym().unwrap()
+
+                let type_name = value.as_sym().unwrap()
                     .text()
                     .ok_or_else(|| {
                         invalid_schema_error_raw(
                             "a base or alias type reference symbol doesn't have text",
                         )
-                    }).map(|type_name| IslTypeRef::Named(type_name.to_owned()))
+                    })?;
+
+                // check for nullable type reference
+                if value.annotations().any(|a| a == &text_token("nullable")) {
+                    let built_in_type_def = IslTypeRef::get_nullable_type_reference_definition(type_name)?;
+                    let value = &element_reader()
+                        .read_one(built_in_type_def.as_bytes())
+                        .map_err(|_| invalid_schema_error_raw(format!("Can not parse nullable type reference for given built in type: {}", type_name)))?;
+                    return IslTypeRef::from_ion_element(value, inline_imported_types);
+                }
+
+                Ok(IslTypeRef::Named(type_name.to_owned()))
             }
             IonType::Struct => {
                 if value.is_null() {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -179,6 +179,12 @@ mod isl_tests {
             "#),
         IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::named("any"))])
     ),
+    case::type_constraint_with_nullable_annotation(
+        load_anonymous_type(r#" // For a schema with `nullable` annotation`
+                {type: nullable::int}
+            "#),
+        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::any_of([IslTypeRef::named("$null"), IslTypeRef::named("$int")]), IslConstraint::type_constraint(IslTypeRef::named("$any"))]))])
+    ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -309,6 +309,25 @@ mod schema_tests {
             "#),
             "my_int"
         ),
+        case::nullable_annotation_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.int
+                    0
+                    -5
+                "#),
+            load(r#"
+                    null.decimal
+                    a
+                    "hello"
+                    false
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_int, type: nullable::int }
+                "#),
+            "my_int"
+        ),
         case::nullable_atomic_type_constraint(
             load(r#"
                 5

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -309,7 +309,7 @@ mod schema_tests {
             "#),
             "my_int"
         ),
-        case::nullable_annotation_type_constraint(
+        case::nullable_annotation_int_type_constraint(
             load(r#"
                     null
                     null.null
@@ -327,6 +327,201 @@ mod schema_tests {
                     type:: { name: my_int, type: nullable::int }
                 "#),
             "my_int"
+        ),
+        case::nullable_annotation_float_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.float
+                    5e2
+                "#),
+            load(r#"
+                    null.decimal
+                    a
+                    "hello"
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_float, type: nullable::float }
+                "#),
+            "my_float"
+        ),
+        case::nullable_annotation_string_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.string
+                    "hi"
+                "#),
+            load(r#"
+                    null.decimal
+                    null.symbol
+                    hello
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_string, type: nullable::string }
+                "#),
+            "my_string"
+        ),
+        case::nullable_annotation_symbol_type_constraint(
+            load(r#"
+                        null
+                        null.null
+                        null.symbol
+                        a
+                    "#),
+            load(r#"
+                        null.string
+                        10.5
+                        "hello"
+                        false
+                        10
+                    "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                        type:: { name: my_symbol, type: nullable::symbol }
+                    "#),
+            "my_symbol"
+        ),
+        case::nullable_annotation_decimal_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.decimal
+                    10.5
+                "#),
+            load(r#"
+                    null.int
+                    a
+                    "hello"
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_decimal, type: nullable::decimal }
+                "#),
+            "my_decimal"
+        ),
+        case::nullable_annotation_timestamp_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.timestamp
+                    2000-01T
+                "#),
+            load(r#"
+                    null.decimal
+                    a
+                    "hello"
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_timestamp, type: nullable::timestamp }
+                "#),
+            "my_timestamp"
+        ),
+        case::nullable_annotation_blob_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.blob
+                    {{ aGVsbG8= }}
+                "#),
+            load(r#"
+                    null.clob
+                    a
+                    "hello"
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_blob, type: nullable::blob }
+                "#),
+            "my_blob"
+        ),
+        case::nullable_annotation_clob_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.clob
+                    {{"12345"}}
+                "#),
+            load(r#"
+                    null.blob
+                    a
+                    "hello"
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_clob, type: nullable::clob }
+                "#),
+            "my_clob"
+        ),
+        case::nullable_annotation_text_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.symbol
+                    null.string
+                    "hello"
+                    hello
+                "#),
+            load(r#"
+                    null.decimal
+                    10.5
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_text, type: nullable::text }
+                "#),
+            "my_text"
+        ),
+        case::nullable_annotation_lob_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.blob
+                    null.clob
+                    {{ aGVsbG8= }}
+                    {{"12345"}}
+                "#),
+            load(r#"
+                    null.decimal
+                    10.5
+                    false
+                    10
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_lob, type: nullable::lob }
+                "#),
+            "my_lob"
+        ),
+        case::nullable_annotation_number_type_constraint(
+            load(r#"
+                    null
+                    null.null
+                    null.int
+                    null.float
+                    null.decimal
+                    10.5
+                    10e2
+                    5
+                "#),
+            load(r#"
+                    null.string
+                    "hello"
+                    false
+                    a
+                "#),
+            load_schema_from_text(r#" // For a schema with named type and `nullable` annotation as below: 
+                    type:: { name: my_number, type: nullable::number }
+                "#),
+            "my_number"
         ),
         case::nullable_atomic_type_constraint(
             load(r#"

--- a/src/system.rs
+++ b/src/system.rs
@@ -376,7 +376,7 @@ impl PendingTypes {
 
 /// Represents an array of BuiltIn derived ISL types
 /// for more information: https://amzn.github.io/ion-schema/docs/spec.html#type-system
-static DERIVED_ISL_TYPES: [&str; 8] = [
+static DERIVED_ISL_TYPES: [&str; 9] = [
     "type::{ name: any, one_of: [ blob, bool, clob, decimal,
                                     float, int, string, symbol, timestamp,
                                     list, sexp, struct ] }",
@@ -389,6 +389,7 @@ static DERIVED_ISL_TYPES: [&str; 8] = [
     "type::{ name: $lob, one_of: [ $blob, $clob ] }",
     "type::{ name: $number, one_of: [ $decimal, $float, $int ] }",
     "type::{ name: $text, one_of: [ $string, $symbol ] }",
+    "type::{ name: nothing, not: $any }",
 ];
 
 pub type TypeId = usize;
@@ -458,7 +459,7 @@ impl TypeStore {
         // add $null to the built-in types [type_id: 24]
         self.add_builtin_type(&BuiltInTypeDefinition::Atomic(Null, Nullability::Nullable));
 
-        // get the derived built in types map and related text value for given type_name [type_ids: 25 - 32]
+        // get the derived built in types map and related text value for given type_name [type_ids: 25 - 33]
         let pending_types = &mut PendingTypes::default();
         for text in DERIVED_ISL_TYPES {
             let isl_type = IslTypeImpl::from_owned_element(

--- a/src/types.rs
+++ b/src/types.rs
@@ -379,63 +379,63 @@ mod type_definition_tests {
             { name: my_int, type: my_int }
          */
         IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("my_int"))]),
-        TypeDefinition::named("my_int", [Constraint::type_constraint(33)])
+        TypeDefinition::named("my_int", [Constraint::type_constraint(34)])
     ),
     case::type_constraint_with_nested_self_reference_type(
         /* For a schema with nested self reference type as below:
             { name: my_int, type: { type: my_int } }
          */
         IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))]),
-        TypeDefinition::named("my_int", [Constraint::type_constraint(34)]) // 0-32 are built-in types which are preloaded to the type_store
+        TypeDefinition::named("my_int", [Constraint::type_constraint(35)]) // 0-32 are built-in types which are preloaded to the type_store
     ),
     case::type_constraint_with_nested_type(
         /* For a schema with nested types as below:
             { name: my_int, type: { type: int } }
          */
         IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))]),
-        TypeDefinition::named("my_int", [Constraint::type_constraint(34)])
+        TypeDefinition::named("my_int", [Constraint::type_constraint(35)])
     ),
     case::type_constraint_with_nested_multiple_types(
         /* For a schema with nested multiple types as below:
             { name: my_int, type: { type: int }, type: { type: my_int } }
          */
         IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))]),
-        TypeDefinition::named("my_int", [Constraint::type_constraint(34), Constraint::type_constraint(35)])
+        TypeDefinition::named("my_int", [Constraint::type_constraint(35), Constraint::type_constraint(36)])
     ),
     case::all_of_constraint(
         /* For a schema with all_of type as below:
             { all_of: [{ type: int }] }
         */
         IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])])]),
-        TypeDefinition::anonymous([Constraint::all_of([34]), Constraint::type_constraint(25)])
+        TypeDefinition::anonymous([Constraint::all_of([35]), Constraint::type_constraint(25)])
     ),
     case::any_of_constraint(
         /* For a schema with any_of constraint as below:
             { any_of: [{ type: int }, { type: decimal }] }
         */
         IslType::anonymous([IslConstraint::any_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])]),
-        TypeDefinition::anonymous([Constraint::any_of([34, 35]), Constraint::type_constraint(25)])
+        TypeDefinition::anonymous([Constraint::any_of([35, 36]), Constraint::type_constraint(25)])
     ),
     case::one_of_constraint(
         /* For a schema with one_of constraint as below:
             { any_of: [{ type: int }, { type: decimal }] }
         */
         IslType::anonymous([IslConstraint::one_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])]),
-        TypeDefinition::anonymous([Constraint::one_of([34, 35]), Constraint::type_constraint(25)])
+        TypeDefinition::anonymous([Constraint::one_of([35, 36]), Constraint::type_constraint(25)])
     ),
     case::not_constraint(
         /* For a schema with not constraint as below:
             { not: { type: int } }
         */
         IslType::anonymous([IslConstraint::not(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))]),
-        TypeDefinition::anonymous([Constraint::not(34), Constraint::type_constraint(25)])
+        TypeDefinition::anonymous([Constraint::not(35), Constraint::type_constraint(25)])
     ),
     case::ordered_elements_constraint(
         /* For a schema with ordered_elements constraint as below:
             { ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
         */
         IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(Range::optional())])])]),
-        TypeDefinition::anonymous([Constraint::ordered_elements([5, 34]), Constraint::type_constraint(25)])
+        TypeDefinition::anonymous([Constraint::ordered_elements([5, 35]), Constraint::type_constraint(25)])
     ),
     case::fields_constraint(
         /* For a schema with fields constraint as below:

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -34,7 +34,6 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/type/inlined_types.isl",
     "ion-schema-tests/constraints/type/inlined_type_import.isl",
     "ion-schema-tests/constraints/type/validation.isl",
-    "ion-schema-tests/constraints/type/nullable.isl",
     "ion-schema-tests/core_types/nothing.isl",
     "ion-schema-tests/core_types/document.isl",
     "ion-schema-tests/constraints/content/validation_closed.isl",

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -34,7 +34,6 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/type/inlined_types.isl",
     "ion-schema-tests/constraints/type/inlined_type_import.isl",
     "ion-schema-tests/constraints/type/validation.isl",
-    "ion-schema-tests/core_types/nothing.isl",
     "ion-schema-tests/core_types/document.isl",
     "ion-schema-tests/constraints/content/validation_closed.isl",
     "ion-schema-tests/constraints/content/validation_mixed.isl",


### PR DESCRIPTION
*Issue #12*

*Description of changes:*
This PR works on implementation of type references that are annotated with `nullable`.

*List of changes:*
- Adds a check for `nullable` annotation on type references (only allows for built in type references e.g. `{ type: int }`)

*Test:*
Adds unit tests for nullable type references and removes skip list tests.
