### PR TITLE
adds `Display` implementation of `Range`

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1529,13 +1529,12 @@ impl ValidValuesConstraint {
 impl Display for ValidValuesConstraint {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "[ ")?;
-        let mut peekable_itr = self.valid_values.iter().peekable();
-        while peekable_itr.peek().is_some() {
-            let valid_value = peekable_itr.next().unwrap();
-            write!(f, "{}", valid_value)?;
-            if peekable_itr.peek().is_some() {
-                write!(f, ", ")?;
-            }
+        let mut itr = self.valid_values.iter();
+        if let Some(item) = itr.next() {
+            write!(f, "{}", item)?;
+        }
+        while let Some(item) = itr.next() {
+            write!(f, ", {}", item)?;
         }
         write!(f, " ]")
     }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -16,6 +16,7 @@ use ion_rs::{Integer, IonType};
 use regex::{Regex, RegexBuilder};
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::fmt::{Display, Formatter};
 use std::iter::Peekable;
 use std::str::Chars;
 
@@ -1525,6 +1526,21 @@ impl ValidValuesConstraint {
     }
 }
 
+impl Display for ValidValuesConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "[ ")?;
+        let mut peekable_itr = self.valid_values.iter().peekable();
+        while peekable_itr.peek().is_some() {
+            let valid_value = peekable_itr.next().unwrap();
+            write!(f, "{}", valid_value)?;
+            if peekable_itr.peek().is_some() {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, " ]")
+    }
+}
+
 impl ConstraintValidator for ValidValuesConstraint {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         match value {
@@ -1556,7 +1572,7 @@ impl ConstraintValidator for ValidValuesConstraint {
                     "valid_values",
                     ViolationCode::InvalidValue,
                     &format!(
-                        "expected valid_values to be from {:?}, found {:?}",
+                        "expected valid_values to be from {}, found {}",
                         &self, value
                     ),
                 ))
@@ -1565,7 +1581,7 @@ impl ConstraintValidator for ValidValuesConstraint {
                 "valid_values",
                 ViolationCode::InvalidValue,
                 &format!(
-                    "expected valid_values to be from {:?}, found {:?}",
+                    "expected valid_values to be from {}, found {}",
                     &self, value
                 ),
             )),

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1533,7 +1533,7 @@ impl Display for ValidValuesConstraint {
         if let Some(item) = itr.next() {
             write!(f, "{}", item)?;
         }
-        while let Some(item) = itr.next() {
+        for item in itr {
             write!(f, ", {}", item)?;
         }
         write!(f, " ]")

--- a/src/isl/isl_range.rs
+++ b/src/isl/isl_range.rs
@@ -683,7 +683,7 @@ impl<T: PartialOrd> RangeImpl<T> {
 
 impl<T: Display> Display for RangeImpl<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "[ {}, {} ]", &self.start, &self.end)
+        write!(f, "range::[ {}, {} ]", &self.start, &self.end)
     }
 }
 
@@ -874,14 +874,7 @@ impl<T: Display> Display for RangeBoundaryValue<T> {
                 Max => "max".to_string(),
                 Min => "min".to_string(),
                 Value(value, range_boundary_type) => {
-                    format!(
-                        "{}{}",
-                        match range_boundary_type {
-                            RangeBoundaryType::Inclusive => "",
-                            RangeBoundaryType::Exclusive => "exclusive::",
-                        },
-                        value
-                    )
+                    format!("{}{}", range_boundary_type, value)
                 }
             }
         )
@@ -893,6 +886,19 @@ impl<T: Display> Display for RangeBoundaryValue<T> {
 pub enum RangeBoundaryType {
     Inclusive,
     Exclusive,
+}
+
+impl Display for RangeBoundaryType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match &self {
+                RangeBoundaryType::Inclusive => "",
+                RangeBoundaryType::Exclusive => "exclusive::",
+            }
+        )
+    }
 }
 
 /// Represents if the range is non negative integer range or not

--- a/src/isl/isl_range.rs
+++ b/src/isl/isl_range.rs
@@ -10,6 +10,7 @@ use ion_rs::value::{IonElement, IonSequence};
 use ion_rs::{Decimal, Integer, IonType, Timestamp};
 use num_bigint::BigInt;
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 use std::prelude::rust_2021::TryInto;
 use std::str::FromStr;
 
@@ -363,6 +364,22 @@ impl From<NumberRange> for Range {
     }
 }
 
+impl Display for Range {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match &self {
+            Range::Integer(integer) => write!(f, "{}", integer),
+            Range::NonNegativeInteger(non_negative_integer) => {
+                write!(f, "{}", non_negative_integer)
+            }
+            Range::TimestampPrecision(timestamp_precision) => write!(f, "{}", timestamp_precision),
+            Range::Timestamp(timestamp) => write!(f, "{}", timestamp),
+            Range::Decimal(decimal) => write!(f, "{}", decimal),
+            Range::Float(float) => write!(f, "{}", float),
+            Range::Number(number) => write!(f, "{}", number),
+        }
+    }
+}
+
 /// Represents a generic range where some constraints can be defined using this range
 // this is a generic implementation of ranges
 #[derive(Debug, Clone, PartialEq)]
@@ -664,6 +681,12 @@ impl<T: PartialOrd> RangeImpl<T> {
     }
 }
 
+impl<T: Display> Display for RangeImpl<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "[ {}, {} ]", &self.start, &self.end)
+    }
+}
+
 // This lets us turn any `T` into a RangeBoundaryValue<T>::Value(_, Inclusive)
 impl<T> From<T> for RangeBoundaryValue<T> {
     fn from(value: T) -> RangeBoundaryValue<T> {
@@ -842,6 +865,29 @@ impl<T: std::cmp::PartialOrd> PartialOrd for RangeBoundaryValue<T> {
     }
 }
 
+impl<T: Display> Display for RangeBoundaryValue<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match &self {
+                Max => "max".to_string(),
+                Min => "min".to_string(),
+                Value(value, range_boundary_type) => {
+                    format!(
+                        "{}{}",
+                        match range_boundary_type {
+                            RangeBoundaryType::Inclusive => "",
+                            RangeBoundaryType::Exclusive => "exclusive::",
+                        },
+                        value
+                    )
+                }
+            }
+        )
+    }
+}
+
 /// Represents the range boundary types in terms of exclusivity (i.e. inclusive or exclusive)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum RangeBoundaryType {
@@ -920,5 +966,11 @@ impl From<&Integer> for Number {
                 Integer::BigInt(big_int_val) => big_int_val.to_owned().into(),
             },
         }
+    }
+}
+
+impl Display for Number {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", &self.big_decimal_value)
     }
 }

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -652,42 +652,42 @@ mod isl_tests {
             RangeBoundaryValue::Min,
             IntegerValue::I64(5)
         ).unwrap(),
-        "[ min, 5 ]"
+        "range::[ min, 5 ]"
     ),
     case::range_with_float(
         FloatRange::new(
             2e1,
             5e1
         ).unwrap(),
-        "[ 20, 50 ]"
+        "range::[ 20, 50 ]"
     ),
     case::range_with_decimal(
         DecimalRange::new(
             Decimal::new(204, -1),
             Decimal::new(505, -1)
         ).unwrap(),
-        "[ 204d-1, 505d-1 ]"
+        "range::[ 204d-1, 505d-1 ]"
     ),
     case::range_with_timestamp(
         TimestampRange::new(
             Timestamp::with_year(2020).with_month(1).with_day(1).build().unwrap(),
             Timestamp::with_year(2021).with_month(1).with_day(1).build().unwrap()
         ).unwrap(),
-        "[ 2020-01-01T, 2021-01-01T ]"
+        "range::[ 2020-01-01T, 2021-01-01T ]"
     ),
     case::range_with_timestamp_precision(
         TimestampPrecisionRange::new(
             TimestampPrecision::Year,
             TimestampPrecision::Month
         ).unwrap(),
-        "[ year, month ]"
+        "range::[ year, month ]"
     ),
     case::range_with_number(
         NumberRange::new(
             Number::from(&IntegerValue::I64(1)),
             Number::try_from(&Decimal::new(55, -1)).unwrap()
         ).unwrap(),
-        "[ 1, 5.5 ]"
+        "range::[ 1, 5.5 ]"
     )
     )]
     fn range_display(range: impl Into<Range>, expected: String) {

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -5,6 +5,7 @@ use ion_rs::value::owned::{text_token, Element};
 use ion_rs::value::IonElement;
 use ion_rs::Timestamp;
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 
 /// Represents an annotation for `annotations` constraint.
 /// Grammar: <ANNOTATION> ::= <SYMBOL>
@@ -134,6 +135,28 @@ impl PartialOrd for TimestampPrecision {
     }
 }
 
+impl Display for TimestampPrecision {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match &self {
+                TimestampPrecision::Year => "year",
+                TimestampPrecision::Month => "month",
+                TimestampPrecision::Day => "day",
+                TimestampPrecision::Minute => "minute",
+                TimestampPrecision::Second => "second",
+                TimestampPrecision::Millisecond => "millisecond",
+                TimestampPrecision::Microsecond => "microsecond",
+                TimestampPrecision::Nanosecond => "nanosecond",
+                TimestampPrecision::OtherFractionalSeconds(_) => {
+                    "fractional second"
+                }
+            }
+        )
+    }
+}
+
 /// Represents a valid value to be ued within `valid_values` constraint
 /// ValidValue could either be a range or Element
 /// Grammar: <VALID_VALUE> ::= <VALUE>
@@ -161,6 +184,15 @@ impl TryFrom<&Element> for ValidValue {
             )
         } else {
             Ok(ValidValue::Element(value.to_owned()))
+        }
+    }
+}
+
+impl Display for ValidValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            ValidValue::Range(range) => write!(f, "{}", range),
+            ValidValue::Element(element) => write!(f, "{}", element),
         }
     }
 }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -138,14 +138,14 @@ impl PartialOrd for TimestampPrecision {
 impl Display for TimestampPrecision {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match &self {
-            TimestampPrecision::Year => write!(f, "{}", "year"),
-            TimestampPrecision::Month => write!(f, "{}", "month"),
-            TimestampPrecision::Day => write!(f, "{}", "day"),
-            TimestampPrecision::Minute => write!(f, "{}", "minute"),
-            TimestampPrecision::Second => write!(f, "{}", "second"),
-            TimestampPrecision::Millisecond => write!(f, "{}", "millisecond"),
-            TimestampPrecision::Microsecond => write!(f, "{}", "microsecond"),
-            TimestampPrecision::Nanosecond => write!(f, "{}", "nanosecond"),
+            TimestampPrecision::Year => write!(f, "year"),
+            TimestampPrecision::Month => write!(f, "month"),
+            TimestampPrecision::Day => write!(f, "day"),
+            TimestampPrecision::Minute => write!(f, "minute"),
+            TimestampPrecision::Second => write!(f, "second"),
+            TimestampPrecision::Millisecond => write!(f, "millisecond"),
+            TimestampPrecision::Microsecond => write!(f, "microsecond"),
+            TimestampPrecision::Nanosecond => write!(f, "nanosecond"),
             TimestampPrecision::OtherFractionalSeconds(scale) => {
                 write!(f, "fractional second (10e{})", scale * -1)
             }

--- a/src/isl/util.rs
+++ b/src/isl/util.rs
@@ -137,23 +137,19 @@ impl PartialOrd for TimestampPrecision {
 
 impl Display for TimestampPrecision {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "{}",
-            match &self {
-                TimestampPrecision::Year => "year",
-                TimestampPrecision::Month => "month",
-                TimestampPrecision::Day => "day",
-                TimestampPrecision::Minute => "minute",
-                TimestampPrecision::Second => "second",
-                TimestampPrecision::Millisecond => "millisecond",
-                TimestampPrecision::Microsecond => "microsecond",
-                TimestampPrecision::Nanosecond => "nanosecond",
-                TimestampPrecision::OtherFractionalSeconds(_) => {
-                    "fractional second"
-                }
+        match &self {
+            TimestampPrecision::Year => write!(f, "{}", "year"),
+            TimestampPrecision::Month => write!(f, "{}", "month"),
+            TimestampPrecision::Day => write!(f, "{}", "day"),
+            TimestampPrecision::Minute => write!(f, "{}", "minute"),
+            TimestampPrecision::Second => write!(f, "{}", "second"),
+            TimestampPrecision::Millisecond => write!(f, "{}", "millisecond"),
+            TimestampPrecision::Microsecond => write!(f, "{}", "microsecond"),
+            TimestampPrecision::Nanosecond => write!(f, "{}", "nanosecond"),
+            TimestampPrecision::OtherFractionalSeconds(scale) => {
+                write!(f, "fractional second (10e{})", scale * -1)
             }
-        )
+        }
     }
 }
 


### PR DESCRIPTION
*Issue #112*

*Description of changes:*
This PR works on adding `Display` implementation of `Range`.

*Test:*
adds unit tests for `Display` implementation of `Range`.

*Base PR:*
https://github.com/amzn/ion-schema-rust/pull/120

*TODO for follow up PR*
- There are many places in the error messages where we could now use the `Element` `Display` implementation of ion-rs.
