### PR TITLE
adds changes for `timestamp_offset` constraint

### DIFF
--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1,7 +1,7 @@
 use crate::isl::isl_constraint::{IslConstraint, IslRegexConstraint};
 use crate::isl::isl_range::{Range, RangeImpl};
 use crate::isl::isl_type_reference::IslTypeRef;
-use crate::isl::util::{Annotation, TimestampPrecision, ValidValue};
+use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
     ValidationResult,
@@ -50,6 +50,7 @@ pub enum Constraint {
     Precision(PrecisionConstraint),
     Regex(RegexConstraint),
     Scale(ScaleConstraint),
+    TimestampOffset(TimestampOffsetConstraint),
     TimestampPrecision(TimestampPrecisionConstraint),
     Type(TypeConstraint),
     Utf8ByteLength(Utf8ByteLengthConstraint),
@@ -158,6 +159,11 @@ impl Constraint {
         Constraint::TimestampPrecision(TimestampPrecisionConstraint::new(
             Range::TimestampPrecision(precision),
         ))
+    }
+
+    /// Creates an [Constraint::TimestampOffset] using the offset list specified in it
+    pub fn timestamp_offset(offsets: Vec<TimestampOffset>) -> Constraint {
+        Constraint::TimestampOffset(TimestampOffsetConstraint::new(offsets))
     }
 
     /// Creates a [Constraint::Utf8ByteLength] from a [Range] specifying a length range.
@@ -312,6 +318,9 @@ impl Constraint {
             IslConstraint::Scale(scale_range) => Ok(Constraint::Scale(ScaleConstraint::new(
                 scale_range.to_owned(),
             ))),
+            IslConstraint::TimestampOffset(timestamp_offset) => Ok(Constraint::TimestampOffset(
+                TimestampOffsetConstraint::new(timestamp_offset.valid_offsets().to_vec()),
+            )),
             IslConstraint::TimestampPrecision(timestamp_precision_range) => {
                 Ok(Constraint::TimestampPrecision(
                     TimestampPrecisionConstraint::new(timestamp_precision_range.to_owned()),
@@ -360,6 +369,9 @@ impl Constraint {
             Constraint::Precision(precision) => precision.validate(value, type_store),
             Constraint::Regex(regex) => regex.validate(value, type_store),
             Constraint::Scale(scale) => scale.validate(value, type_store),
+            Constraint::TimestampOffset(timestamp_offset) => {
+                timestamp_offset.validate(value, type_store)
+            }
             Constraint::TimestampPrecision(timestamp_precision) => {
                 timestamp_precision.validate(value, type_store)
             }
@@ -1853,6 +1865,51 @@ impl ConstraintValidator for Utf8ByteLengthConstraint {
                 &format!(
                     "expected utf8 byte length {:?} found {}",
                     length_range, size
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Implements Ion Schema's `timestamp_offset` constraint
+/// [timestamp_offset]: https://amzn.github.io/ion-schema/docs/isl-1-0/spec#timestamp_offset
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampOffsetConstraint {
+    valid_offsets: Vec<TimestampOffset>,
+}
+
+impl TimestampOffsetConstraint {
+    pub fn new(valid_offsets: Vec<TimestampOffset>) -> Self {
+        Self { valid_offsets }
+    }
+
+    pub fn valid_offsets(&self) -> &Vec<TimestampOffset> {
+        &self.valid_offsets
+    }
+}
+
+impl ConstraintValidator for TimestampOffsetConstraint {
+    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+        // get timestamp value
+        let timestamp_value = value
+            .expect_element_of_type(&[IonType::Timestamp], "timestamp_offset")?
+            .as_timestamp()
+            .unwrap();
+
+        // get isl timestamp precision as a range
+        let valid_offsets: &Vec<TimestampOffset> = self.valid_offsets();
+
+        // return a Violation if the value didn't follow timestamp precision constraint
+        if !valid_offsets.contains(&timestamp_value.offset().into()) {
+            return Err(Violation::new(
+                "timestamp_offset",
+                ViolationCode::InvalidLength,
+                &format!(
+                    "expected timestamp offset from {:?} found {:?}",
+                    valid_offsets,
+                    timestamp_value.offset()
                 ),
             ));
         }

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1903,13 +1903,16 @@ impl ConstraintValidator for TimestampOffsetConstraint {
 
         // return a Violation if the value didn't follow timestamp precision constraint
         if !valid_offsets.contains(&timestamp_value.offset().into()) {
+            let formatted_valid_offsets: Vec<String> =
+                valid_offsets.iter().map(|t| format!("{}", t)).collect();
+
             return Err(Violation::new(
                 "timestamp_offset",
                 ViolationCode::InvalidLength,
                 &format!(
-                    "expected timestamp offset from {:?} found {:?}",
-                    valid_offsets,
-                    timestamp_value.offset()
+                    "expected timestamp offset from {:?} found {}",
+                    formatted_valid_offsets,
+                    <Option<i32> as Into<TimestampOffset>>::into(timestamp_value.offset())
                 ),
             ));
         }

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -437,8 +437,8 @@ impl IslConstraint {
                     }
                     _ => {
                         return invalid_schema_error(format!(
-                            "ion type: {:?} is not supported with occurs constraint",
-                            value.ion_type()
+                            "`timestamp_offset` requires a list of offset strings, but found: {}",
+                            value
                         ))
                     }
                 };
@@ -459,17 +459,6 @@ impl IslConstraint {
                     + " does not exist",
             )),
         }
-    }
-
-    // helper method to convert from a string to offset in minutes
-    fn offset_minutes(s: &str, range: Range) -> IonSchemaResult<i32> {
-        let int = s
-            .parse::<i32>()
-            .map_err(|e| invalid_schema_error_raw(format!("invalid timestamp offset {}", s)))?;
-        if !range.contains(&(int as i64).into()) {
-            return invalid_schema_error(format!("invalid timestamp offset {}", int));
-        }
-        Ok(int)
     }
 
     // helper method for from_ion_element to get isl type references from given ion element

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -350,7 +350,7 @@ mod isl_tests {
             ]
         )
     ),
-    case::timetsamp_offset_constraint(
+    case::timestamp_offset_constraint(
         load_anonymous_type(r#" // For a schema with timestamp_offset constraint as below:
                             { timestamp_offset: ["+00:00"] }
                         "#),

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -350,6 +350,14 @@ mod isl_tests {
             ]
         )
     ),
+    case::timetsamp_offset_constraint(
+        load_anonymous_type(r#" // For a schema with timestamp_offset constraint as below:
+                            { timestamp_offset: ["+00:00"] }
+                        "#),
+        IslType::anonymous(
+        [IslConstraint::timestamp_offset(vec!["+00:00".try_into().unwrap()])]
+    )
+    )
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -286,6 +286,12 @@ mod schema_tests {
                     type:: { name: regex_type, regex: "[abc]" }
                  "#).into_iter(),
         1 // this includes named type regex_type
+    ),
+    case::timestamp_offset_constraint(
+        load(r#" // For a schema with timestamp_offset constraint as below:
+                        type:: { name: timestamp_offset_type, timestamp_offset: ["+07:00", "+08:00", "+08:45", "+09:00"] }
+                     "#).into_iter(),
+        1 // this includes named type regex_type
     )
     )]
     fn owned_elements_to_schema<I: Iterator<Item = Element>>(
@@ -1078,6 +1084,25 @@ mod schema_tests {
                             type::{ name: regex_type, regex: "ab|cd|ef" }
                     "#),
             "regex_type"
+        ),
+        case::timestamp_offset_constraint(
+            load(r#"
+                      2000T
+                      2000-01-01T00:00:00-00:00   // unknown local offset
+                      2000-01-01T00:00:00Z        // UTC
+                      2000-01-01T00:00:00+00:00   // UTC
+                      2000-01-01T00:00:00+01:00
+                      2000-01-01T00:00:00-01:01
+                    "#),
+            load(r#"
+                      2000-01-01T00:00:00-01:00   
+                      2000-01-01T00:00:00+01:01  
+                      2000-01-01T00:00:00+07:00
+                    "#),
+            load_schema_from_text(r#" // For a schema with timestamp_offset constraint as below:
+                            type::{ name: timestamp_offset_type, timestamp_offset: ["-00:00", "+00:00", "+01:00", "-01:01"] }
+                    "#),
+            "timestamp_offset_type"
         ),
     )]
     fn type_validation(

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -670,6 +670,17 @@ mod type_definition_tests {
             ).unwrap(),
             Constraint::type_constraint(34)
         ])
+    ),
+    case::timestamp_offset_constraint(
+        /* For a schema with timestamp_offset constraint as below:
+            { timestamp_offset: ["-00:00"] }
+        */
+        IslType::anonymous(
+            [IslConstraint::timestamp_offset(vec!["-00:00".try_into().unwrap()])]
+        ),
+        TypeDefinition::anonymous([Constraint::timestamp_offset(vec!["-00:00".try_into().unwrap()]),
+            Constraint::type_constraint(34)
+        ])
     )
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinition) {

--- a/ion-schema/tests/ion_schema_tests_runner.rs
+++ b/ion-schema/tests/ion_schema_tests_runner.rs
@@ -45,6 +45,7 @@ const SKIP_LIST: &[&str] = &[
     "ion-schema-tests/constraints/valid_values/validation_list_timestamp_ranges.isl",
     "ion-schema-tests/constraints/valid_values/validation_ranges.isl",
     "ion-schema-tests/constraints/valid_values/validation_timestamp_range.isl",
+    "ion-schema-tests/constraints/timestamp_offset/validation.isl",
 ];
 
 #[test_resources("ion-schema-tests/core_types/*.isl")]
@@ -66,6 +67,7 @@ const SKIP_LIST: &[&str] = &[
 #[test_resources("ion-schema-tests/constraints/valid_values/*.isl")]
 #[test_resources("ion-schema-tests/constraints/regex/*.isl")]
 #[test_resources("ion-schema-tests/constraints/utf8_byte_length/*.isl")]
+#[test_resources("ion-schema-tests/constraints/timestamp_offset/*.isl")]
 // `test_resources` breaks for test-case names containing `$` and it doesn't allow
 // to rename test-case names hence using `rstest` for `$*.isl` test files
 // For more information: https://github.com/frehberg/test-generator/issues/11


### PR DESCRIPTION
*Issue #9 #10*

*Description of changes:*
This PR works on adding implementation of `timestamp_offset` constraint.

*Grammar:*
```ANTLR
timestamp_offset: [ "[+|-]hh:mm"... ]
```

*Ion Schema specification:*
https://amzn.github.io/ion-schema/docs/isl-1-0/spec#timestamp_offset

*List of changes:*
* adds changes for `timestamp_offset` constraint implementation
* adds a util implementation of `TimestampOffset` to create `timestamp_offset` constraint with valid  timetsamp offset values
* adds `TimestampOffsetLength` enum variants for `IslConstraint` and `Constraint`
* adds `TimestampOffsetConstraint` implementations
* adds validation logic for `timestamp_offset`
* adds unit tests for `timestamp_offset`

*Tests:*
added unit tests for `timestamp_offset` implementation.
- adds tests for programmatically creating `timestamp_offset` constraint
- adds tests for loading a schema using `timestamp_offset` constraint 
- adds validation tests for `timestamp_offset` constraint

