### PR TITLE
adds `wasm-schema-sandbox` to `ion-schema-rust` repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ion-schema-schemas"]
 	path = ion-schema-schemas
 	url = https://github.com/amzn/ion-schema-schemas.git
+[submodule "wasm-schema-sandbox/www/ace-builds"]
+	path = wasm-schema-sandbox/www/ace-builds
+	url = https://github.com/ajaxorg/ace-builds.git

--- a/wasm-schema-sandbox/.gitignore
+++ b/wasm-schema-sandbox/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "wasm-ion-schema"
+version = "0.1.0"
+authors = ["Amazon Ion Team <ion-team@amazon.com>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+wasm-bindgen = "0.2.82"
+ion-schema = { path="../../ion-schema-rust" }
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.6", optional = true }
+
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however.
+#
+# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
+wee_alloc = { version = "0.4.5", optional = true }
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+    "console",
+]
+[dev-dependencies]
+wasm-bindgen-test = "0.3.32"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/wasm-schema-sandbox/LICENSE_APACHE
+++ b/wasm-schema-sandbox/LICENSE_APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/wasm-schema-sandbox/LICENSE_MIT
+++ b/wasm-schema-sandbox/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Khushboo Desai <desaikd@amazon.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/wasm-schema-sandbox/README.md
+++ b/wasm-schema-sandbox/README.md
@@ -1,6 +1,6 @@
 # Ion schema sandbox (Experimental package)
 
-Ion schema sandbox is intended to provide a validation tool to validate an Ion value using Ion schema provided by user.
+Ion schema sandbox is a tool to validate an Ion value against a [schema](https://amzn.github.io/ion-schema/docs/spec/isl-1-0-spec.html) provided by user.
 
 _**Please note, at this stage the code within this package is considered experimental and should not be used for production.**_
 

--- a/wasm-schema-sandbox/README.md
+++ b/wasm-schema-sandbox/README.md
@@ -1,0 +1,56 @@
+# Ion schema sandbox (Experimental package)
+
+Ion schema sandbox is intended to provide a validation tool to validate an Ion value using Ion schema provided by user.
+
+_**Please note, at this stage the code within this package is considered experimental and should not be used for production.**_
+
+## Local Usage
+For local usage follow the below steps.
+
+1. Ensure `wasm-pack` is installed on your machine by running the following command; if not, install it from [here](https://rustwasm.github.io/wasm-pack/installer/):
+```bash
+wasm-pack --version
+```
+2. Ensure `npm` is installed on your machine; see [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for more details:
+```bash
+npm --version
+```
+3. The easiest way to clone the `wasm-schema-sandbox` repository is to run the following command:
+```bash
+git clone --recursive https://github.com/partiql/partiql-lang-rust.git
+```
+4. Enter the `wasm-schema-sandbox` root directory:
+```bash
+cd ion-schema-rust/wasm-schema-sandbox
+```
+5. Run `wasm-pack build`:
+```
+wasm-pack build
+```
+6. Start the node server from `wasm-schema-sandbox` package's `www` directory:
+```bash
+cd wwww
+npm install
+npm run start
+```
+Note: In this step run `npm audit fix` if there are any issues with installing dependencies.
+7. In your browser go to `http://localhost:8000/`
+
+## Development
+`Ion schema sandbox` uses [WebAssembly (Wasm)](https://webassembly.org/) for integrating the front-end with ion-schema-rust back-end.
+Considering this, please install the `wasm-pack` by following the instructions [here](https://github.com/rustwasm/wasm-pack#-prerequisities).
+
+Upon any changes to the package's Rust dependencies (E.g. `ion-schema-rust`) or the wasm code under `./src/lib` of this package, you need to rebuild the Wasm package using the following command from the root of this package:
+```bash
+wasm-pack build --target web
+```
+
+_**Please note, as the package is experimental at this stage, all HTML code and assets reside in this package, but this doesn't necessarily mean that it'll be the case in the future.**_
+
+## Dependencies
+| Package                                                                | License                                                                                         |
+|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| [ace Editor](https://ace.c9.io/)                                       | [BSD License](https://github.com/ajaxorg/ace/blob/master/LICENSE)                               |
+| [node](https://nodejs.org/en/)                                         | [MIT License](https://github.com/nodejs/node/blob/main/LICENSE)                                 |
+| [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)               | [Apache License Version 2.0](https://github.com/rustwasm/wasm-bindgen/blob/main/LICENSE-APACHE) | 
+| [wasm-pack](https://github.com/rustwasm/wasm-pack)                     | [Apache License Version 2.0](https://github.com/rustwasm/wasm-pack/blob/master/LICENSE-APACHE)  |

--- a/wasm-schema-sandbox/README.md
+++ b/wasm-schema-sandbox/README.md
@@ -29,7 +29,7 @@ wasm-pack build
 ```
 6. Start the node server from `wasm-schema-sandbox` package's `www` directory:
 ```bash
-cd wwww
+cd www
 npm install
 npm run start
 ```

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -1,0 +1,213 @@
+use ion_schema::authority::{DocumentAuthority, MapDocumentAuthority};
+use ion_schema::external::ion_rs::value::owned::OwnedElement;
+use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
+use ion_schema::external::ion_rs::IonResult;
+use ion_schema::result::{IonSchemaResult, ValidationResult};
+use ion_schema::schema::Schema;
+use ion_schema::system::SchemaSystem;
+use ion_schema::types::TypeRef;
+use std::rc::Rc;
+use std::str;
+use wasm_bindgen::prelude::*;
+
+extern crate web_sys;
+
+// A macro to provide `println!(..)`-style syntax for `console.log` logging.
+macro_rules! log {
+    ( $( $t:tt )* ) => {
+        web_sys::console::log_1(&format!( $( $t )* ).into());
+    }
+}
+
+// Verify if the given value is valid and print violation for invalid value
+fn check_value(value: OwnedElement, type_ref: &TypeRef) -> ValidationResult {
+    type_ref.validate(&value)
+}
+
+fn load(text: &str) -> IonResult<OwnedElement> {
+    element_reader().read_one(text.as_bytes())
+}
+
+#[wasm_bindgen]
+pub struct SchemaValidationResult {
+    result: bool,
+    violation: String,
+    value: String,
+    has_error: bool,
+    error: String,
+}
+
+#[wasm_bindgen]
+impl SchemaValidationResult {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        r: bool,
+        v: String,
+        val: String,
+        has_error: bool,
+        error: String,
+    ) -> SchemaValidationResult {
+        SchemaValidationResult {
+            result: r,
+            violation: v,
+            value: val,
+            has_error,
+            error,
+        }
+    }
+
+    pub fn result(&self) -> bool {
+        self.result
+    }
+
+    pub fn set_result(&mut self, val: bool) {
+        self.result = val;
+    }
+
+    pub fn violation(&self) -> String {
+        self.violation.to_owned()
+    }
+
+    pub fn set_violation(&mut self, val: String) {
+        self.violation = val;
+    }
+
+    pub fn value(&self) -> String {
+        self.value.to_owned()
+    }
+
+    pub fn set_value(&mut self, val: String) {
+        self.value = val;
+    }
+
+    pub fn error(&self) -> String {
+        self.error.to_owned()
+    }
+
+    pub fn set_error(&mut self, val: String) {
+        self.error = val;
+    }
+
+    pub fn has_error(&self) -> bool {
+        self.has_error.to_owned()
+    }
+
+    pub fn set_has_error(&mut self, val: bool) {
+        self.has_error = val;
+    }
+}
+
+#[wasm_bindgen]
+pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationResult {
+    // map with (id, ion content) to represent `sample_number` schema
+    let map_authority = [("sample_number.isl", schema)];
+
+    log!("inside schema validation function");
+    // Create a MapDocumentAuthority using a map like above with
+    // schema id as key and schema as value
+    let map_document_authority = MapDocumentAuthority::new(map_authority);
+    let document_authorities: Vec<Box<dyn DocumentAuthority>> =
+        vec![Box::new(map_document_authority)];
+
+    // Create a new schema system using given document authorities
+    let mut schema_system = SchemaSystem::new(document_authorities);
+
+    log!("created schema system successfully!");
+
+    // Provide schema id for the schema you want to load (schema_id is the schema file name here)
+    let schema_id = "sample_number.isl";
+
+    // Load schema
+    let schema_result: IonSchemaResult<Rc<Schema>> = schema_system.load_schema(schema_id);
+
+    match &schema_result {
+        Ok(_) => {}
+        Err(_error) => {
+            // TODO: once we have a better Display for _error, replace the error portion of SchemaValidationResult to take this _error
+            return SchemaValidationResult::new(
+                false,
+                "".to_string(),
+                ion.to_string(),
+                true,
+                "Can not load given schema!\nPlease check Ion schema syntax for given schema."
+                    .to_string(),
+            );
+        }
+    };
+
+    let schema: Rc<Schema> = schema_result.unwrap();
+
+    log!("loaded schema successfully!");
+
+    // This example uses a schema that was created using how to load a schema section (`my_schema.isl`)?
+    // Retrieve a particular type from this schema
+    let type_ref_result: Option<TypeRef> = schema.get_type(schema_type);
+
+    let type_ref = match &type_ref_result {
+        Some(type_ref) => type_ref,
+        None => {
+            return SchemaValidationResult::new(
+                false,
+                "".to_string(),
+                ion.to_string(),
+                true,
+                format!(
+                    "Type definition: {} does not exist in this schema",
+                    schema_type
+                ),
+            )
+        }
+    };
+
+    log!(
+        "{}",
+        format!("got type definition for: {} successfully!", schema_type)
+    );
+
+    // get OwnedElement from given ion text
+    let value_result = load(ion);
+
+    let value = match value_result {
+        Ok(v) => v,
+        Err(_) => {
+            return SchemaValidationResult::new(
+                false,
+                "".to_string(),
+                ion.to_string(),
+                true,
+                format!(
+                    "Can not parse given Ion value: {} for validation",
+                    ion.to_string()
+                ),
+            )
+        }
+    };
+
+    log!("loaded ion value successfully!");
+
+    // Validate data based on the type: 'my_int_type'
+    let result = check_value(value.to_owned(), &type_ref);
+
+    log!("validation complete!");
+
+    let violation = match &result {
+        Ok(_) => "".to_string(),
+        Err(violation) => {
+            format!("{:#?}", violation)
+        }
+    };
+
+    log!("Creating validation result....");
+
+    let result: SchemaValidationResult = SchemaValidationResult::new(
+        result.is_ok(),
+        violation.to_owned(),
+        format!("{}", value),
+        false,
+        "".to_string(),
+    );
+
+    log!("Schema validation was successful!");
+
+    result
+}

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -171,10 +171,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
                 "".to_string(),
                 ion.to_string(),
                 true,
-                format!(
-                    "Can not parse given Ion value: {} for validation",
-                    ion.to_string()
-                ),
+                format!("Can not parse given Ion value: {} for validation", ion),
             )
         }
     };
@@ -197,7 +194,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
 
     let result: SchemaValidationResult = SchemaValidationResult::new(
         result.is_ok(),
-        violation.to_owned(),
+        violation,
         format!("{}", value),
         false,
         "".to_string(),

--- a/wasm-schema-sandbox/tests/web.rs
+++ b/wasm-schema-sandbox/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}

--- a/wasm-schema-sandbox/www/.gitignore
+++ b/wasm-schema-sandbox/www/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/wasm-schema-sandbox/www/LICENSE-APACHE
+++ b/wasm-schema-sandbox/www/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/wasm-schema-sandbox/www/LICENSE-MIT
+++ b/wasm-schema-sandbox/www/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) [year] [name]
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/wasm-schema-sandbox/www/bootstrap.js
+++ b/wasm-schema-sandbox/www/bootstrap.js
@@ -1,0 +1,5 @@
+// A dependency graph that contains any wasm must all be imported
+// asynchronously. This `bootstrap.js` file does the single async import, so
+// that no one else needs to worry about it again.
+import("./index.js")
+  .catch(e => console.error("Error importing `index.js`:", e));

--- a/wasm-schema-sandbox/www/css/ion-schema-sandbox.css
+++ b/wasm-schema-sandbox/www/css/ion-schema-sandbox.css
@@ -1,0 +1,63 @@
+#sandbox {
+    padding-left: 10%;
+    padding-top: 2%;
+}
+#schema {
+    width: 500px;
+    height: 200px;
+    position: relative;
+}
+#value {
+    width: 500px;
+    height: 100px;
+    position: relative;
+}
+pre {
+    color: #009926;
+}
+button {
+    background-color: #fff;
+    border: 1px solid #d5d9d9;
+    border-radius: 8px;
+    box-shadow: rgba(213, 217, 217, .5) 0 2px 5px 0;
+    box-sizing: border-box;
+    color: #0f1111;
+    cursor: pointer;
+    display: inline-block;
+    font-family: "Amazon Ember",sans-serif;
+    font-size: 13px;
+    line-height: 29px;
+    padding: 0 10px 0 11px;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: manipulation;
+    vertical-align: middle;
+    width: 100px;
+}
+button:hover {
+    background-color: #f7fafa;
+}
+
+button:focus {
+    border-color: #008296;
+    box-shadow: rgba(213, 217, 217, .5) 0 2px 5px 0;
+    outline: 0;
+}
+#violation {
+    border-left: 0px;
+    background: white;
+    color: red;
+    text-align: left;
+}
+#result {
+    border-left: 0px;
+    background: white;
+}
+label {
+    display: block;
+    margin-bottom: 10px;
+    font-size: medium;
+}

--- a/wasm-schema-sandbox/www/index.html
+++ b/wasm-schema-sandbox/www/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <meta charset="utf-8">
+      <title>Ion Schema Sandbox</title>
+      <link rel="stylesheet" href="./css/ion-schema-sandbox.css"/>
+      <script src="./bootstrap.js"></script>
+      <script src="/ace-builds/src-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+  </head>
+  <body>
+  <div id="sandbox">
+      <h3>Ion Schema Sandbox</h3>
+      <label for="schema">Ion schema:</label>
+      <div id="schema"></div>
+      <br>
+      <label for="schema_type">Schema type to be used for validation:</label>
+      <input type="text" id="schema_type" placeholder="e.g. my_type" name="schema_type" rows="5" cols="33"/>
+      <br>
+      <br>
+      <label for="value">Ion input data to be validated:</label>
+      <div id="value"></div>
+      <br>
+      <br>
+      <button id="validate" type="submit">validate</button>
+      <h3><pre id="result"></pre></h3>
+      <br>
+      <h3><pre id="violation"></pre></h3>
+  </div>
+  </body>
+</html>

--- a/wasm-schema-sandbox/www/index.js
+++ b/wasm-schema-sandbox/www/index.js
@@ -1,0 +1,51 @@
+import * as ion from "wasm-ion-schema";
+
+const validateButton = document.getElementById("validate");
+function loadPage() {
+    document.getElementById("schema_type").setAttribute("placeholder", "e.g. my_type");
+    document.getElementById("schema_type").value = "";
+    var schemaEditor = ace.edit("schema");
+    schemaEditor.setOptions({
+        mode: 'ace/mode/ion',
+        theme: 'ace/theme/base',
+        placeholder: "Write your schema here!\ne.g. type::{ name: my_type, type: string }",
+    });
+
+    var valueEditor = ace.edit("value");
+    valueEditor.setOptions({
+        mode: 'ace/mode/ion',
+        theme: 'ace/theme/base',
+        placeholder: "e.g. \"hello\"",
+    });
+}
+
+loadPage();
+const show = () => {
+    const pre = document.getElementById('result');
+    const schemaContent = document.getElementById('schema').getElementsByClassName("ace_scroller").item(0).innerText;
+    const valueContent = document.getElementById('value').getElementsByClassName("ace_scroller").item(0).innerText;
+
+    const result = ion.validate(valueContent, schemaContent, document.getElementById('schema_type').value);
+    const violation = document.getElementById('violation');
+    violation.textContent = result.violation();
+
+    if (result.has_error()) {
+        alert(result.error());
+    }
+    if (result.result()) {
+        pre.style.color = "#009926";
+        pre.textContent = result.value() + " is valid!";
+    } else {
+        if (result.has_error()) {
+            pre.textContent = "";
+        } else {
+            pre.style.color = "#ff0000";
+            pre.textContent = result.value() + " is invalid!\n";
+        }
+    }
+    console.log(result);
+};
+
+validateButton.addEventListener("click", event => {
+    show()
+});

--- a/wasm-schema-sandbox/www/package.json
+++ b/wasm-schema-sandbox/www/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ion-schema-sandbox",
+  "version": "0.1.0",
+  "description": "Creates an app to consume generated ion-schema web assembly code",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack-dev-server"
+  },
+  "keywords": [
+    "webassembly",
+    "wasm",
+    "rust",
+    "webpack",
+    "ion",
+    "schema",
+    "ion-schema"
+  ],
+  "author": "Amazon Ion Team <ion-team@amazon.com>",
+  "license": "(MIT OR Apache-2.0)",
+  "dependencies": {
+    "wasm-ion-schema": "file:../pkg/"
+  },
+  "devDependencies": {
+    "webpack": "^4.29.3",
+    "webpack-cli": "^3.1.0",
+    "webpack-dev-server": "^3.1.5",
+    "copy-webpack-plugin": "^5.0.0"
+  }
+}

--- a/wasm-schema-sandbox/www/webpack.config.js
+++ b/wasm-schema-sandbox/www/webpack.config.js
@@ -1,0 +1,14 @@
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const path = require('path');
+
+module.exports = {
+  entry: "./bootstrap.js",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "bootstrap.js",
+  },
+  mode: "development",
+  plugins: [
+    new CopyWebpackPlugin(['index.html'])
+  ],
+};


### PR DESCRIPTION
*Description of changes:*
This PR works on adding Ion schema sandbox using Web Assembly.

*List of changes:*
* adds Cargo.toml and README.md for the wasm-schema-sandbox
* adds ion-schema-rust va;lidation logic to be generated as wasm
* adds index.html and index.js containing the web app contents for sandbox
* adds ace-builds as submodule which provides Ion editors for sandbox

*Test:*
adds a wasm-bindgen test
