### PR TITLE
Bumps verison to v0.12.0

### DIFF
--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -31,5 +31,5 @@ half = "2.2.1"
 
 [dev-dependencies]
 rstest = "0.9"
-clap = {version = "2.33.3", features = ["yaml"]}
+clap = { version = "2.33.3", features = ["yaml"] }
 test-generator = "0.3.0"


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR bumps version to 0.12.0 which will include an API change for `get_type` #215.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
