### PR TITLE
bumps version to `v0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
*Description of changes:*
This PR bumps version to `v0.6.0`.