### PR TITLE
bumps version to v0.5.0 and adds reference links to README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 An implementation of [Amazon Ion Schema](http://amzn.github.io/ion-schema) in Rust.
 
+If you want to try out a web tool to validate your Ion values using `ion-schema-rust`, please visit: https://amzn.github.io/ion-schema/sandbox
+
 **This package is considered experimental, under active/early development, and the API is subject to change.**
 
 ## Getting Started
@@ -114,6 +116,8 @@ Violation {
     ],
 }
 ```
+
+For more getting started examples, please visit: https://amzn.github.io/ion-schema/docs/cookbook/ion-schema-rust-getting-started
 
 ## Development
 


### PR DESCRIPTION
*Description of changes:*
This PR bumps version to v0.5.0 and adds reference links to README.

*List of changes:*
* adds version bump change in `Cargo.toml`
* adds reference link to Ion schema sandbox web tool
* adds reference link to Ion schema GitHub website's cookbook examples
