### PR TITLE
Updates `wasm-schema-sandbox` package with latest `ion-rust` Element API changes

### DIFF
--- a/wasm-schema-sandbox/README.md
+++ b/wasm-schema-sandbox/README.md
@@ -17,7 +17,7 @@ npm --version
 ```
 3. The easiest way to clone the `wasm-schema-sandbox` repository is to run the following command:
 ```bash
-git clone --recursive https://github.com/partiql/partiql-lang-rust.git
+git clone --recursive https://github.com/amzn/ion-schema-rust.git
 ```
 4. Enter the `wasm-schema-sandbox` root directory:
 ```bash

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -1,5 +1,5 @@
 use ion_schema::authority::{DocumentAuthority, MapDocumentAuthority};
-use ion_schema::external::ion_rs::value::owned::OwnedElement;
+use ion_schema::external::ion_rs::value::owned::Element;
 use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
 use ion_schema::external::ion_rs::IonResult;
 use ion_schema::result::IonSchemaResult;
@@ -19,7 +19,7 @@ macro_rules! log {
     }
 }
 
-fn load(text: &str) -> IonResult<OwnedElement> {
+fn load(text: &str) -> IonResult<Element> {
     element_reader().read_one(text.as_bytes())
 }
 
@@ -160,7 +160,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
         format!("got type definition for: {} successfully!", schema_type)
     );
 
-    // get OwnedElement from given ion text
+    // get Element from given ion text
     let value_result = load(ion);
 
     let value = match value_result {


### PR DESCRIPTION
*Description of changes:*
This PR updates `wasm-schema-sandbox` with latest `ion-rust` Element API changes. 

*List of changes:*
- changes all `OwnedElement` references to `Element` as `ion-rust` latest version renamed the struct
- changes README.md with `ion-schema-rust` clone instruction.

*Test:*
Locally tested with `wasm-pack build`.
