### PR TITLE
adds changes for `utf8_byte_length` constraint

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -687,7 +687,7 @@ impl OrderedElementsConstraint {
 
         // greedily take as many values as we can of this type without going out
         // of the maximum of the range
-        while values_iter.peek() != None && occurs_range.contains(&(count + 1).into()) {
+        while Option::is_some(&values_iter.peek()) && occurs_range.contains(&(count + 1).into()) {
             // don't consume it until we know it's valid for the type
             if let Some(value) = values_iter.peek() {
                 let schema_element: IonSchemaElement = (*value).into();
@@ -703,7 +703,7 @@ impl OrderedElementsConstraint {
         }
 
         // verify if there is no values left to validate and if it follows `occurs` constraint for this expected type
-        if values_iter.peek() == None && !occurs_range.contains(&count.into()) {
+        if Option::is_none(&values_iter.peek()) && !occurs_range.contains(&count.into()) {
             // there's not enough values of this expected type
             return Err(Violation::new(
                 "ordered_elements",
@@ -759,7 +759,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
             )?;
         }
 
-        if values_iter.peek() != None {
+        if Option::is_some(&values_iter.peek()) {
             // check if there still values left at the end of sequence (list/sexp), when we have already
             // completed visiting through all of the ordered elements type_defs
             Err(Violation::with_violations(
@@ -1235,7 +1235,7 @@ impl AnnotationsConstraint {
     ) -> bool {
         // As there are open content possible for annotations that doesn't have list-level `closed` annotation
         // traverse through the next annotations to find this expected, ordered and required annotation
-        while value_annotations.peek() != None && !self.is_closed {
+        while Option::is_some(&value_annotations.peek()) && !self.is_closed {
             if expected_annotation.value() == value_annotations.next().unwrap() {
                 return true;
             }
@@ -1284,7 +1284,7 @@ impl AnnotationsConstraint {
             }
         }
 
-        if self.is_closed && value_annotations.peek() != None {
+        if self.is_closed && Option::is_some(&value_annotations.peek()) {
             // check if there are still annotations left at the end of the list
             return Err(Violation::with_violations(
                 "annotations",

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -52,6 +52,7 @@ pub enum Constraint {
     Scale(ScaleConstraint),
     TimestampPrecision(TimestampPrecisionConstraint),
     Type(TypeConstraint),
+    Utf8ByteLength(Utf8ByteLengthConstraint),
     ValidValues(ValidValuesConstraint),
 }
 
@@ -157,6 +158,13 @@ impl Constraint {
         Constraint::TimestampPrecision(TimestampPrecisionConstraint::new(
             Range::TimestampPrecision(precision),
         ))
+    }
+
+    /// Creates a [Constraint::Utf8ByteLength] from a [Range] specifying a length range.
+    pub fn utf8_byte_length(length: RangeImpl<usize>) -> Constraint {
+        Constraint::Utf8ByteLength(Utf8ByteLengthConstraint::new(Range::NonNegativeInteger(
+            length,
+        )))
     }
 
     /// Creates a [Constraint::Fields] referring to the fields represented by the provided field name and [TypeId]s.
@@ -309,6 +317,9 @@ impl Constraint {
                     TimestampPrecisionConstraint::new(timestamp_precision_range.to_owned()),
                 ))
             }
+            IslConstraint::Utf8ByteLength(utf8_byte_length) => Ok(Constraint::Utf8ByteLength(
+                Utf8ByteLengthConstraint::new(utf8_byte_length.to_owned()),
+            )),
             IslConstraint::ValidValues(valid_values) => {
                 Ok(Constraint::ValidValues(ValidValuesConstraint {
                     valid_values: valid_values.values().to_owned(),
@@ -351,6 +362,9 @@ impl Constraint {
             Constraint::Scale(scale) => scale.validate(value, type_store),
             Constraint::TimestampPrecision(timestamp_precision) => {
                 timestamp_precision.validate(value, type_store)
+            }
+            Constraint::Utf8ByteLength(utf8_byte_length) => {
+                utf8_byte_length.validate(value, type_store)
             }
             Constraint::ValidValues(valid_values) => valid_values.validate(value, type_store),
         }
@@ -1799,5 +1813,50 @@ impl PartialEq for RegexConstraint {
         self.expression.as_str().eq(other.expression.as_str())
             && self.case_insensitive == other.case_insensitive
             && self.multiline == other.multiline
+    }
+}
+
+/// Implements Ion Schema's `utf8_byte_length` constraint
+/// [utf8_byte_length]: https://amzn.github.io/ion-schema/docs/isl-1-0/spec#utf8_byte_length
+#[derive(Debug, Clone, PartialEq)]
+pub struct Utf8ByteLengthConstraint {
+    length_range: Range,
+}
+
+impl Utf8ByteLengthConstraint {
+    pub fn new(length_range: Range) -> Self {
+        Self { length_range }
+    }
+
+    pub fn length(&self) -> &Range {
+        &self.length_range
+    }
+}
+
+impl ConstraintValidator for Utf8ByteLengthConstraint {
+    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+        // get the size of given bytes
+        let size = value
+            .expect_element_of_type(&[IonType::String, IonType::Symbol], "utf8_byte_length")?
+            .as_str()
+            .unwrap()
+            .len();
+
+        // get isl length as a range
+        let length_range: &Range = self.length();
+
+        // return a Violation if the string/symbol size didn't follow utf8_byte_length constraint
+        if !length_range.contains(&(size as i64).into()) {
+            return Err(Violation::new(
+                "utf8_byte_length",
+                ViolationCode::InvalidLength,
+                &format!(
+                    "expected utf8 byte length {:?} found {}",
+                    length_range, size
+                ),
+            ));
+        }
+
+        Ok(())
     }
 }

--- a/src/isl/isl_constraint.rs
+++ b/src/isl/isl_constraint.rs
@@ -34,6 +34,7 @@ pub enum IslConstraint {
     Scale(Range),
     TimestampPrecision(Range),
     Type(IslTypeRef),
+    Utf8ByteLength(Range),
     ValidValues(IslValidValuesConstraint),
 }
 
@@ -110,6 +111,11 @@ impl IslConstraint {
     /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> IslConstraint {
         IslConstraint::TimestampPrecision(Range::TimestampPrecision(precision))
+    }
+
+    /// Creates an [IslConstraint::Utf8ByteLength] using the range specified in it
+    pub fn utf8_byte_length(length: NonNegativeIntegerRange) -> IslConstraint {
+        IslConstraint::Utf8ByteLength(Range::NonNegativeInteger(length))
     }
 
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
@@ -371,6 +377,10 @@ impl IslConstraint {
             "timestamp_precision" => Ok(IslConstraint::TimestampPrecision(
                 Range::from_ion_element(value, RangeType::TimestampPrecision)?,
             )),
+            "utf8_byte_length" => Ok(IslConstraint::Utf8ByteLength(Range::from_ion_element(
+                value,
+                RangeType::NonNegativeInteger,
+            )?)),
             "valid_values" => Ok(IslConstraint::ValidValues(value.try_into()?)),
             _ => Err(invalid_schema_error_raw(
                 "Type: ".to_owned()

--- a/src/isl/isl_range.rs
+++ b/src/isl/isl_range.rs
@@ -229,11 +229,7 @@ impl Range {
     ) -> IonSchemaResult<usize> {
         // minimum precision must be greater than or equal to 1
         // for more information: https://amzn.github.io/ion-schema/docs/spec.html#precision
-        let min_value = if range_type == &RangeType::Precision {
-            1
-        } else {
-            0
-        };
+        let min_value = i64::from(range_type == &RangeType::Precision);
         match value.as_i64() {
             Some(v) => {
                 if v >= min_value {
@@ -394,8 +390,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
         start: RangeBoundaryValue<T>,
         end: RangeBoundaryValue<T>,
     ) -> IonSchemaResult<Self> {
-        if start.range_boundary_value() == None
-            && end.range_boundary_value() == None
+        if Option::is_none(&start.range_boundary_value())
+            && Option::is_none(&end.range_boundary_value())
             && (start.range_boundary_type() == &RangeBoundaryType::Exclusive
                 || end.range_boundary_type() == &RangeBoundaryType::Exclusive)
         {
@@ -603,7 +599,7 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
                 // verify that v2 here doesn't have an unknown offset
                 // For timestamp ranges neither boundaries should have an unknown offset
                 if let Some(range_end_timestamp_value) = v2.range_boundary_value() {
-                    if range_end_timestamp_value.offset() == None {
+                    if Option::is_none(&range_end_timestamp_value.offset()) {
                         return invalid_schema_error(
                             "Range boundary can not have an unknown offset",
                         );
@@ -616,7 +612,7 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
                 // verify that v1 here doesn't have an unknown offset
                 // For timestamp ranges neither boundaries should have an unknown offset
                 if let Some(range_end_timestamp_value) = v1.range_boundary_value() {
-                    if range_end_timestamp_value.offset() == None {
+                    if Option::is_none(&range_end_timestamp_value.offset()) {
                         return invalid_schema_error(
                             "Range boundary can not have an unknown offset",
                         );

--- a/src/isl/mod.rs
+++ b/src/isl/mod.rs
@@ -331,6 +331,12 @@ mod isl_tests {
             ]
         )
     ),
+    case::utf8_byte_length_constraint(
+        load_anonymous_type(r#" // For a schema with utf8_byte_length constraint as below:
+                        { utf8_byte_length: 3 }
+                    "#),
+        IslType::anonymous([IslConstraint::utf8_byte_length(3.into())])
+    ),
     case::regex_constraint(
         load_anonymous_type(r#" // For a schema with regex constraint as below:
                             { regex: "[abc]" }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -275,6 +275,12 @@ mod schema_tests {
                  "#).into_iter(),
         1 // this includes named type valid_values_type
     ),
+    case::utf8_byte_length_constraint(
+        load(r#" // For a schema with utf8_byte_length constraint as below:
+                        type:: { name: utf8_byte_length_type, utf8_byte_length: 3 }
+                    "#).into_iter(),
+        1 // this includes named type utf8_byte_length_type
+    ),
     case::regex_constraint(
         load(r#" // For a schema with regex constraint as below:
                     type:: { name: regex_type, regex: "[abc]" }
@@ -986,6 +992,32 @@ mod schema_tests {
                                 type::{ name: timestamp_precision_type, timestamp_precision: range::[month, second] }
                         "#),
             "timestamp_precision_type"
+        ),
+        case::utf8_byte_length_constraint(
+            load(r#"
+                          "hello"
+                          hello
+                          world
+                          "world"
+                          '\u00A2\u20AC'
+                        "#),
+            load(r#"
+                          null
+                          null.bool
+                          null.null
+                          null.string
+                          null.symbol
+                          ""
+                          "hi"
+                          hi
+                          "greetings"
+                          greetings
+                          '\u20AC\u20AC'
+                        "#),
+            load_schema_from_text(r#" // For a schema with byte_length constraint as below:
+                                type::{ name: utf8_byte_length_type, utf8_byte_length: 5 }
+                        "#),
+            "utf8_byte_length_type"
         ),
         case::valid_values_constraint(
             load(r#"

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,7 +183,7 @@ impl TypeValidator for BuiltInTypeDefinition {
                 if other_type.name() == &Some("document".to_owned()) {
                     // Verify whether the given derived type is document
                     // And check if it is using enum variant IonSchemaIonElement::Document
-                    if value.as_document() == None {
+                    if Option::is_none(&value.as_document()) {
                         return Err(Violation::new(
                             "type_constraint",
                             ViolationCode::TypeMismatched,

--- a/src/types.rs
+++ b/src/types.rs
@@ -644,6 +644,13 @@ mod type_definition_tests {
             Constraint::type_constraint(34)
         ])
     ),
+    case::utf8_byte_length_constraint(
+        /* For a schema with utf8_byte_length constraint as below:
+            { utf8_byte_length: 3 }
+        */
+        IslType::anonymous([IslConstraint::utf8_byte_length(3.into())]),
+        TypeDefinition::anonymous([Constraint::utf8_byte_length(3.into()), Constraint::type_constraint(34)])
+    ),
     case::regex_constraint(
         /* For a schema with regex constraint as below:
             { regex: "[abc]" }

--- a/tests/ion_schema_tests_runner.rs
+++ b/tests/ion_schema_tests_runner.rs
@@ -65,6 +65,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/timestamp_precision/*.isl")]
 #[test_resources("ion-schema-tests/constraints/valid_values/*.isl")]
 #[test_resources("ion-schema-tests/constraints/regex/*.isl")]
+#[test_resources("ion-schema-tests/constraints/utf8_byte_length/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `utf8_byte_length` constraint.

*Grammar:*
```ANTLR
utf8_byte_length: <INT>
utf8_byte_length: <RANGE<INT>>
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/isl-1-0/spec#utf8_byte_length

*List of changes:*
* adds changes for `utf8_byte_length` constraint implementation
* adds `Utf8ByteLength` enum variants for `IslConstraint` and `Constraint`
* adds `Utf8ByteLengthConstraint` implementations
* adds validation logic for `utf8
_byte_length`
* adds unit tests for `utf8_byte_length`

*Tests:*
added unit tests for `utf8_byte_length` implementation.
- adds tests for programmatically creating `utf8_byte_length` constraint
- adds tests for loading a schema using `utf8_byte_length` constraint 
- adds validation tests for `utf8_byte_length` constraint
