### PR TITLE
Adds an error check for top level type definition's `name` field

### DIFF
--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -22,6 +22,15 @@ impl IslType {
         IslType::Anonymous(IslTypeImpl::new(None, constraints.into()))
     }
 
+    /// Provides a name if the ISL type is named type definition
+    /// Otherwise returns None
+    pub fn name(&self) -> &Option<String> {
+        match self {
+            IslType::Named(named_isl_type) => named_isl_type.name(),
+            IslType::Anonymous(_) => &None,
+        }
+    }
+
     /// Provides the underlying constraints of [IslTypeImpl]
     pub fn constraints(&self) -> &[IslConstraint] {
         match &self {

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -73,7 +73,7 @@
 //                    returning resolved types in a schema) and store generated [TypeId] in the constraint.
 
 use crate::isl::isl_import::{IslImport, IslImportType};
-use crate::isl::isl_type::IslTypeImpl;
+use crate::isl::isl_type::IslType;
 
 pub mod isl_constraint;
 pub mod isl_import;
@@ -88,9 +88,9 @@ pub struct IslSchema {
     // Represents all the IslImports inside the schema file.
     // For more information: https://amzn.github.io/ion-schema/docs/spec.html#imports
     imports: Vec<IslImport>,
-    // Represents all the IslTypeImpls defined in this schema file.
+    // Represents all the IslType defined in this schema file.
     // For more information: https://amzn.github.io/ion-schema/docs/spec.html#type-definitions
-    types: Vec<IslTypeImpl>,
+    types: Vec<IslType>,
     // Represents all the inline IslImportTypes in this schema file.
     inline_imported_types: Vec<IslImportType>,
 }
@@ -98,7 +98,7 @@ pub struct IslSchema {
 impl IslSchema {
     pub fn new(
         imports: Vec<IslImport>,
-        types: Vec<IslTypeImpl>,
+        types: Vec<IslType>,
         inline_imports: Vec<IslImportType>,
     ) -> Self {
         Self {
@@ -112,7 +112,7 @@ impl IslSchema {
         &self.imports
     }
 
-    pub fn types(&self) -> &[IslTypeImpl] {
+    pub fn types(&self) -> &[IslType] {
         &self.types
     }
 


### PR DESCRIPTION
*Description of changes:*
This PR adds an error check for a top level type definition `name` field.

*List of changes:*
- modifies `IslSchema#types()` to return `IslType` instead of `IslTypeImpl`
- adds `name()` method for `IslType`
- adds an error check for top level type def `name` field
- adds a unit test for this error check

*Test:*
Adds a unit test for the error check