### PR TITLE
Add support for programmatically adding closed `fields`

### DIFF
--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -273,13 +273,13 @@ pub mod v_2_0 {
 
     /// Creates a `fields` constraint using the field names and [IslVariablyOccurringTypeRef]s referenced inside it
     /// and specify if the `fields` are closed or not (i.e. indicates whether only fields that are explicitly specified should be allowed or not).
-    pub fn fields<I>(fields: I, content_closed: bool) -> IslConstraint
+    pub fn fields<I>(fields: I, is_closed: bool) -> IslConstraint
     where
         I: Iterator<Item = (String, IslVariablyOccurringTypeRef)>,
     {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintValue::Fields(fields.collect(), content_closed),
+            IslConstraintValue::Fields(fields.collect(), is_closed),
         )
     }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -272,13 +272,14 @@ pub mod v_2_0 {
     }
 
     /// Creates a `fields` constraint using the field names and [IslVariablyOccurringTypeRef]s referenced inside it
-    pub fn fields<I>(fields: I) -> IslConstraint
+    /// and specify if the `fields` are closed or not (i.e. indicates whether only fields that are explicitly specified should be allowed or not).
+    pub fn fields<I>(fields: I, content_closed: bool) -> IslConstraint
     where
         I: Iterator<Item = (String, IslVariablyOccurringTypeRef)>,
     {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintValue::Fields(fields.collect(), false),
+            IslConstraintValue::Fields(fields.collect(), content_closed),
         )
     }
 

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -501,12 +501,18 @@ mod isl_tests {
                 "#),
         anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), UsizeRange::new_single_value(1)), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), UsizeRange::new_single_value(1))])])
     ),
-    case::fields_constraint(
-        load_isl_type(r#" // For a schema with fields constraint as below:
+    case::closed_fields_constraint(
+        load_isl_type_v2_0(r#" // For a schema with fields constraint as below:
+                    { fields: closed::{ name: string, id: int} }
+                "#),
+        anonymous_type([isl_constraint::v_2_0::fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), UsizeRange::zero_or_one())), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), UsizeRange::zero_or_one()))].into_iter(), true)]),
+    ),
+        case::fields_constraint(
+            load_isl_type(r#" // For a schema with fields constraint as below:
                     { fields: { name: string, id: int} }
                 "#),
-        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), UsizeRange::zero_or_one())), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), UsizeRange::zero_or_one()))].into_iter())]),
-    ),
+            anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), UsizeRange::zero_or_one())), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), UsizeRange::zero_or_one()))].into_iter())]),
+        ),
     case::field_names_constraint(
         load_isl_type_v2_0(r#" // For a schema with field_names constraint as below:
                         { field_names: distinct::symbol }


### PR DESCRIPTION
### Issue #217 

### Description of changes:
This PR works on adding support programmatically adding closed `fields`.

### List of changes:
- Modified `fields` constraint API to add a boolean representing `fields` are closed or not.
- Added relevant test for closed fields

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
