### PR TITLE
Streamlines ISL model using version maker traits 

### DIFF
--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -19,8 +19,10 @@
 //!
 //! ## Example usage of `isl` module to create an `IslSchema` using `IslType`:
 //! ```
-//! use ion_schema::isl::{isl_type::v_1_0::*, isl_constraint::v_1_0::*, isl_type_reference::v_1_0::*, IslSchema};
-//! use ion_schema::schema::Schema;
+//! use ion_schema::isl::isl_constraint::v_1_0::{all_of, type_constraint};
+//! use ion_schema::isl::isl_type::v_1_0::named_type;
+//! use ion_schema::isl::isl_type_reference::v_1_0::{anonymous_type_ref, named_type_ref};
+//! use ion_schema::isl::IslSchema;
 //! use ion_schema::system::SchemaSystem;
 //!
 //! // below code represents an ISL type:
@@ -31,6 +33,7 @@
 //! //          { type: bool }
 //! //      ]
 //! //  }
+//!
 //! let isl_type = named_type(
 //!     // represents the `name` of the defined type
 //!     "my_type_name".to_owned(),
@@ -149,6 +152,7 @@ pub mod isl_range;
 pub mod isl_type;
 pub mod isl_type_reference;
 pub mod util;
+pub mod version_based_isl;
 
 /// Represents Ion Schema Language Versions
 /// Currently it support v1.0 and v2.0

--- a/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
@@ -10,7 +10,7 @@ impl<V: IslVersionTrait> AllOf<V> {
         Self { type_args }
     }
 
-    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+    pub fn type_args(&self) -> &[IslTypeArgument<V>] {
         &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
@@ -1,16 +1,16 @@
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AllOf<V: IslVersionTrait> {
-    type_refs: Vec<IslTypeRef<V>>,
+    type_args: Vec<IslTypeArgument<V>>,
 }
 
 impl<V: IslVersionTrait> AllOf<V> {
-    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
-        Self { type_refs }
+    pub fn new(type_args: Vec<IslTypeArgument<V>>) -> Self {
+        Self { type_args }
     }
 
-    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
-        &self.type_refs
+    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+        &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/all_of.rs
@@ -1,0 +1,16 @@
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AllOf<V: IslVersionTrait> {
+    type_refs: Vec<IslTypeRef<V>>,
+}
+
+impl<V: IslVersionTrait> AllOf<V> {
+    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
+        Self { type_refs }
+    }
+
+    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
+        &self.type_refs
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
@@ -1,0 +1,16 @@
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnyOf<V: IslVersionTrait> {
+    type_refs: Vec<IslTypeRef<V>>,
+}
+
+impl<V: IslVersionTrait> AnyOf<V> {
+    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
+        Self { type_refs }
+    }
+
+    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
+        &self.type_refs
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
@@ -10,7 +10,7 @@ impl<V: IslVersionTrait> AnyOf<V> {
         Self { type_args }
     }
 
-    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+    pub fn type_args(&self) -> &[IslTypeArgument<V>] {
         &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/any_of.rs
@@ -1,16 +1,16 @@
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnyOf<V: IslVersionTrait> {
-    type_refs: Vec<IslTypeRef<V>>,
+    type_args: Vec<IslTypeArgument<V>>,
 }
 
 impl<V: IslVersionTrait> AnyOf<V> {
-    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
-        Self { type_refs }
+    pub fn new(type_args: Vec<IslTypeArgument<V>>) -> Self {
+        Self { type_args }
     }
 
-    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
-        &self.type_refs
+    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+        &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/mod.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/mod.rs
@@ -21,7 +21,7 @@ pub enum IslConstraint<V: IslVersionTrait> {
     OneOf(OneOf<V>),
     Not(Not<V>),
     Type(Type<V>),
-    Unknown(OpenContent),
+    OpenContent(OpenContent),
 }
 
 impl<V: IslVersionTrait> IslConstraint<V> {
@@ -51,9 +51,9 @@ impl<V: IslVersionTrait> IslConstraint<V> {
         IslConstraint::Not(Not::new(isl_type_ref))
     }
 
-    /// Creates an `open_content` using the field name and value referenced inside it
+    /// Creates open content using the field name and value referenced inside it
     /// Note: This open content has no effect
     pub fn open_content(field_name: String, field_value: Element) -> IslConstraint<V> {
-        IslConstraint::Unknown(OpenContent::new(field_name, field_value))
+        IslConstraint::OpenContent(OpenContent::new(field_name, field_value))
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/mod.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/mod.rs
@@ -4,7 +4,7 @@ use crate::isl::version_based_isl::constraints::not::Not;
 use crate::isl::version_based_isl::constraints::one_of::OneOf;
 use crate::isl::version_based_isl::constraints::open_content::OpenContent;
 use crate::isl::version_based_isl::constraints::r#type::Type;
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 use ion_rs::element::Element;
 
 pub mod all_of;
@@ -21,33 +21,33 @@ pub enum IslConstraint<V: IslVersionTrait> {
     OneOf(OneOf<V>),
     Not(Not<V>),
     Type(Type<V>),
-    Unknown(OpenContent<V>),
+    Unknown(OpenContent),
 }
 
 impl<V: IslVersionTrait> IslConstraint<V> {
-    /// Creates a `type` constraint using the [IslTypeRef] referenced inside it
+    /// Creates a `type` constraint using the [IslTypeArgument] referenced inside it
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
-    pub fn type_constraint(isl_type_ref: IslTypeRef<V>) -> IslConstraint<V> {
+    pub fn type_constraint(isl_type_ref: IslTypeArgument<V>) -> IslConstraint<V> {
         IslConstraint::Type(Type::new(isl_type_ref))
     }
 
-    /// Creates an `all_of` constraint using the [IslTypeRef] referenced inside it
-    pub fn all_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+    /// Creates an `all_of` constraint using the [IslTypeArgument] referenced inside it
+    pub fn all_of<A: Into<Vec<IslTypeArgument<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
         IslConstraint::AllOf(AllOf::new(isl_type_refs.into()))
     }
 
-    /// Creates an `any_of` constraint using the [IslTypeRef] referenced inside it
-    pub fn any_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+    /// Creates an `any_of` constraint using the [IslTypeArgument] referenced inside it
+    pub fn any_of<A: Into<Vec<IslTypeArgument<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
         IslConstraint::AnyOf(AnyOf::new(isl_type_refs.into()))
     }
 
-    /// Creates a `one_of` constraint using the [IslTypeRef] referenced inside it
-    pub fn one_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+    /// Creates a `one_of` constraint using the [IslTypeArgument] referenced inside it
+    pub fn one_of<A: Into<Vec<IslTypeArgument<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
         IslConstraint::OneOf(OneOf::new(isl_type_refs.into()))
     }
 
-    /// Creates a `not` constraint using the [IslTypeRef] referenced inside it
-    pub fn not(isl_type_ref: IslTypeRef<V>) -> IslConstraint<V> {
+    /// Creates a `not` constraint using the [IslTypeArgument] referenced inside it
+    pub fn not(isl_type_ref: IslTypeArgument<V>) -> IslConstraint<V> {
         IslConstraint::Not(Not::new(isl_type_ref))
     }
 

--- a/ion-schema/src/isl/version_based_isl/constraints/mod.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/mod.rs
@@ -1,0 +1,59 @@
+use crate::isl::version_based_isl::constraints::all_of::AllOf;
+use crate::isl::version_based_isl::constraints::any_of::AnyOf;
+use crate::isl::version_based_isl::constraints::not::Not;
+use crate::isl::version_based_isl::constraints::one_of::OneOf;
+use crate::isl::version_based_isl::constraints::open_content::OpenContent;
+use crate::isl::version_based_isl::constraints::r#type::Type;
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use ion_rs::element::Element;
+
+pub mod all_of;
+pub mod any_of;
+pub mod not;
+pub mod one_of;
+pub mod open_content;
+pub mod r#type;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IslConstraint<V: IslVersionTrait> {
+    AllOf(AllOf<V>),
+    AnyOf(AnyOf<V>),
+    OneOf(OneOf<V>),
+    Not(Not<V>),
+    Type(Type<V>),
+    Unknown(OpenContent<V>),
+}
+
+impl<V: IslVersionTrait> IslConstraint<V> {
+    /// Creates a `type` constraint using the [IslTypeRef] referenced inside it
+    // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
+    pub fn type_constraint(isl_type_ref: IslTypeRef<V>) -> IslConstraint<V> {
+        IslConstraint::Type(Type::new(isl_type_ref))
+    }
+
+    /// Creates an `all_of` constraint using the [IslTypeRef] referenced inside it
+    pub fn all_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+        IslConstraint::AllOf(AllOf::new(isl_type_refs.into()))
+    }
+
+    /// Creates an `any_of` constraint using the [IslTypeRef] referenced inside it
+    pub fn any_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+        IslConstraint::AnyOf(AnyOf::new(isl_type_refs.into()))
+    }
+
+    /// Creates a `one_of` constraint using the [IslTypeRef] referenced inside it
+    pub fn one_of<A: Into<Vec<IslTypeRef<V>>>>(isl_type_refs: A) -> IslConstraint<V> {
+        IslConstraint::OneOf(OneOf::new(isl_type_refs.into()))
+    }
+
+    /// Creates a `not` constraint using the [IslTypeRef] referenced inside it
+    pub fn not(isl_type_ref: IslTypeRef<V>) -> IslConstraint<V> {
+        IslConstraint::Not(Not::new(isl_type_ref))
+    }
+
+    /// Creates an `open_content` using the field name and value referenced inside it
+    /// Note: This open content has no effect
+    pub fn open_content(field_name: String, field_value: Element) -> IslConstraint<V> {
+        IslConstraint::Unknown(OpenContent::new(field_name, field_value))
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/not.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/not.rs
@@ -1,0 +1,16 @@
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Not<V: IslVersionTrait> {
+    type_ref: IslTypeRef<V>,
+}
+
+impl<V: IslVersionTrait> Not<V> {
+    pub fn new(type_ref: IslTypeRef<V>) -> Self {
+        Self { type_ref }
+    }
+
+    pub fn type_ref(&self) -> &IslTypeRef<V> {
+        &self.type_ref
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/not.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/not.rs
@@ -1,16 +1,16 @@
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Not<V: IslVersionTrait> {
-    type_ref: IslTypeRef<V>,
+    type_arg: IslTypeArgument<V>,
 }
 
 impl<V: IslVersionTrait> Not<V> {
-    pub fn new(type_ref: IslTypeRef<V>) -> Self {
-        Self { type_ref }
+    pub fn new(type_arg: IslTypeArgument<V>) -> Self {
+        Self { type_arg }
     }
 
-    pub fn type_ref(&self) -> &IslTypeRef<V> {
-        &self.type_ref
+    pub fn type_arg(&self) -> &IslTypeArgument<V> {
+        &self.type_arg
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
@@ -10,7 +10,7 @@ impl<V: IslVersionTrait> OneOf<V> {
         Self { type_args }
     }
 
-    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+    pub fn type_args(&self) -> &[IslTypeArgument<V>] {
         &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
@@ -1,0 +1,16 @@
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OneOf<V: IslVersionTrait> {
+    type_refs: Vec<IslTypeRef<V>>,
+}
+
+impl<V: IslVersionTrait> OneOf<V> {
+    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
+        Self { type_refs }
+    }
+
+    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
+        &self.type_refs
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/one_of.rs
@@ -1,16 +1,16 @@
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct OneOf<V: IslVersionTrait> {
-    type_refs: Vec<IslTypeRef<V>>,
+    type_args: Vec<IslTypeArgument<V>>,
 }
 
 impl<V: IslVersionTrait> OneOf<V> {
-    pub fn new(type_refs: Vec<IslTypeRef<V>>) -> Self {
-        Self { type_refs }
+    pub fn new(type_args: Vec<IslTypeArgument<V>>) -> Self {
+        Self { type_args }
     }
 
-    pub fn type_refs(&self) -> &Vec<IslTypeRef<V>> {
-        &self.type_refs
+    pub fn type_args(&self) -> &Vec<IslTypeArgument<V>> {
+        &self.type_args
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/open_content.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/open_content.rs
@@ -1,20 +1,16 @@
-use crate::isl::version_based_isl::IslVersionTrait;
 use ion_rs::element::Element;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct OpenContent<V: IslVersionTrait> {
+pub struct OpenContent {
     field_name: String,
     field_value: Element,
-    phantom: PhantomData<V>,
 }
 
-impl<V: IslVersionTrait> OpenContent<V> {
-    pub fn new(field_name: String, field_value: Element) -> OpenContent<V> {
+impl OpenContent {
+    pub fn new(field_name: String, field_value: Element) -> OpenContent {
         OpenContent {
             field_name,
             field_value,
-            phantom: Default::default(),
         }
     }
 

--- a/ion-schema/src/isl/version_based_isl/constraints/open_content.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/open_content.rs
@@ -1,0 +1,27 @@
+use crate::isl::version_based_isl::IslVersionTrait;
+use ion_rs::element::Element;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OpenContent<V: IslVersionTrait> {
+    field_name: String,
+    field_value: Element,
+    phantom: PhantomData<V>,
+}
+
+impl<V: IslVersionTrait> OpenContent<V> {
+    pub fn new(field_name: String, field_value: Element) -> OpenContent<V> {
+        OpenContent {
+            field_name,
+            field_value,
+            phantom: Default::default(),
+        }
+    }
+
+    pub fn field_name(&self) -> &String {
+        &self.field_name
+    }
+    pub fn field_value(&self) -> &Element {
+        &self.field_value
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/constraints/type.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/type.rs
@@ -1,16 +1,16 @@
-use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+use crate::isl::version_based_isl::{IslTypeArgument, IslVersionTrait};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Type<V: IslVersionTrait> {
-    type_ref: IslTypeRef<V>,
+    type_arg: IslTypeArgument<V>,
 }
 
 impl<V: IslVersionTrait> Type<V> {
-    pub fn new(type_ref: IslTypeRef<V>) -> Self {
-        Self { type_ref }
+    pub fn new(type_arg: IslTypeArgument<V>) -> Self {
+        Self { type_arg }
     }
 
-    pub fn type_ref(&self) -> &IslTypeRef<V> {
-        &self.type_ref
+    pub fn type_arg(&self) -> &IslTypeArgument<V> {
+        &self.type_arg
     }
 }

--- a/ion-schema/src/isl/version_based_isl/constraints/type.rs
+++ b/ion-schema/src/isl/version_based_isl/constraints/type.rs
@@ -1,0 +1,16 @@
+use crate::isl::version_based_isl::{IslTypeRef, IslVersionTrait};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Type<V: IslVersionTrait> {
+    type_ref: IslTypeRef<V>,
+}
+
+impl<V: IslVersionTrait> Type<V> {
+    pub fn new(type_ref: IslTypeRef<V>) -> Self {
+        Self { type_ref }
+    }
+
+    pub fn type_ref(&self) -> &IslTypeRef<V> {
+        &self.type_ref
+    }
+}

--- a/ion-schema/src/isl/version_based_isl/mod.rs
+++ b/ion-schema/src/isl/version_based_isl/mod.rs
@@ -1,0 +1,350 @@
+//! Provides a way to construct ISL types and constraints programmatically.
+//!
+//! This module consists of three submodules that help constructing ISL types/constraint:
+//!
+//! * `constraints` module provides schema constraints [IslConstraint]
+//! which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
+//!
+//! [IslConstraint]: IslConstraint
+//!
+//! ## Example usage of `version_based_isl` module to create an `IslSchema` using `IslType`:
+//! ```
+//! use ion_rs::element::Element;
+//! use ion_schema::isl::version_based_isl::constraints::IslConstraint;
+//! use ion_schema::isl::version_based_isl::{IslSchema, IslTypeRef, IslV1_0};
+//! use ion_schema::isl::version_based_isl::constraints::open_content::OpenContent;
+//! use crate::ion_schema::isl::version_based_isl::IslType;
+//! use crate::ion_schema::isl::version_based_isl::constraints::r#type::Type;
+//!
+//! // below code represents an ISL type:
+//! // type:: {
+//! //      name:my_type_name,
+//! //      type: int,
+//! //      all_of: [
+//! //          { type: bool }
+//! //      ]
+//! //  }
+//! let isl_type: IslType<IslV1_0> = IslType::named(
+//!     // represents the `name` of the defined type
+//!     "my_type_name".to_owned(),
+//!     vec![
+//!         // represents the `type: int` constraint
+//!         IslConstraint::type_constraint(
+//!             IslTypeRef::named("int")
+//!         ),
+//!         // represents `all_of` with anonymous type `{ type: bool }` constraint
+//!         IslConstraint::all_of(
+//!             vec![
+//!                 IslTypeRef::anonymous(
+//!                     vec![
+//!                         IslConstraint::type_constraint(
+//!                             IslTypeRef::named("bool")
+//!                         )
+//!                     ]
+//!                 )
+//!             ]
+//!         ),
+//!         // represents some open content which will be ignored while doing validation
+//!         IslConstraint::open_content("open_content".to_owned(), Element::string("This is an open content!"))
+//!     ]
+//! );
+//!
+//! // create an ISL schema using above IslType
+//! let isl_schema = IslSchema::new("my_schema", vec![], vec![isl_type], vec![], vec![]);
+//! assert_eq!(isl_schema.types().len(), 1);
+//! assert_eq!(isl_schema.types()[0].name(), &Some("my_type_name".to_owned()));
+//! assert_eq!(isl_schema.types()[0].constraints().len(), 3);
+//! // verify that the last constraint is actually an open content field
+//! assert!(matches!(isl_schema.types()[0].constraints()[2], IslConstraint::Unknown(_)));
+//! ```
+
+use crate::isl::isl_range::Range;
+use crate::isl::isl_type_reference::NullabilityModifier;
+use crate::isl::version_based_isl::constraints::IslConstraint;
+use ion_rs::element::Element;
+use ion_rs::IonType;
+use std::marker::PhantomData;
+
+pub mod constraints;
+
+pub trait IslVersionTrait {}
+
+pub struct IslV1_0 {}
+impl IslVersionTrait for IslV1_0 {}
+
+// TODO: This can be a trait if we have get a new minor version of ISL
+#[derive(Debug, Clone)]
+pub struct IslV2_0 {}
+impl IslVersionTrait for IslV2_0 {}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct UserReservedFields<V: IslVersionTrait> {
+    schema_header_fields: Vec<String>,
+    schema_footer_fields: Vec<String>,
+    type_fields: Vec<String>,
+    phantom: PhantomData<V>,
+}
+
+impl UserReservedFields<IslV2_0> {
+    pub(crate) fn new(
+        schema_header_fields: Vec<String>,
+        schema_footer_fields: Vec<String>,
+        type_fields: Vec<String>,
+    ) -> Self {
+        Self {
+            schema_header_fields,
+            schema_footer_fields,
+            type_fields,
+            phantom: Default::default(),
+        }
+    }
+}
+
+/// Provides an internal representation of an schema file
+#[derive(Debug, Clone)]
+pub struct IslSchema<V: IslVersionTrait> {
+    /// Represents an id for the given ISL model
+    id: String,
+    /// Represents the user defined reserved fields
+    /// For ISL 2.0 this contains the use reserved fields that are defined within schema header,
+    /// Otherwise, it is None.
+    user_reserved_fields: Option<UserReservedFields<IslV2_0>>,
+    /// Represents all the IslImports inside the schema file.
+    /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
+    imports: Vec<IslImport>,
+    /// Represents all the IslType defined in this schema file.
+    /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#type-definitions
+    types: Vec<IslType<V>>,
+    /// Represents all the inline IslImportTypes in this schema file.
+    inline_imported_types: Vec<IslImportType>,
+    /// Represents open content as `Element`s
+    /// Note: This doesn't preserve the information about where the open content is placed in the schema file.
+    /// e.g. This method doesn't differentiate between following schemas with open content:
+    /// ```ion
+    /// $foo
+    /// $bar
+    /// type::{ name: foo, codepoint_length: 1 }
+    /// ```
+    ///
+    /// ```ion
+    /// type::{ name: foo, codepoint_length: 1 }
+    /// $foo
+    /// $bar
+    /// ```
+    open_content: Vec<Element>,
+    phantom: PhantomData<V>,
+}
+
+impl<V: IslVersionTrait> IslSchema<V> {
+    pub fn new<A: AsRef<str>>(
+        id: A,
+        imports: Vec<IslImport>,
+        types: Vec<IslType<V>>,
+        inline_imports: Vec<IslImportType>,
+        open_content: Vec<Element>,
+    ) -> Self {
+        Self {
+            id: id.as_ref().to_owned(),
+            user_reserved_fields: None,
+            imports,
+            types,
+            inline_imported_types: inline_imports,
+            open_content,
+            phantom: Default::default(),
+        }
+    }
+
+    pub fn with_user_reserved_fields(
+        self,
+        user_reserved_fields: UserReservedFields<IslV2_0>,
+    ) -> Self {
+        Self {
+            id: self.id,
+            user_reserved_fields: Some(user_reserved_fields),
+            imports: self.imports,
+            types: self.types,
+            inline_imported_types: self.inline_imported_types,
+            open_content: self.open_content,
+            phantom: Default::default(),
+        }
+    }
+
+    pub fn id(&self) -> String {
+        self.id.to_owned()
+    }
+
+    pub fn imports(&self) -> &[IslImport] {
+        &self.imports
+    }
+
+    pub fn types(&self) -> &[IslType<V>] {
+        &self.types
+    }
+
+    pub fn inline_imported_types(&self) -> &[IslImportType] {
+        &self.inline_imported_types
+    }
+
+    /// Provides top level open content for given schema
+    /// For open content defined within type definitions use IslType#open_content()
+    pub fn open_content(&self) -> &Vec<Element> {
+        &self.open_content
+    }
+
+    /// Provide user reserved field defined in the given schema for ISL 2.0,
+    /// Otherwise returns None
+    pub fn user_reserved_fields(&self) -> Option<&UserReservedFields<IslV2_0>> {
+        self.user_reserved_fields.as_ref()
+    }
+}
+
+/// Represents both named and anonymous [IslType]s and can be converted to a resolved type definition
+/// Named ISL type grammar: `type:: { name: <NAME>, <CONSTRAINT>...}`
+/// Anonymous ISL type grammar: `{ <CONSTRAINT>... }`
+#[derive(Debug, Clone, PartialEq)]
+pub struct IslType<V: IslVersionTrait> {
+    name: Option<String>,
+    constraints: Vec<IslConstraint<V>>,
+    // Represents the ISL type struct in string format for anonymous type definition
+    // For named type definition & programmatically created type definition, this will be `None`
+    pub(crate) isl_type_struct: Option<Element>,
+    phantom: PhantomData<V>,
+}
+
+impl<V: IslVersionTrait> IslType<V> {
+    pub(crate) fn new(name: Option<String>, constraints: Vec<IslConstraint<V>>) -> Self {
+        Self {
+            name,
+            constraints,
+            isl_type_struct: None,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Creates a named [IslType] using the [IslConstraint] defined within it
+    pub fn named<A: Into<String>, B: Into<Vec<IslConstraint<V>>>>(
+        name: A,
+        constraints: B,
+    ) -> IslType<V> {
+        IslType::new(Some(name.into()), constraints.into())
+    }
+
+    /// Creates an anonymous [IslType] using the [IslConstraint] defined within it
+    pub fn anonymous<A: Into<Vec<IslConstraint<V>>>>(constraints: A) -> IslType<V> {
+        IslType::new(None, constraints.into())
+    }
+
+    /// Provides a name if the ISL type is named type definition
+    /// Otherwise returns None
+    pub fn name(&self) -> &Option<String> {
+        &self.name
+    }
+
+    /// Provides open content that is there in the type definition
+    pub fn open_content(&self) -> Vec<(&String, &Element)> {
+        let mut open_contents = vec![];
+        for constraint in &self.constraints {
+            if let IslConstraint::Unknown(open_content) = constraint {
+                open_contents.push((open_content.field_name(), open_content.field_value()))
+            }
+        }
+        open_contents
+    }
+
+    /// Provides the underlying constraints of [IslType]
+    pub fn constraints(&self) -> &[IslConstraint<V>] {
+        &self.constraints
+    }
+}
+
+/// Provides an internal representation of a schema type reference.
+/// The type reference grammar is defined in the [Ion Schema Spec]
+///
+/// [Ion Schema spec]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#grammar
+#[derive(Debug, Clone, PartialEq)]
+pub enum IslTypeRef<V: IslVersionTrait> {
+    /// Represents a reference to a named type (including aliases and built-in types)
+    Named(String, NullabilityModifier),
+    /// Represents a type reference defined as an inlined import of a type from another schema
+    TypeImport(IslImportType, NullabilityModifier),
+    /// represents an unnamed type definition reference
+    Anonymous(IslType<V>, NullabilityModifier),
+}
+
+impl<V: IslVersionTrait> IslTypeRef<V> {
+    /// Creates a named [IslTypeRef] using the name of the type referenced inside it
+    pub fn named<A: Into<String>>(name: A) -> IslTypeRef<V> {
+        IslTypeRef::Named(name.into(), NullabilityModifier::Nothing)
+    }
+
+    /// Creates a nullable [IslTypeRef] using the [IonType] referenced inside it
+    pub fn nullable_built_in(name: IonType) -> IslTypeRef<IslV1_0> {
+        IslTypeRef::Named(format!("{name}"), NullabilityModifier::Nullable)
+    }
+
+    /// Creates an anonymous [IslTypeRef] using the [IslConstraint]s referenced inside it
+    pub fn anonymous<A: Into<Vec<IslConstraint<V>>>>(constraints: A) -> IslTypeRef<V> {
+        IslTypeRef::Anonymous(
+            IslType::new(None, constraints.into()),
+            NullabilityModifier::Nothing,
+        )
+    }
+
+    /// Creates an [IslVariablyOccurringTypeRef] using the [IslConstraint]s and [Range] referenced inside it
+    pub fn variably_occurring(
+        type_ref: IslTypeRef<V>,
+        occurs: Range,
+    ) -> IslVariablyOccurringTypeRef<V> {
+        IslVariablyOccurringTypeRef::new(type_ref, occurs)
+    }
+
+    /// Creates a nullable [IslTypeRef] using the name of the type referenced inside it for ISL 2.0
+    pub fn null_or_named_type_ref<A: Into<String>>(name: A) -> IslTypeRef<IslV2_0> {
+        IslTypeRef::Named(name.into(), NullabilityModifier::NullOr)
+    }
+}
+
+/// Represents a [variably occurring type reference] that will be used by `ordered_elements` and `fields` constraints.
+///  
+/// ```ion
+/// Grammar: <VARIABLY_OCCURRING_TYPE_ARGUMENT> ::= { <OCCURS>, <CONSTRAINT>... }
+///                                      | <TYPE_ARGUMENT>
+///
+///         <OCCURS> ::= occurs: <INT>
+///            | occurs: <RANGE_INT>
+///            | occurs: optional
+///            | occurs: required
+/// ```
+///
+/// [variably occurring type reference]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#variably-occurring-type-arguments
+#[derive(Debug, Clone, PartialEq)]
+pub struct IslVariablyOccurringTypeRef<V: IslVersionTrait> {
+    type_ref: IslTypeRef<V>,
+    occurs: Range,
+}
+
+impl<V: IslVersionTrait> IslVariablyOccurringTypeRef<V> {
+    pub(crate) fn new(type_ref: IslTypeRef<V>, occurs: Range) -> Self {
+        Self { type_ref, occurs }
+    }
+}
+
+/// Represents an [import] in an ISL schema.
+///
+/// [import]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IslImport {
+    Schema(String),
+    Type(IslImportType),
+    TypeAlias(IslImportType),
+}
+
+/// Represents typed and type aliased [IslImport]s
+/// Typed import grammar: `{ id: <ID>, type: <TYPE_NAME> }`
+/// Type aliased import grammar: `{ id: <ID>, type: <TYPE_NAME>, as: <TYPE_ALIAS> }`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IslImportType {
+    id: String,
+    type_name: String,
+    alias: Option<String>,
+}


### PR DESCRIPTION
### Issue #187

### Description of changes:
This PR works on streamlining the ISL model using version maker traits. 

### List of changes:
* adds version marker traits which will be used to construct schema,
types and constraints for a particular ISL version
* adds logic constraints implementations
* adds type reference, type and import implementations based on version
marker trait
* adds example usage of this new change for the ISL model

_Note for reviewers_: 
- This PR creates a new module `version_based_isl` which will eventually be placed as the current `isl` module. This is because the change is too big and involves changing mostly entire ISL model. In order to divide the change into pieces created `version_based_isl`. 
- All the structs/enums for ISL model are same as previous ISL model except they now accept a generic `V`(version marker trait). 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
