### PR TITLE
adds implementation for `document` type

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -809,7 +809,7 @@ impl ConstraintValidator for FieldsConstraint {
 
         // get struct value
         let ion_struct = value
-            .expect_element_of_type("fields", &[IonType::Struct])?
+            .expect_element_of_type(&[IonType::Struct], "fields")?
             .as_struct()
             .unwrap();
 
@@ -1031,7 +1031,7 @@ impl ConstraintValidator for ByteLengthConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get the size of given bytes
         let size = value
-            .expect_element_of_type("byte_length", &[IonType::Blob, IonType::Clob])?
+            .expect_element_of_type(&[IonType::Blob, IonType::Clob], "byte_length")?
             .as_bytes()
             .unwrap()
             .len();
@@ -1073,7 +1073,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get the size of given string/symbol Unicode codepoints
         let size = value
-            .expect_element_of_type("codepoint_length", &[IonType::String, IonType::Symbol])?
+            .expect_element_of_type(&[IonType::String, IonType::Symbol], "codepoint_length")?
             .as_str()
             .unwrap()
             .chars()
@@ -1129,7 +1129,7 @@ impl ConstraintValidator for ElementConstraint {
         // this type_id was validated while creating `ElementConstraint` hence the unwrap here is safe
         let type_def = type_store.get_type_by_id(self.type_id).unwrap();
 
-        // get the size of given string/symbol Unicode codepoints
+        // validate element constraint for container types
         match value {
             IonSchemaElement::SingleElement(element) => {
                 // Check for null container
@@ -1363,7 +1363,7 @@ impl ConstraintValidator for AnnotationsConstraint {
                 Err(Violation::new(
                     "annotations",
                     ViolationCode::AnnotationMismatched,
-                    "annotations don't match expectations",
+                    "annotations constraint is not applicable for document type",
                 ))
             }
         }
@@ -1391,7 +1391,7 @@ impl ConstraintValidator for PrecisionConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get precision of decimal value
         let value_precision = value
-            .expect_element_of_type("precision", &[IonType::Decimal])?
+            .expect_element_of_type(&[IonType::Decimal], "precision")?
             .as_decimal()
             .unwrap()
             .precision();
@@ -1436,7 +1436,7 @@ impl ConstraintValidator for ScaleConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get scale of decimal value
         let value_scale = value
-            .expect_element_of_type("precision", &[IonType::Decimal])?
+            .expect_element_of_type(&[IonType::Decimal], "precision")?
             .as_decimal()
             .unwrap()
             .scale();
@@ -1480,7 +1480,7 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get timestamp value
         let timestamp_value = value
-            .expect_element_of_type("timestamp_precision", &[IonType::Timestamp])?
+            .expect_element_of_type(&[IonType::Timestamp], "timestamp_precision")?
             .as_timestamp()
             .unwrap();
 
@@ -1568,7 +1568,10 @@ impl ConstraintValidator for ValidValuesConstraint {
             IonSchemaElement::Document(document) => Err(Violation::new(
                 "valid_values",
                 ViolationCode::InvalidValue,
-                "valid_values constraint is not allowed to be used for document",
+                &format!(
+                    "expected valid_values to be from {:?}, found {:?}",
+                    &self, value
+                ),
             )),
         }
     }
@@ -1736,7 +1739,7 @@ impl ConstraintValidator for RegexConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         // get string value and return violation if its not a string or symbol type
         let string_value = value
-            .expect_element_of_type("regex", &[IonType::String, IonType::Symbol])?
+            .expect_element_of_type(&[IonType::String, IonType::Symbol], "regex")?
             .as_str()
             .unwrap();
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -957,7 +957,7 @@ impl ConstraintValidator for ContainsConstraint {
         value: I,
         type_store: &TypeStore,
     ) -> ValidationResult {
-        let schema_element: IonSchemaElement = value.to_owned().into();
+        let schema_element: IonSchemaElement = value.into();
 
         // Create a peekable iterator for given sequence
         let values: Vec<OwnedElement> = match &schema_element {
@@ -1275,7 +1275,7 @@ impl ConstraintValidator for ElementConstraint {
         let type_def = type_store.get_type_by_id(self.type_id).unwrap();
 
         // get the size of given string/symbol Unicode codepoints
-        let size = match schema_element {
+        match schema_element {
             IonSchemaElement::SingleElement(element) => {
                 // Check for null container
                 if element.is_null() {
@@ -1322,7 +1322,7 @@ impl ConstraintValidator for ElementConstraint {
                     }
                 }
             }
-        };
+        }
 
         if !violations.is_empty() {
             return Err(Violation::with_violations(
@@ -1507,11 +1507,11 @@ impl ConstraintValidator for AnnotationsConstraint {
             }
             IonSchemaElement::Document(document) => {
                 // document type can not have annotations
-                return Err(Violation::new(
+                Err(Violation::new(
                     "annotations",
                     ViolationCode::AnnotationMismatched,
                     "annotations don't match expectations",
-                ));
+                ))
             }
         }
     }
@@ -1803,13 +1803,11 @@ impl ConstraintValidator for ValidValuesConstraint {
                     ),
                 ))
             }
-            IonSchemaElement::Document(document) => {
-                return Err(Violation::new(
-                    "valid_values",
-                    ViolationCode::InvalidValue,
-                    "valid_values constraint is not allowed to be used for document",
-                ));
-            }
+            IonSchemaElement::Document(document) => Err(Violation::new(
+                "valid_values",
+                ViolationCode::InvalidValue,
+                "valid_values constraint is not allowed to be used for document",
+            )),
         }
     }
 }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -714,7 +714,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
 
         // Create a peekable iterator for given sequence
         let mut values_iter = match &schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 match element.as_sequence() {
                     None => {
                         return Err(Violation::with_violations(
@@ -811,7 +811,7 @@ impl ConstraintValidator for FieldsConstraint {
 
         // Create a peekable iterator for given struct
         let ion_struct = match &schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 match element.as_struct() {
                     None => {
                         return Err(Violation::with_violations(
@@ -921,7 +921,7 @@ impl ConstraintValidator for ContainsConstraint {
 
         // Create a peekable iterator for given sequence
         let values: Vec<OwnedElement> = match &schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 match element.as_sequence() {
                     None => {
                         // return Violation if value is not an Ion sequence
@@ -995,7 +995,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
 
         // get the size of given value container
         let size = match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // Check for null container
                 if element.is_null() {
                     return Err(Violation::new(
@@ -1068,7 +1068,7 @@ impl ConstraintValidator for ByteLengthConstraint {
 
         // get the size of given bytes
         let size = match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 match element.as_bytes() {
                     Some(bytes) => bytes.len(),
                     _ => {
@@ -1137,7 +1137,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
 
         // get the size of given string/symbol Unicode codepoints
         let size = match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 match element.as_str() {
                     Some(text) => text.chars().count(),
                     _ => {
@@ -1221,7 +1221,7 @@ impl ConstraintValidator for ElementConstraint {
 
         // get the size of given string/symbol Unicode codepoints
         let size = match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // Check for null container
                 if element.is_null() {
                     return Err(Violation::new(
@@ -1437,7 +1437,7 @@ impl ConstraintValidator for AnnotationsConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // validate annotations that have list-level `ordered` annotation
                 if self.is_ordered {
                     return self.validate_ordered_annotations(&element, type_store, violations);
@@ -1480,7 +1480,7 @@ impl ConstraintValidator for PrecisionConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // get the precision of given decimal
                 let value_precision = match element.as_decimal() {
                     Some(decimal_value) => decimal_value.precision(),
@@ -1549,7 +1549,7 @@ impl ConstraintValidator for ScaleConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // get the scale of given decimal
                 let value_scale = match element.as_decimal() {
                     Some(decimal_value) => decimal_value.scale(),
@@ -1617,7 +1617,7 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 // get the precision of given timestamp
                 let timestamp_value = match element.as_timestamp() {
                     Some(timestamp_value) => timestamp_value,
@@ -1696,7 +1696,7 @@ impl ConstraintValidator for ValidValuesConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(value) => {
+            IonSchemaElement::SingleElement(value) => {
                 for valid_value in &self.valid_values {
                     match valid_value {
                         ValidValue::Range(range) => match value.ion_type() {
@@ -1901,7 +1901,7 @@ impl ConstraintValidator for RegexConstraint {
         let schema_element: IonSchemaElement = value.into();
 
         match schema_element {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 let value = match element.as_str() {
                     Some(string_value) => {
                         let re = Regex::new(r"\r").unwrap();

--- a/src/isl/isl_type_reference.rs
+++ b/src/isl/isl_type_reference.rs
@@ -102,6 +102,11 @@ impl IslTypeRef {
                         "a base or alias type reference can not be null.struct",
                     )
                 }
+                if value.annotations().any(|a| a.text() == Some("nullable")) {
+                    return invalid_schema_error(
+                        "nullable type reference is only allowed for built in types",
+                    )
+                }
                 let value_struct = try_to!(value.as_struct());
                 // if the struct doesn't have an id field then it must be an anonymous type
                 if value_struct.get("id").is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,14 +54,14 @@ pub mod external {
 /// ```
 #[derive(Debug, Clone)]
 pub enum IonSchemaElement {
-    Element(OwnedElement),
+    SingleElement(OwnedElement),
     Document(Vec<OwnedElement>),
 }
 
 impl IonSchemaElement {
     pub fn as_element(&self) -> Option<&OwnedElement> {
         match self {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 Some(element)
             }
             IonSchemaElement::Document(_) => {
@@ -74,7 +74,7 @@ impl IonSchemaElement {
 impl Display for IonSchemaElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            IonSchemaElement::Element(element) => {
+            IonSchemaElement::SingleElement(element) => {
                 write!(f, "{}", element)
             }
             IonSchemaElement::Document(document) => {
@@ -113,7 +113,7 @@ impl From<&OwnedElement> for IonSchemaElement {
             };
             return IonSchemaElement::Document(sequence);
         }
-        IonSchemaElement::Element(value.to_owned())
+        IonSchemaElement::SingleElement(value.to_owned())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,13 @@ impl IonSchemaElement {
         }
     }
 
+    pub fn as_document(&self) -> Option<&Vec<OwnedElement>> {
+        match self {
+            IonSchemaElement::SingleElement(_) => None,
+            IonSchemaElement::Document(document) => Some(document),
+        }
+    }
+
     fn expect_element_of_type(
         &self,
         constraint_name: &str,
@@ -105,7 +112,7 @@ impl Display for IonSchemaElement {
                 write!(f, "{}", element)
             }
             IonSchemaElement::Document(document) => {
-                write!(f, "document::( ")?;
+                write!(f, "/* Ion document */ ")?;
                 let mut peekable_itr = document.iter().peekable();
                 while peekable_itr.peek() != None {
                     let value = peekable_itr.next().unwrap();
@@ -114,7 +121,7 @@ impl Display for IonSchemaElement {
                         write!(f, " ")?;
                     }
                 }
-                write!(f, " )")
+                write!(f, " /* end */")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ impl From<&OwnedElement> for IonSchemaElement {
                     panic!("invalid document")
                 }
             };
-            // println!("{:?}", sequence);
             return IonSchemaElement::Document(sequence);
         }
         IonSchemaElement::Element(value.to_owned())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 // TODO: remove the following line once we have a basic implementation ready
 #![allow(dead_code, unused_variables)]
 
+use crate::external::ion_rs::IonType;
+use ion_rs::value::owned::OwnedElement;
+use ion_rs::value::reader::{element_reader, ElementReader};
+use ion_rs::value::{Element, Sequence, SymbolToken};
 /// A [`try`]-like macro to workaround the [`Option`]/[`Result`] nested APIs.
 /// These API require checking the type and then calling the appropriate getter function
 /// (which returns a None if you got it wrong). This macro turns the `None` into
@@ -28,4 +32,42 @@ mod violation;
 /// Re-export of the ion-rs dependency that is part of our public API.
 pub mod external {
     pub use ion_rs;
+}
+
+/// Provide an Ion schema element which includes all OwnedElements and a document type
+pub enum IonSchemaElement {
+    Element(OwnedElement),
+    Document(Vec<OwnedElement>),
+}
+
+impl From<&OwnedElement> for IonSchemaElement {
+    fn from(value: &OwnedElement) -> Self {
+        if value.annotations().any(|a| a.text() == Some("document")) {
+            let sequence = match value.ion_type() {
+                IonType::String => load(&value.as_str().unwrap()),
+                IonType::List | IonType::SExpression => {
+                    let elements: Vec<OwnedElement> = value
+                        .as_sequence()
+                        .unwrap()
+                        .iter()
+                        .map(|oe| oe.to_owned())
+                        .collect();
+                    elements
+                }
+                _ => {
+                    panic!("invalid document")
+                }
+            };
+            // println!("{:?}", sequence);
+            return IonSchemaElement::Document(sequence);
+        }
+        IonSchemaElement::Element(value.to_owned())
+    }
+}
+
+// helper function to be used by schema tests
+fn load(text: &str) -> Vec<OwnedElement> {
+    element_reader()
+        .read_all(text.as_bytes())
+        .expect("parsing failed unexpectedly")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,8 @@ pub enum IonSchemaElement {
 impl IonSchemaElement {
     pub fn as_element(&self) -> Option<&OwnedElement> {
         match self {
-            IonSchemaElement::SingleElement(element) => {
-                Some(element)
-            }
-            IonSchemaElement::Document(_) => {
-                None
-            }
+            IonSchemaElement::SingleElement(element) => Some(element),
+            IonSchemaElement::Document(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl From<&OwnedElement> for IonSchemaElement {
     fn from(value: &OwnedElement) -> Self {
         if value.annotations().any(|a| a.text() == Some("document")) {
             let sequence = match value.ion_type() {
-                IonType::String => load(&value.as_str().unwrap()),
+                IonType::String => load(value.as_str().unwrap()),
                 IonType::List | IonType::SExpression => {
                     let elements: Vec<OwnedElement> = value
                         .as_sequence()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,22 @@ pub mod external {
 }
 
 /// Provide an Ion schema element which includes all OwnedElements and a document type
+///
+/// ## Example:
+/// In general `TypeRef` `validate()` takes in IonSchemaElement as the value to be validated.
+/// In order to create an `IonSchemaElement`:
+///
+/// ```
+/// use ion_rs::value::owned::OwnedElement;
+/// use ion_schema::IonSchemaElement;
+///
+/// // create an IonSchemaElement from an OwnedElement
+/// let owned_element: OwnedElement = 4.into();
+/// let ion_schema_element: IonSchemaElement = (&owned_element).into();
+///
+/// // create an IonSchemaElement for document type based on vector of owned elements
+/// let document: IonSchemaElement = IonSchemaElement::Document(vec![owned_element]);
+/// ```
 pub enum IonSchemaElement {
     Element(OwnedElement),
     Document(Vec<OwnedElement>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ impl IonSchemaElement {
 
     fn expect_element_of_type(
         &self,
-        constraint_name: &str,
         types: &[IonType],
+        constraint_name: &str,
     ) -> Result<&OwnedElement, Violation> {
         match self {
             IonSchemaElement::SingleElement(element) => {
@@ -113,15 +113,10 @@ impl Display for IonSchemaElement {
             }
             IonSchemaElement::Document(document) => {
                 write!(f, "/* Ion document */ ")?;
-                let mut peekable_itr = document.iter().peekable();
-                while peekable_itr.peek() != None {
-                    let value = peekable_itr.next().unwrap();
-                    write!(f, "{}", value)?;
-                    if peekable_itr.peek() != None {
-                        write!(f, " ")?;
-                    }
+                for value in document {
+                    write!(f, "{} ", value)?;
                 }
-                write!(f, " /* end */")
+                write!(f, "/* end */")
             }
         }
     }
@@ -148,6 +143,12 @@ impl From<&OwnedElement> for IonSchemaElement {
             return IonSchemaElement::Document(sequence);
         }
         IonSchemaElement::SingleElement(value.to_owned())
+    }
+}
+
+impl From<&Vec<OwnedElement>> for IonSchemaElement {
+    fn from(value: &Vec<OwnedElement>) -> Self {
+        IonSchemaElement::Document(value.to_owned())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use crate::external::ion_rs::IonType;
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::{Element, Sequence, SymbolToken};
+use std::fmt::{Display, Formatter};
 /// A [`try`]-like macro to workaround the [`Option`]/[`Result`] nested APIs.
 /// These API require checking the type and then calling the appropriate getter function
 /// (which returns a None if you got it wrong). This macro turns the `None` into
@@ -51,9 +52,45 @@ pub mod external {
 /// // create an IonSchemaElement for document type based on vector of owned elements
 /// let document: IonSchemaElement = IonSchemaElement::Document(vec![owned_element]);
 /// ```
+#[derive(Debug, Clone)]
 pub enum IonSchemaElement {
     Element(OwnedElement),
     Document(Vec<OwnedElement>),
+}
+
+impl IonSchemaElement {
+    pub fn as_element(&self) -> Option<&OwnedElement> {
+        match self {
+            IonSchemaElement::Element(element) => {
+                Some(element)
+            }
+            IonSchemaElement::Document(_) => {
+                None
+            }
+        }
+    }
+}
+
+impl Display for IonSchemaElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            IonSchemaElement::Element(element) => {
+                write!(f, "{}", element)
+            }
+            IonSchemaElement::Document(document) => {
+                write!(f, "document::( ")?;
+                let mut peekable_itr = document.iter().peekable();
+                while peekable_itr.peek() != None {
+                    let value = peekable_itr.next().unwrap();
+                    write!(f, "{}", value)?;
+                    if peekable_itr.peek() != None {
+                        write!(f, " ")?;
+                    }
+                }
+                write!(f, " )")
+            }
+        }
+    }
 }
 
 impl From<&OwnedElement> for IonSchemaElement {

--- a/src/system.rs
+++ b/src/system.rs
@@ -377,20 +377,22 @@ impl PendingTypes {
 /// Represents an array of BuiltIn derived ISL types
 /// for more information: https://amzn.github.io/ion-schema/docs/spec.html#type-system
 static DERIVED_ISL_TYPES: [&str; 10] = [
-    "type::{ name: any, one_of: [ blob, bool, clob, decimal,
-                                    float, int, string, symbol, timestamp,
-                                    list, sexp, struct ] }",
     "type::{ name: lob, one_of: [ blob, clob ] }",
     "type::{ name: number, one_of: [ decimal, float, int ] }",
     "type::{ name: text, one_of: [ string, symbol ] }",
-    "type::{ name: $any, one_of: [ $blob, $bool, $clob, $decimal,
-                                    $float, $int, $string, $symbol, $timestamp,
-                                    $list, $sexp, $struct, $null ] }",
     "type::{ name: $lob, one_of: [ $blob, $clob ] }",
     "type::{ name: $number, one_of: [ $decimal, $float, $int ] }",
     "type::{ name: $text, one_of: [ $string, $symbol ] }",
+    "type::{ name: $any, one_of: [ $blob, $bool, $clob, $decimal,
+                                    $float, $int, $string, $symbol, $timestamp,
+                                    $list, $sexp, $struct, $null ] }",
+    // this is just a place holder for document type,
+    // IonSchemaElement::Document(_) type is used to verify the correctness on the validation side
+    "type::{ name: document }",
     "type::{ name: nothing, not: $any }",
-    "type::{ name: document, annotations: required::closed::[\"$ion_schema_document\"], type: any }",
+    "type::{ name: any, one_of: [ blob, bool, clob, decimal,
+                                    float, int, string, symbol, timestamp,
+                                    list, sexp, struct, document ] }",
 ];
 
 pub type TypeId = usize;

--- a/src/system.rs
+++ b/src/system.rs
@@ -390,7 +390,7 @@ static DERIVED_ISL_TYPES: [&str; 10] = [
     "type::{ name: $number, one_of: [ $decimal, $float, $int ] }",
     "type::{ name: $text, one_of: [ $string, $symbol ] }",
     "type::{ name: nothing, not: $any }",
-    "type::{ name: document, annotations: required::closed::[\"document\"], type: any }",
+    "type::{ name: document, annotations: required::closed::[\"$ion_schema_document\"], type: any }",
 ];
 
 pub type TypeId = usize;

--- a/src/system.rs
+++ b/src/system.rs
@@ -527,7 +527,7 @@ impl TypeStore {
 
     /// Provides the [Type] associated with given [TypeId] if it exists in the [TypeStore]  
     /// Otherwise returns None
-    pub fn get_type_by_id(&self, id: TypeId) -> Option<&TypeDefinition> {
+    pub(crate) fn get_type_by_id(&self, id: TypeId) -> Option<&TypeDefinition> {
         self.types_by_id.get(id)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -267,7 +267,7 @@ impl TypeValidator for TypeDefinition {
                     if other_type.name() == &Some("document".to_owned()) {
                         // Verify whether the given derived type is document
                         // And check if it is using enum variant IonSchemaElement::Document
-                        if !matches!(value, IonSchemaElement::Document(_)) {
+                        if value.as_document() == None {
                             return Err(Violation::new(
                                 "type_constraint",
                                 ViolationCode::TypeMismatched,
@@ -393,7 +393,6 @@ impl TypeDefinitionImpl {
             actual_type_id = pending_types.update_anonymous_type(type_id, type_def, type_store);
         }
 
-        // let type_ref = TypeRef::new(final_type_id, Rc::from(type_store.to_owned()));
         Ok(actual_type_id)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,6 +39,46 @@ impl TypeRef {
         self.id
     }
 
+    /// Provides the validation for the given value based on this schema type
+    /// ```
+    /// use ion_rs::value::owned::OwnedElement;
+    /// use ion_schema::IonSchemaElement;
+    /// use ion_schema::authority::{FileSystemDocumentAuthority, DocumentAuthority};
+    /// use ion_schema::system::SchemaSystem;
+    /// use ion_schema::result::IonSchemaResult;
+    /// use std::path::Path;
+    ///
+    /// fn main() -> IonSchemaResult<()> {
+    ///     // create an IonSchemaElement from an OwnedElement
+    ///     let owned_element: OwnedElement = 4.into();
+    ///
+    ///     // create a vector of authorities and construct schema system
+    ///     // this example sets ion-schema-tests submodule as the authority
+    ///     let authorities: Vec<Box<dyn DocumentAuthority>> = vec![Box::new(
+    ///            FileSystemDocumentAuthority::new(Path::new("../ion-schema-tests/")),
+    ///         )];
+    ///     let mut schema_system = SchemaSystem::new(authorities);
+    ///
+    ///     // use this schema_system to load a schema as following
+    ///     // this example uses byte_length schema file from ion-schema-tests submodule
+    ///     let schema = schema_system.load_schema("schema/byte_length.isl")?;
+    ///
+    ///     // definition for int_non_negative type:
+    ///     //
+    ///     // type::{
+    ///     //   name: int_non_negative,
+    ///     //   type: int,
+    ///     //   annotations: [exclusive],
+    ///     //   valid_values: range::[0, max],
+    ///     // }
+    ///
+    ///     // unwrap() here because we know that the `int_non_negative` type exists in byte_length.isl
+    ///     let type_ref = schema.get_type("int_non_negative").unwrap();
+    ///
+    ///     assert!(type_ref.validate(&owned_element).is_ok());
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate<I: Into<IonSchemaElement>>(&self, value: I) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let type_def = self.type_store.get_type_by_id(self.id).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -299,7 +299,7 @@ impl TypeValidator for TypeDefinition {
                         return Ok(());
                     }
                     // if it is not a document type do validation using the type definition
-                    other_type.validate(value.to_owned(), type_store)
+                    other_type.validate(value, type_store)
                 }
             },
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,30 +50,33 @@ impl TypeRef {
     ///
     /// fn main() -> IonSchemaResult<()> {
     ///     // create an IonSchemaElement from an OwnedElement
+    ///     use ion_schema::authority::MapDocumentAuthority;
     ///     let owned_element: OwnedElement = 4.into();
     ///
+    ///     let map_authority = [
+    ///         (
+    ///            "sample.isl",
+    ///             r#"
+    ///                 type::{
+    ///                     name: "my_int",
+    ///                     type: int,
+    ///                 }
+    ///             "#
+    ///         )   
+    ///     ];
+    ///
     ///     // create a vector of authorities and construct schema system
-    ///     // this example sets ion-schema-tests submodule as the authority
+    ///     // this example uses above mentioned map as the authority
     ///     let authorities: Vec<Box<dyn DocumentAuthority>> = vec![Box::new(
-    ///            FileSystemDocumentAuthority::new(Path::new("../ion-schema-tests/")),
+    ///             MapDocumentAuthority::new(map_authority),
     ///         )];
     ///     let mut schema_system = SchemaSystem::new(authorities);
     ///
     ///     // use this schema_system to load a schema as following
-    ///     // this example uses byte_length schema file from ion-schema-tests submodule
-    ///     let schema = schema_system.load_schema("schema/byte_length.isl")?;
+    ///     let schema = schema_system.load_schema("sample.isl")?;
     ///
-    ///     // definition for int_non_negative type:
-    ///     //
-    ///     // type::{
-    ///     //   name: int_non_negative,
-    ///     //   type: int,
-    ///     //   annotations: [exclusive],
-    ///     //   valid_values: range::[0, max],
-    ///     // }
-    ///
-    ///     // unwrap() here because we know that the `int_non_negative` type exists in byte_length.isl
-    ///     let type_ref = schema.get_type("int_non_negative").unwrap();
+    ///     // unwrap() here because we know that the `my_int` type exists in sample.isl
+    ///     let type_ref = schema.get_type("my_int").unwrap();
     ///
     ///     assert!(type_ref.validate(&owned_element).is_ok());
     ///     Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,11 +15,19 @@ use std::rc::Rc;
 pub trait TypeValidator {
     /// If the specified value violates one or more of this type's constraints,
     /// returns `false`, otherwise `true`
-    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> bool;
+    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> bool;
 
     /// Returns `Err(violation)` with details as to which constraints were violated,
     /// otherwise returns `Ok(())` indicating no violations were found during the validation
-    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> ValidationResult;
+    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> ValidationResult;
 }
 
 // Provides a public facing schema type which has a reference to TypeStore
@@ -101,7 +109,8 @@ impl TypeRef {
         let schema_element: IonSchemaElement = value.into();
 
         for constraint in type_def.constraints() {
-            if let Err(violation) = constraint.validate(schema_element.to_owned(), &self.type_store) {
+            if let Err(violation) = constraint.validate(schema_element.to_owned(), &self.type_store)
+            {
                 violations.push(violation);
             }
         }
@@ -219,12 +228,20 @@ impl TypeDefinition {
 }
 
 impl TypeValidator for TypeDefinition {
-    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> bool {
+    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> bool {
         let violation = self.validate(value, type_store);
         violation.is_ok()
     }
 
-    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> ValidationResult {
+    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> ValidationResult {
         let schema_element: IonSchemaElement = value.to_owned().into();
 
         match self {
@@ -246,7 +263,11 @@ impl TypeValidator for TypeDefinition {
                                 return Err(Violation::new(
                                     "type_constraint",
                                     ViolationCode::TypeMismatched,
-                                    &format!("expected type {:?}, found {:?}", ion_type, element.ion_type()),
+                                    &format!(
+                                        "expected type {:?}, found {:?}",
+                                        ion_type,
+                                        element.ion_type()
+                                    ),
                                 ));
                             }
 
@@ -269,10 +290,13 @@ impl TypeValidator for TypeDefinition {
                             return Err(Violation::new(
                                 "type_constraint",
                                 ViolationCode::TypeMismatched,
-                                &format!("expected type document found {:?}", schema_element.as_element().unwrap().ion_type()),
+                                &format!(
+                                    "expected type document found {:?}",
+                                    schema_element.as_element().unwrap().ion_type()
+                                ),
                             ));
                         }
-                        return Ok(())
+                        return Ok(());
                     }
                     // if it is not a document type do validation using the type definition
                     other_type.validate(value.to_owned(), type_store)
@@ -400,12 +424,20 @@ impl PartialEq for TypeDefinitionImpl {
 }
 
 impl TypeValidator for TypeDefinitionImpl {
-    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> bool {
+    fn is_valid<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> bool {
         let violation = self.validate(value, type_store);
         violation.is_ok()
     }
 
-    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(&self, value: I, type_store: &TypeStore) -> ValidationResult {
+    fn validate<I: Into<IonSchemaElement> + std::fmt::Display + Clone>(
+        &self,
+        value: I,
+        type_store: &TypeStore,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let type_name = match self.name() {
             None => "",

--- a/src/types.rs
+++ b/src/types.rs
@@ -100,9 +100,9 @@ impl TypeRef {
         // convert given IonSchemaElement to an OwnedElement
         // converts document type to SExpression
         let value = match value.into() {
-            IonSchemaElement::Element(element) => element.to_owned(),
+            IonSchemaElement::Element(element) => element,
             IonSchemaElement::Document(document) => {
-                OwnedElement::new_sexp(document.to_vec().into_iter())
+                OwnedElement::new_sexp(document.iter().cloned())
                     .with_annotations(vec![text_token("document")])
             }
         };
@@ -356,7 +356,7 @@ impl TypeDefinitionImpl {
             actual_type_id = pending_types.update_named_type(
                 type_id,
                 type_name.as_ref().unwrap(),
-                type_def.to_owned(),
+                type_def,
                 type_store,
             );
 
@@ -364,8 +364,7 @@ impl TypeDefinitionImpl {
             pending_types.clear_parent();
         } else {
             // update with this resolved type_def to context for type_id
-            actual_type_id =
-                pending_types.update_anonymous_type(type_id, type_def.to_owned(), type_store);
+            actual_type_id = pending_types.update_anonymous_type(type_id, type_def, type_store);
         }
 
         // let type_ref = TypeRef::new(final_type_id, Rc::from(type_store.to_owned()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,7 +103,7 @@ impl TypeRef {
             IonSchemaElement::Element(element) => element,
             IonSchemaElement::Document(document) => {
                 OwnedElement::new_sexp(document.iter().cloned())
-                    .with_annotations(vec![text_token("document")])
+                    .with_annotations(vec![text_token("$ion_schema_document")])
             }
         };
 
@@ -450,7 +450,7 @@ mod type_definition_tests {
             { name: my_int, type: { type: my_int } }
          */
         IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))]),
-        TypeDefinition::named("my_int", [Constraint::type_constraint(36)]) // 0-32 are built-in types which are preloaded to the type_store
+        TypeDefinition::named("my_int", [Constraint::type_constraint(36)]) // 0-35 are built-in types which are preloaded to the type_store
     ),
     case::type_constraint_with_nested_type(
         /* For a schema with nested types as below:

--- a/src/types.rs
+++ b/src/types.rs
@@ -234,7 +234,7 @@ impl TypeValidator for TypeDefinition {
                 BuiltInTypeDefinition::Atomic(ion_type, is_nullable) => {
                     // atomic types doesn't include document type
                     match schema_element {
-                        IonSchemaElement::Element(element) => {
+                        IonSchemaElement::SingleElement(element) => {
                             if *is_nullable == Nullability::NotNullable && element.is_null() {
                                 return Err(Violation::new(
                                     "type_constraint",


### PR DESCRIPTION
*Issue #103*

*Description of changes:*
This PR adds implementation of `document` type.

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/spec.html#type-system

> document: represents a series of top-level values

*List of changes:*
* adds `IonSchemaElement` implementation
* `TypeRef` validate method now uses `IonSchemaElement` as input
* `TypeDefinitionImpl`'s `parse_from_isl_type` method now returns a `TypeId`
instead of `TypeDefinitionImpl`
* adds `nullable` annotation check for non built in type references to
return an error
* Remove `document` type tests from skip list
* adds `id()` for `TypeRef` to get the `TypeId` of that `TypeRef`
* adds doc examples

*Tests:*
adds unit tests for document type (removes previously unsupported tests from skip list)