### PR TITLE
Removes dependency to `wee_alloc` and `console_error_panic_hook`

### DIFF
--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -7,25 +7,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["console_error_panic_hook"]
-
 [dependencies]
 wasm-bindgen = "0.2.82"
 ion-schema = { path="../../ion-schema-rust" }
-
-# The `console_error_panic_hook` crate provides better debugging of panics by
-# logging them with `console.error`. This is great for development, but requires
-# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
-# code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
-
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
*Description of changes:*
This PR removes dependency to `wee_alloc` and `console_error_panic_hook`. 

