### PR TITLE
Modifies `PartialEq` for `Violation`

### DIFF
--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -121,8 +121,8 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
     // get the schema content from given schema file path
     let ion_content = fs::read(ctx.current_dir.as_path())
         .unwrap_or_else(|e| panic!("Unable to read {path_string} – {e}"));
-    let schema_content = Element::read_all(ion_content)
-        .unwrap_or_else(|e| panic!("Error in {path_string} – {e:?}"));
+    let schema_content =
+        Element::read_all(ion_content).unwrap_or_else(|e| panic!("Error in {path_string} – {e:?}"));
 
     let isl_version = find_isl_version(&schema_content);
 

--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -121,7 +121,7 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
     // get the schema content from given schema file path
     let ion_content = fs::read(ctx.current_dir.as_path())
         .unwrap_or_else(|e| panic!("Unable to read {path_string} – {e}"));
-    let schema_content = Element::read_all(&ion_content)
+    let schema_content = Element::read_all(ion_content)
         .unwrap_or_else(|e| panic!("Error in {path_string} – {e:?}"));
 
     let isl_version = find_isl_version(&schema_content);

--- a/ion-schema/examples/schema.rs
+++ b/ion-schema/examples/schema.rs
@@ -65,7 +65,7 @@ fn validate(command_args: &ArgMatches) -> IonSchemaResult<()> {
     // Extract Ion value provided by user
     let input_file = command_args.value_of("input").unwrap();
     let value = fs::read(input_file).expect("Can not load given ion file");
-    let owned_elements = Element::read_all(&value).expect("parsing failed unexpectedly");
+    let owned_elements = Element::read_all(value).expect("parsing failed unexpectedly");
 
     // Set up authorities vector
     let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 /// Represents a single element in Ion Path which is either an index value or a field name depending on its parent container type
-#[derive(Clone, PartialEq, PartialOrd)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Hash)]
 pub enum IonPathElement {
     Index(usize),
     Field(String),
@@ -57,7 +57,7 @@ impl fmt::Display for IonPathElement {
 /// ```ion
 /// ( greetings 1 ) // here 1 represents the index of "hi" in the Ion list value
 /// ```
-#[derive(Default, Clone, PartialEq, PartialOrd)]
+#[derive(Default, Clone, PartialEq, PartialOrd, Eq, Hash)]
 pub struct IonPath {
     ion_path_elements: Vec<IonPathElement>,
 }

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -70,6 +70,10 @@ impl IonPath {
     pub fn pop(&mut self) -> Option<IonPathElement> {
         self.ion_path_elements.pop()
     }
+
+    pub(crate) fn new(ion_path_elements: Vec<IonPathElement>) -> Self {
+        Self { ion_path_elements }
+    }
 }
 
 impl From<IonPath> for Element {

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -86,7 +86,7 @@ pub mod v_1_0 {
     {
         IslConstraint::new(
             IslVersion::V1_0,
-            IslConstraintValue::Fields(fields.map(|(s, t)| (s, t)).collect(), false),
+            IslConstraintValue::Fields(fields.collect(), false),
         )
     }
 
@@ -278,7 +278,7 @@ pub mod v_2_0 {
     {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintValue::Fields(fields.map(|(s, t)| (s, t)).collect(), false),
+            IslConstraintValue::Fields(fields.collect(), false),
         )
     }
 

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -152,6 +152,8 @@ impl fmt::Display for ViolationCode {
 }
 
 #[macro_export]
+/// Equivalence for `Violation`s is not supported due to its tree structure of having children violations.
+/// This macro can be used for comparing if two violations are equal and uses `flattened_violations` for the comparison.
 macro_rules! assert_equivalent_violations {
     ($left:expr, $right:expr $(,)?) => {
         let mut left_strings: Vec<String> = $left
@@ -186,6 +188,9 @@ macro_rules! assert_equivalent_violations {
 }
 
 #[macro_export]
+
+/// Equivalence for `Violation`s is not supported due to its tree structure of having children violations.
+/// This macro can be used for comparing if two violations are not equal and uses `flattened_violations` for the comparison.
 macro_rules! assert_non_equivalent_violations {
     ($left:expr, $right:expr $(,)?) => {
         let mut left_strings: Vec<String> = $left

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -237,11 +237,17 @@ mod violation_tests {
                     &mut IonPath::default(),
                     vec![
                         Violation::new(
-                        "container_length",
-                        ViolationCode::InvalidLength,
-                        "invalid length",
-                        &mut IonPath::default(),
-                    )
+                            "container_length",
+                            ViolationCode::InvalidLength,
+                            "invalid length",
+                            &mut IonPath::default(),
+                        ),
+                        Violation::new(
+                            "codepoint_length",
+                            ViolationCode::InvalidLength,
+                            "invalid length",
+                            &mut IonPath::default(),
+                        )
                     ]
                 )
             ],
@@ -259,10 +265,16 @@ mod violation_tests {
                     &mut IonPath::default(),
                     vec![
                         Violation::new(
-                        "container_length",
-                        ViolationCode::InvalidLength,
-                        "invalid length",
-                        &mut IonPath::default(),
+                            "codepoint_length",
+                            ViolationCode::InvalidLength,
+                            "invalid length",
+                            &mut IonPath::default(),
+                        ),
+                        Violation::new(
+                            "container_length",
+                            ViolationCode::InvalidLength,
+                            "invalid length",
+                            &mut IonPath::default(),
                         )
                     ]
                 )

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -6,6 +6,7 @@ use ion_schema::result::IonSchemaResult;
 use ion_schema::schema::Schema;
 use ion_schema::system::SchemaSystem;
 use ion_schema::types::TypeDefinition;
+use ion_schema::violation::Violation;
 use ion_schema::IonSchemaElement;
 use js_sys::Array;
 use serde::{Deserialize, Serialize};
@@ -193,9 +194,9 @@ pub fn validate(
 
     log!("validation complete!");
 
-    let violations = match &result {
+    let violations: Vec<&Violation> = match &result {
         Ok(_) => vec![],
-        Err(violation) => violation.flattened_violations(),
+        Err(violation) => violation.flattened_violations().into_iter().collect(),
     };
 
     log!("Creating validation result....");

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -196,7 +196,7 @@ pub fn validate(
 
     let violations: Vec<&Violation> = match &result {
         Ok(_) => vec![],
-        Err(violation) => violation.flattened_violations().into_iter().collect(),
+        Err(violation) => violation.flattened_violations(),
     };
 
     log!("Creating validation result....");


### PR DESCRIPTION
### Issue #206:

### Description of changes:
This PR works on fixing `PartialEq` for `Violation` and modifies `flattened_violations` return sorted violations which can be used for comparison.

### List of changes:
* Changes `PartialEq` for `Violation` to defer to flattened violations
for equivalence rather then `Violation`s tree
* Modified `flattened_violations` to return sorted vector absed on
constraint
* Modified `flattened_violations` to not return the violation itself
when there are no children
* adds clippy and rustfmt changes

### Test: 
Adds test for violations equivalence.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
