### PR TITLE
adds check for `name` field's Ion type and occurence in type definition

### DIFF
--- a/src/isl/isl_type.rs
+++ b/src/isl/isl_type.rs
@@ -89,12 +89,24 @@ impl IslTypeImpl {
         let ion_struct = try_to!(ion.as_struct());
 
         // parses the name of the type specified by schema
+        if ion_struct.get_all("name").count() > 1 {
+            return Err(invalid_schema_error_raw(
+                "type definition must only contain a single field that represents name of the type",
+            ));
+        }
         let type_name: Option<String> = match ion_struct.get("name") {
-            Some(name_element) => match name_element.as_str() {
-                Some(name) => Some(name.to_owned()),
+            Some(name_element) => match name_element.as_sym() {
+                Some(name_symbol) => match name_symbol.text() {
+                    None => {
+                        return Err(invalid_schema_error_raw(
+                            "type names must be a symbol with defined text",
+                        ))
+                    }
+                    Some(name) => Some(name.to_owned()),
+                },
                 None => {
                     return Err(invalid_schema_error_raw(
-                        "type names must be a string or a symbol with defined text",
+                        "type names must be a symbol with defined text",
                     ))
                 }
             },

--- a/src/system.rs
+++ b/src/system.rs
@@ -1667,6 +1667,43 @@ mod schema_system_tests {
     }
 
     #[test]
+    fn top_level_type_def_with_multiple_name_field() {
+        // map with (id, ion content)
+        let map_authority = [(
+            "sample.isl",
+            r#"
+                    type::{
+                        name: my_type,
+                        name: new_type
+                    }
+                "#,
+        )];
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema return error for top level type definition with multiple `name` field
+        let schema = schema_system.load_schema("sample.isl");
+        assert!(schema.is_err());
+    }
+
+    #[test]
+    fn top_level_type_def_with_non_symbol_name_field() {
+        // map with (id, ion content)
+        let map_authority = [(
+            "sample.isl",
+            r#"
+                    type::{
+                        name: "my_type"
+                    }
+                "#,
+        )];
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        // verify if the schema return error for top level type definition with a `name` field of string type
+        let schema = schema_system.load_schema("sample.isl");
+        assert!(schema.is_err());
+    }
+
+    #[test]
     fn valid_isl_version_marker_test() {
         // map with (id, ion content)
         let map_authority = [(

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,7 +59,7 @@ impl TypeRef {
     ///            "sample.isl",
     ///             r#"
     ///                 type::{
-    ///                     name: "my_int",
+    ///                     name: my_int,
     ///                     type: int,
     ///                 }
     ///             "#


### PR DESCRIPTION
*Description of changes:*
This PR works on issues related to `name` field in a type definition as mentioned in https://github.com/amzn/ion-schema-rust/pull/124#discussion_r1023352762.

*Issue:*
Type definitions described as below with multiple `name` fields and of non symbol type should return an error:
```
// invalid type definition with multiple names
type:: {
   name: my_type,
   name: new_type
}

// invalid type definition which has `name` field with non symbol type
type:: {
     name: "my_type"
}
```

*List of changes:*
- adds check for multiple `name` fields in a type definition
- adds check for non symbol `name` field values
- modifies doc tests to not accept string as type name

*Tests*
- adds unit tests for both occurrence and type of `name` field in type definition
