### PR TITLE
Fix error message for unsupported ISL version

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -778,9 +778,10 @@ impl Resolver {
             {
                 // This implementation only supports Ion Schema 1.0
                 if value.as_str() != Some(r"$ion_schema_1_0") {
-                    return invalid_schema_error(
-                        "Unsupported Ion Schema version: ${it.stringValue()}",
-                    );
+                    return invalid_schema_error(format!(
+                        "Unsupported Ion Schema version: {}",
+                        value
+                    ));
                 }
             }
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

When I was testing something out with `ion-schema-rust`, I saw that the error message said "Unsupported Ion Schema version: ${it.stringValue()}"—this changes it to use `format!` instead of Kotlin string interpolation so that the message will be like  "Unsupported Ion Schema version: $ion_schema_0_1"


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
