### PR TITLE
Remove wrappers around ISL model

### DIFF
--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -1,4 +1,4 @@
-use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
+use crate::isl::isl_constraint::{IslConstraint, IslConstraintValue};
 use crate::isl::isl_import::IslImportType;
 use crate::isl::IslVersion;
 use crate::isl::WriteToIsl;
@@ -8,8 +8,8 @@ use ion_rs::{IonType, IonWriter};
 
 /// Provides public facing APIs for constructing ISL types programmatically for ISL 1.0
 pub mod v_1_0 {
-    use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
-    use crate::isl::isl_type::{IslType, IslTypeImpl};
+    use crate::isl::isl_constraint::{IslConstraint, IslConstraintValue};
+    use crate::isl::isl_type::IslType;
 
     /// Creates a named [IslType] using the [IslConstraint] defined within it
     pub fn named_type<A: Into<String>, B: Into<Vec<IslConstraint>>>(
@@ -17,24 +17,17 @@ pub mod v_1_0 {
         constraints: B,
     ) -> IslType {
         let constraints = constraints.into();
-        let isl_constraints: Vec<IslConstraintImpl> = constraints
-            .iter()
-            .map(|c| c.constraint.to_owned())
-            .collect();
-        IslType::new(
-            IslTypeImpl::new(Some(name.into()), isl_constraints, None),
-            constraints,
-        )
+        IslType::new(Some(name.into()), constraints, None)
     }
 
     /// Creates an anonymous [IslType] using the [IslConstraint] defined within it
     pub fn anonymous_type<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslType {
         let constraints = constraints.into();
-        let isl_constraints: Vec<IslConstraintImpl> = constraints
+        let isl_constraints: Vec<IslConstraintValue> = constraints
             .iter()
-            .map(|c| c.constraint.to_owned())
+            .map(|c| c.constraint_value.to_owned())
             .collect();
-        IslType::new(IslTypeImpl::new(None, isl_constraints, None), constraints)
+        IslType::new(None, constraints, None)
     }
 }
 
@@ -57,54 +50,22 @@ pub mod v_2_0 {
     }
 }
 
-/// Represents a type in an ISL schema.
-#[derive(Debug, Clone, PartialEq)]
-pub struct IslType {
-    pub(crate) type_definition: IslTypeImpl,
-    constraints: Vec<IslConstraint>,
-}
-
-impl IslType {
-    pub(crate) fn new(type_definition: IslTypeImpl, constraints: Vec<IslConstraint>) -> Self {
-        Self {
-            type_definition,
-            constraints,
-        }
-    }
-
-    /// Provides a name if the ISL type is named type definition
-    /// Otherwise returns None
-    pub fn name(&self) -> &Option<String> {
-        self.type_definition.name()
-    }
-
-    /// Provides open content that is there in the type definition
-    pub fn open_content(&self) -> Vec<(String, Element)> {
-        self.type_definition.open_content()
-    }
-
-    /// Provides the underlying constraints of [IslType]
-    pub fn constraints(&self) -> &[IslConstraint] {
-        &self.constraints
-    }
-}
-
 /// Represents both named and anonymous [IslType]s and can be converted to a resolved type definition
 /// Named ISL type grammar: `type:: { name: <NAME>, <CONSTRAINT>...}`
 /// Anonymous ISL type grammar: `{ <CONSTRAINT>... }`
 #[derive(Debug, Clone)]
-pub(crate) struct IslTypeImpl {
+pub struct IslType {
     name: Option<String>,
-    constraints: Vec<IslConstraintImpl>,
+    constraints: Vec<IslConstraint>,
     // Represents the ISL type struct in string format for anonymous type definition
     // For named type definition & programmatically created type definition, this will be `None`
     pub(crate) isl_type_struct: Option<Element>,
 }
 
-impl IslTypeImpl {
-    pub fn new(
+impl IslType {
+    pub(crate) fn new(
         name: Option<String>,
-        constraints: Vec<IslConstraintImpl>,
+        constraints: Vec<IslConstraint>,
         isl_type_struct: Option<Element>,
     ) -> Self {
         Self {
@@ -118,14 +79,16 @@ impl IslTypeImpl {
         &self.name
     }
 
-    pub fn constraints(&self) -> &[IslConstraintImpl] {
+    pub fn constraints(&self) -> &[IslConstraint] {
         &self.constraints
     }
 
     pub fn open_content(&self) -> Vec<(String, Element)> {
         let mut open_content = vec![];
         for constraint in &self.constraints {
-            if let IslConstraintImpl::Unknown(constraint_name, element) = constraint {
+            if let IslConstraintValue::Unknown(constraint_name, element) =
+                &constraint.constraint_value
+            {
                 open_content.push((constraint_name.to_owned(), element.to_owned()))
             }
         }
@@ -134,14 +97,17 @@ impl IslTypeImpl {
 
     pub(crate) fn is_open_content_allowed(&self) -> bool {
         let mut open_content = true;
-        if self.constraints.contains(&IslConstraintImpl::ContentClosed) {
+        if self.constraints.contains(&IslConstraint::new(
+            IslVersion::V1_0,
+            IslConstraintValue::ContentClosed,
+        )) {
             open_content = false;
         }
         open_content
     }
 
-    /// Parse constraints inside an [Element] to an [IslTypeImpl]
-    pub fn from_owned_element(
+    /// Parse constraints inside an [Element] to an [IslType]
+    pub(crate) fn from_owned_element(
         isl_version: IslVersion,
         ion: &Element,
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
@@ -209,24 +175,23 @@ impl IslTypeImpl {
                 }
             };
 
-            let constraint = IslConstraintImpl::from_ion_element(
+            let constraint = IslConstraint::new(
                 isl_version,
-                constraint_name,
-                value,
-                &isl_type_name,
-                inline_imported_types,
-            )?;
+                IslConstraintValue::from_ion_element(
+                    isl_version,
+                    constraint_name,
+                    value,
+                    &isl_type_name,
+                    inline_imported_types,
+                )?,
+            );
             constraints.push(constraint);
         }
-        Ok(IslTypeImpl::new(
-            type_name,
-            constraints,
-            Some(ion.to_owned()),
-        ))
+        Ok(IslType::new(type_name, constraints, Some(ion.to_owned())))
     }
 }
 
-impl WriteToIsl for IslTypeImpl {
+impl WriteToIsl for IslType {
     fn write_to<W: IonWriter>(&self, writer: &mut W) -> IonSchemaResult<()> {
         writer.set_annotations(["type"]);
         writer.step_in(IonType::Struct)?;
@@ -239,7 +204,7 @@ impl WriteToIsl for IslTypeImpl {
                 "Top level type definitions must contain a `name` field",
             ))?;
         for constraint in self.constraints() {
-            constraint.write_to(writer)?;
+            constraint.constraint_value.write_to(writer)?;
         }
         writer.step_out()?;
         Ok(())
@@ -248,7 +213,7 @@ impl WriteToIsl for IslTypeImpl {
 
 // OwnedStruct doesn't preserve field order hence the PartialEq won't work properly for unordered constraints
 // Related issue: https://github.com/amazon-ion/ion-rust/issues/200
-impl PartialEq for IslTypeImpl {
+impl PartialEq for IslType {
     fn eq(&self, other: &Self) -> bool {
         self.constraints.len() == other.constraints.len()
             && self.name == other.name

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -3,8 +3,8 @@
 
 use crate::external::ion_rs::IonType;
 use crate::ion_path::IonPath;
-use crate::isl::isl_constraint::IslConstraintImpl;
-use crate::isl::isl_type::IslTypeImpl;
+use crate::isl::isl_constraint::IslConstraintValue;
+use crate::isl::isl_type::IslType;
 use crate::isl::WriteToIsl;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use crate::violation::{Violation, ViolationCode};
@@ -312,16 +312,13 @@ impl UserReservedFields {
         Ok(())
     }
 
-    pub(crate) fn validate_field_names_in_type(
-        &self,
-        isl_type: &IslTypeImpl,
-    ) -> IonSchemaResult<()> {
+    pub(crate) fn validate_field_names_in_type(&self, isl_type: &IslType) -> IonSchemaResult<()> {
         let unexpected_fields: &Vec<&String> = &isl_type
             .constraints()
             .iter()
-            .filter(|c| matches!(c, IslConstraintImpl::Unknown(_, _)))
-            .map(|c| match c {
-                IslConstraintImpl::Unknown(f, v) => f,
+            .filter(|c| matches!(c.constraint_value, IslConstraintValue::Unknown(_, _)))
+            .map(|c| match &c.constraint_value {
+                IslConstraintValue::Unknown(f, v) => f,
                 _ => {
                     unreachable!("we have already filtered all other constraints")
                 }


### PR DESCRIPTION
### Description of changes:
This PR updates ISL model to remove wrappers, also makes enum `IslConstraintValue` public to be used for matching constraints.

### List of changes:
* Renames structs `IslTypeImpl` -> I`slType`, `IslTypeRefImpl` -> `IslTypeRef`, `IslSchemaImpl` -> `IslSchema`
* adds `constraint()` to get constraint type enum
* Makes enum `IslConstraintValue` public to be used to match against ISL constraint types and get underlying constraint value

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
