### PR TITLE
Adds stubs for TypeDefinitionBuilder, internal traits, and implementations for AnnotationsV2Simple

### DIFF
--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.10", features = ["experimental-reader-writer"] }
+ion-rs = { version = "1.0.0-rc.11", features = ["experimental-reader-writer"] }
 thiserror = "1.0"
 num-traits = "0.2"
 regex = "1.5.6"

--- a/ion-schema/src/internal_traits.rs
+++ b/ion-schema/src/internal_traits.rs
@@ -5,10 +5,10 @@
 //       instead of being clobbered together.
 
 use crate::result::IonSchemaResult;
+use crate::type_reference::TypeReference;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
 use std::ops::ControlFlow;
-use std::sync::Arc;
 
 /// For internal implementation of validation.
 ///
@@ -25,14 +25,24 @@ pub(crate) trait ValidateInternal {
     ) -> ControlFlow<()>
     where
         R: ViolationRecorder<'a>;
+}
 
-    /// Resolve any type references in preparation for validation.
-    fn resolve(&self, schema_store: &Arc<InvisibleSchemaStore>) -> IonSchemaResult<()>;
+/// Trait for visiting all the type references of things that could have type references.
+///
+/// This can be implemented for things with no type references, and if done so, the implementations
+/// of each function should be a no-op.
+trait HasTypeReferences {
+    /// Recursively visit each [TypeReference] held by self or by members of self.
+    ///
+    /// Used for:
+    ///   - Identifying references to other schemas that may need to be loaded
+    ///   - Ensuring that all references are resolvable
+    fn visit_type_references<F: FnMut(&TypeReference)>(&self, visitor: F);
 
-    /// Un-resolve all type references.
-    /// This is not strictly required, but if type reference resolution were to fail,
-    /// we should undo any changes before returning ownership to the user.
-    fn unresolve(&self);
+    /// Recursively visit each [TypeReference] held by self or by members of self.
+    ///
+    /// Used for resolving the type references.
+    fn visit_mut_type_references<F: FnMut(&mut TypeReference)>(&mut self, visitor: F);
 }
 
 // TODO: fields/functions to support
@@ -41,7 +51,7 @@ pub(crate) trait ValidateInternal {
 //  - "validate" configuration options
 pub(crate) struct ValidationContext {}
 
-pub(crate) struct InvisibleSchemaStore {
+pub(crate) struct SchemaStore {
     // TODO: This is a placeholder
 }
 

--- a/ion-schema/src/internal_traits.rs
+++ b/ion-schema/src/internal_traits.rs
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: This file is a placeholder. These things will eventually be moved to more sensible locations
+//       instead of being clobbered together.
+
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
+use ion_rs::{Element, ValueWriter};
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+/// For internal implementation of validation.
+///
+/// Should be implemented by TypeDefinition, TypeArgument, etc. and all constraints.
+pub(crate) trait ValidateInternal {
+    /// Validate a value.
+    /// Panics if any unresolved type references are encountered. This crate must
+    /// ensure that resolve() is called before calling validate.
+    fn validate_internal<'a, R>(
+        &'a self,
+        value: &'a IonSchemaElement,
+        ctx: &ValidationContext,
+        recorder: &'a mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'a>;
+
+    /// Resolve any type references in preparation for validation.
+    fn resolve(&self, schema_store: &Arc<InvisibleSchemaStore>) -> IonSchemaResult<()>;
+
+    /// Un-resolve all type references.
+    /// This is not strictly required, but if type reference resolution were to fail,
+    /// we should undo any changes before returning ownership to the user.
+    fn unresolve(&self);
+}
+
+// TODO: fields/functions to support
+//  - looking up references in the InvisibleSchemaStore
+//  - any other state or needed for validation
+//  - "validate" configuration options
+pub(crate) struct ValidationContext {}
+
+pub(crate) struct InvisibleSchemaStore {
+    // TODO: This is a placeholder
+}
+
+/// For internal implementation of serialization.
+///
+/// Implementations of `WriteAsIon` may delegate to this when possible.
+pub(crate) trait WriteAsIsl<V: IslVersion> {
+    fn write_as_isl<W: ValueWriter>(&self, writer: W) -> IonSchemaResult<()>;
+}
+
+/// For internal implementation of reading Ion Schema Language.
+pub(crate) trait ReadFromIsl<V: IslVersion>: Sized {
+    fn try_read(ion: &Element, ctx: &LoaderContext) -> IonSchemaResult<Self>;
+}
+
+// TODO: fields/functions to support
+//    * looking up types/schemas that are already loaded
+//    * queueing up types/schemas that need to be loaded
+//    * any other context that we discover that we need.
+pub(crate) struct LoaderContext {}

--- a/ion-schema/src/ion_extension.rs
+++ b/ion-schema/src/ion_extension.rs
@@ -45,7 +45,7 @@ pub(crate) trait SymbolExtensions: Sized {
 
 impl SymbolExtensions for Symbol {
     fn expect_known_symbol(self) -> IonResult<Self> {
-        let result = (&self).expect_text();
+        let result = self.expect_text();
         match result {
             Ok(_) => Ok(self),
             Err(e) => Err(e),

--- a/ion-schema/src/ion_extension.rs
+++ b/ion-schema/src/ion_extension.rs
@@ -1,4 +1,4 @@
-use ion_rs::Decimal;
+use ion_rs::{Decimal, IonResult, Symbol};
 use ion_rs::{Element, Value};
 use num_traits::ToPrimitive;
 
@@ -34,6 +34,21 @@ impl ElementExtensions for Element {
             Value::Float(f) => (*f).try_into().ok(),
             Value::Decimal(d) => Some(*d),
             _ => None,
+        }
+    }
+}
+
+pub(crate) trait SymbolExtensions: Sized {
+    /// Returns Err if the symbol has unknown text, otherwise returns Ok(self).
+    fn expect_known_symbol(self) -> IonResult<Self>;
+}
+
+impl SymbolExtensions for Symbol {
+    fn expect_known_symbol(self) -> IonResult<Self> {
+        let result = (&self).expect_text();
+        match result {
+            Ok(_) => Ok(self),
+            Err(e) => Err(e),
         }
     }
 }

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -37,7 +37,9 @@ mod type_reference;
 pub mod types;
 pub mod violation;
 
+mod internal_traits;
 mod ion_schema_version;
+mod model;
 mod violation_recorder;
 
 pub use ion_schema_element::*;

--- a/ion-schema/src/model/builder.rs
+++ b/ion-schema/src/model/builder.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::constraints::AnyConstraint;
+use crate::IslVersion;
+use ion_rs::Element;
+use std::marker::PhantomData;
+
+/// A version-safe builder for Ion Schema type definitions.
+pub struct TypeDefinitionBuilder<V: IslVersion> {
+    pub(crate) constraints: Vec<AnyConstraint>,
+    open_content: Vec<(String, Element)>,
+    isl_version: PhantomData<V>,
+}

--- a/ion-schema/src/model/constraints/annotations_v2_simple.rs
+++ b/ion-schema/src/model/constraints/annotations_v2_simple.rs
@@ -9,7 +9,6 @@ use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaRes
 use crate::{IonSchemaElement, ViolationInfo, ViolationRecorder, ISL_2_0};
 use ion_rs::{Element, Symbol, ValueWriter};
 use std::ops::ControlFlow;
-use std::sync::Arc;
 
 /// Modifier for the simple syntax of Ion Schema 2.0 `annotations` constraint.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -91,7 +90,7 @@ impl ValidateInternal for AnnotationsV2Simple {
             ));
         };
 
-        let mut actual_annotations: Vec<&Symbol> = element.annotations().iter().collect();
+        let actual_annotations: Vec<&Symbol> = element.annotations().iter().collect();
 
         if self.modifier.is_closed() {
             let mut extra_anns = vec![];
@@ -125,27 +124,16 @@ impl ValidateInternal for AnnotationsV2Simple {
         }
         ControlFlow::Continue(())
     }
-
-    fn resolve(&self, schema_store: &Arc<InvisibleSchemaStore>) -> IonSchemaResult<()> {
-        Ok(())
-    }
-
-    fn unresolve(&self) { /* no-op */
-    }
 }
 
 impl WriteAsIsl<ISL_2_0> for AnnotationsV2Simple {
     fn write_as_isl<W: ValueWriter>(&self, writer: W) -> IonSchemaResult<()> {
-        let mut modifiers = vec![];
-        if self.modifier.is_closed() {
-            modifiers.push("closed")
-        }
-        if self.modifier.is_required() {
-            modifiers.push("required")
-        }
-        writer
-            .with_annotations(modifiers)?
-            .write_list(&self.annotations)?;
+        let writer = match self.modifier {
+            Closed => writer.with_annotations(["closed"]),
+            Required => writer.with_annotations(["required"]),
+            ClosedAndRequired => writer.with_annotations(["closed", "required"]),
+        }?;
+        writer.write_list(&self.annotations)?;
         Ok(())
     }
 }
@@ -185,7 +173,7 @@ impl ReadFromIsl<ISL_2_0> for AnnotationsV2Simple {
             .iter()
             .map(|el| {
                 el.expect_symbol()
-                    .map(|it| it.clone())
+                    .cloned()
                     .and_then(|symbol| symbol.expect_known_symbol())
             })
             .collect::<Result<Vec<Symbol>, _>>()?;
@@ -203,7 +191,7 @@ mod tests {
     use super::AnnotationsV2Simple;
     use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl};
     use ion_rs::v1_0::Text;
-    use ion_rs::{v1_0, Element, SequenceWriter, TextFormat, WriteConfig, Writer};
+    use ion_rs::{Element, SequenceWriter, Writer};
     use rstest::rstest;
 
     // TODO: Tests for TypeDefinitionBuilder function impl, once TypeDefinitionBuilder is further developed
@@ -219,7 +207,7 @@ mod tests {
         #[case] expected_ion: &str,
         #[case] constraint: AnnotationsV2Simple,
     ) {
-        let mut buffer = Vec::new();
+        let buffer = Vec::new();
         let mut writer = Writer::new(Text, buffer).unwrap();
         constraint.write_as_isl(writer.value_writer()).unwrap();
         let output = writer.close().unwrap();

--- a/ion-schema/src/model/constraints/annotations_v2_simple.rs
+++ b/ion-schema/src/model/constraints/annotations_v2_simple.rs
@@ -1,0 +1,260 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::*;
+use crate::ion_extension::SymbolExtensions;
+use crate::model::builder::TypeDefinitionBuilder;
+use crate::model::constraints::AnnotationsV2Modifier::{Closed, ClosedAndRequired, Required};
+use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
+use crate::{IonSchemaElement, ViolationInfo, ViolationRecorder, ISL_2_0};
+use ion_rs::{Element, Symbol, ValueWriter};
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+/// Modifier for the simple syntax of Ion Schema 2.0 `annotations` constraint.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AnnotationsV2Modifier {
+    Closed,
+    Required,
+    ClosedAndRequired,
+}
+impl AnnotationsV2Modifier {
+    fn is_closed(&self) -> bool {
+        *self != AnnotationsV2Modifier::Required
+    }
+    fn is_required(&self) -> bool {
+        *self != AnnotationsV2Modifier::Closed
+    }
+}
+
+/// Represents the [annotations] constraint, simple syntax, in Ion Schema 2.0
+///
+/// [annotations]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#annotations
+#[derive(Debug, PartialEq, Clone)]
+pub struct AnnotationsV2Simple {
+    pub(crate) modifier: AnnotationsV2Modifier,
+    pub(crate) annotations: Vec<Symbol>,
+}
+
+impl AnnotationsV2Simple {
+    pub(crate) fn new<T: Into<Symbol>>(
+        modifier: AnnotationsV2Modifier,
+        annotations: Vec<T>,
+    ) -> Self {
+        Self {
+            modifier,
+            annotations: annotations.into_iter().map(|it| it.into()).collect(),
+        }
+    }
+
+    pub fn modifier(&self) -> AnnotationsV2Modifier {
+        self.modifier
+    }
+    pub fn annotations(&self) -> &[Symbol] {
+        self.annotations.as_slice()
+    }
+}
+
+impl TypeDefinitionBuilder<ISL_2_0> {
+    /// Adds an Ion Schema 2.0 `annotations` constraint using the simple syntax.
+    ///
+    /// For standard syntax, see [annotations_type].
+    fn annotations<S: Into<Symbol>, T: IntoIterator<Item = S>>(
+        mut self,
+        modifier: AnnotationsV2Modifier,
+        annotations: T,
+    ) -> Self {
+        let constraint = AnnotationsV2Simple {
+            modifier,
+            annotations: annotations.into_iter().map(Into::into).collect(),
+        };
+        self.constraints.push(constraint.into());
+        self
+    }
+}
+
+impl ValidateInternal for AnnotationsV2Simple {
+    fn validate_internal<'a, R>(
+        &'a self,
+        value: &IonSchemaElement<'a>,
+        ctx: &ValidationContext,
+        recorder: &'a mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'a>,
+    {
+        let Some(element) = value.as_element() else {
+            return recorder.accept(ViolationInfo::new(
+                self.into(),
+                value.clone(),
+                "document type is always invalid for annotations constraint".to_string(),
+            ));
+        };
+
+        let mut actual_annotations: Vec<&Symbol> = element.annotations().iter().collect();
+
+        if self.modifier.is_closed() {
+            let mut extra_anns = vec![];
+            for &text in actual_annotations.iter() {
+                if !self.annotations.iter().any(|it| it == text) {
+                    extra_anns.push(text)
+                }
+            }
+            if !extra_anns.is_empty() {
+                recorder.accept(ViolationInfo::new(
+                    self.into(),
+                    value.clone(),
+                    format!("Unexpected extra annotations: {:?}", extra_anns),
+                ))?
+            }
+        }
+        if self.modifier.is_required() {
+            let mut missing_annotations = vec![];
+            for required in &self.annotations {
+                if !actual_annotations.contains(&required) {
+                    missing_annotations.push(required)
+                }
+            }
+            if !missing_annotations.is_empty() {
+                recorder.accept(ViolationInfo::new(
+                    self.into(),
+                    value.clone(),
+                    format!("Missing required annotations: {:?}", missing_annotations),
+                ))?
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn resolve(&self, schema_store: &Arc<InvisibleSchemaStore>) -> IonSchemaResult<()> {
+        Ok(())
+    }
+
+    fn unresolve(&self) { /* no-op */
+    }
+}
+
+impl WriteAsIsl<ISL_2_0> for AnnotationsV2Simple {
+    fn write_as_isl<W: ValueWriter>(&self, writer: W) -> IonSchemaResult<()> {
+        let mut modifiers = vec![];
+        if self.modifier.is_closed() {
+            modifiers.push("closed")
+        }
+        if self.modifier.is_required() {
+            modifiers.push("required")
+        }
+        writer
+            .with_annotations(modifiers)?
+            .write_list(&self.annotations)?;
+        Ok(())
+    }
+}
+
+impl ReadFromIsl<ISL_2_0> for AnnotationsV2Simple {
+    fn try_read(ion: &Element, ctx: &LoaderContext) -> IonSchemaResult<Self> {
+        let required = ion.annotations().contains("required");
+        let closed = ion.annotations().contains("closed");
+        let annotations_len = ion.annotations().len();
+
+        if annotations_len != (required as usize + closed as usize) {
+            return invalid_schema_error(format!(
+                "unexpected annotations on annotations constraint argument: {}",
+                ion
+            ));
+        }
+
+        let modifier = match (closed, required) {
+            (true, true) => ClosedAndRequired,
+            (true, false) => Closed,
+            (false, true) => Required,
+            (false, false) => {
+                return invalid_schema_error(format!(
+                    "annotations must be closed, required, or both: {}",
+                    ion
+                ))
+            }
+        };
+        let annotations = ion
+            .as_list()
+            .ok_or_else(|| {
+                invalid_schema_error_raw(format!(
+                    "annotations constraint requires a list of annotations, found: {}",
+                    ion
+                ))
+            })?
+            .iter()
+            .map(|el| {
+                el.expect_symbol()
+                    .map(|it| it.clone())
+                    .and_then(|symbol| symbol.expect_known_symbol())
+            })
+            .collect::<Result<Vec<Symbol>, _>>()?;
+
+        Ok(AnnotationsV2Simple {
+            modifier,
+            annotations,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnnotationsV2Modifier;
+    use super::AnnotationsV2Simple;
+    use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl};
+    use ion_rs::v1_0::Text;
+    use ion_rs::{v1_0, Element, SequenceWriter, TextFormat, WriteConfig, Writer};
+    use rstest::rstest;
+
+    // TODO: Tests for TypeDefinitionBuilder function impl, once TypeDefinitionBuilder is further developed
+
+    // validate_internal will be covered by ion-schema-tests
+
+    #[rstest]
+    #[case::closed("closed::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Closed, vec!["foo"]) )]
+    #[case::required("required::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Required, vec!["foo"]) )]
+    #[case::closed_and_required("closed::required::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::ClosedAndRequired, vec!["foo"]) )]
+    #[case::empty_annotation_list("closed::[]", AnnotationsV2Simple { modifier: AnnotationsV2Modifier::Closed, annotations: vec![] } )]
+    fn annotations_v2_simple_write_as_isl(
+        #[case] expected_ion: &str,
+        #[case] constraint: AnnotationsV2Simple,
+    ) {
+        let mut buffer = Vec::new();
+        let mut writer = Writer::new(Text, buffer).unwrap();
+        constraint.write_as_isl(writer.value_writer()).unwrap();
+        let output = writer.close().unwrap();
+
+        let actual_element = Element::read_one(output);
+        let expected_element = Element::read_one(expected_ion);
+
+        assert_eq!(expected_element, actual_element);
+    }
+
+    #[rstest]
+    #[case::closed("closed::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Closed, vec!["foo"]))]
+    #[case::required("required::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Required, vec!["foo"]) )]
+    #[case::closed_and_required("closed::required::[foo]", AnnotationsV2Simple::new(AnnotationsV2Modifier::ClosedAndRequired, vec!["foo"]) )]
+    #[case::empty_annotation_list("closed::[]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Closed, Vec::<String>::new()))]
+    fn annotations_v2_simple_try_read_ok(#[case] ion: &str, #[case] expected: AnnotationsV2Simple) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext {};
+        let result = AnnotationsV2Simple::try_read(&element, &load_ctx);
+        assert_eq!(result, Ok(expected))
+    }
+
+    #[rstest]
+    #[case::annotations_list_must_have_a_modifier_annotation("[foo]")]
+    #[case::required_may_not_be_repeated("required::required::[foo]")]
+    #[case::closed_may_not_be_repeated("closed::closed::[foo]")]
+    #[case::closed_and_required_are_the_only_allowed_annotations("required::ordered::[foo]")]
+    #[case::annotations_cannot_be_non_text("required::[1]")]
+    #[case::annotations_cannot_be_strings("required::[\"foo\"]")]
+    #[case::annotations_must_be_in_a_list("required::(foo)")]
+    #[case::annotations_cannot_have_unknown_text("required::[$0]")]
+    fn annotations_v2_simple_try_read_err(#[case] ion: &str) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext {};
+        let result = AnnotationsV2Simple::try_read(&element, &load_ctx);
+        assert!(result.is_err())
+    }
+}

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use crate::model::constraints::*;
+
+macro_rules! any_of_these {
+    (#[$derives:meta] enum $super_:ident { $($name:ident,)+ }) => {
+        #[$derives]
+        pub enum $super_ {
+            $($name($name)),*
+        }
+
+        $(
+        impl From<$name> for $super_ {
+            fn from(value: $name) -> Self { $super_::$name(value) }
+        }
+        )+
+
+        // Any traits that should be implemented by delegating to the enum variants can be added here.
+    }
+}
+
+any_of_these!(
+    #[derive(Debug, PartialEq, Clone)]
+    enum AnyConstraint {
+        // AllOf,
+        // AnnotationsV1,
+        AnnotationsV2Simple,
+        // AnnotationsV2Standard,
+        // AnyOf,
+        // ByteLength,
+        // CodepointLength,
+        // ContainerLength,
+        // Contains,
+        // ElementConstraint,
+        // Exponent,
+        // Fields,
+        // FieldNames,
+        // Ieee754Float,
+        // Not,
+        // OneOf,
+        // OrderedElements,
+        // Precision,
+        // Regex,
+        // Scale,
+        // TimestampOffset,
+        // TimestampPrecision,
+        // Type,
+        // Utf8ByteLength,
+        // ValidValues,
+    }
+);
+
+macro_rules! any_of_these_refs {
+    (#[$derives:meta] enum $super_:ident { $($name:ident,)+ }) => {
+        #[$derives]
+        pub enum $super_<'a> {
+            $($name(&'a $name)),*
+        }
+
+        $(
+        impl<'a> From<&'a $name> for $super_<'a> {
+            fn from(value: &'a $name) -> Self { $super_::$name(value) }
+        }
+        )+
+
+        // Any traits that should be implemented by delegating to the enum variants can be added here.
+    }
+}
+
+any_of_these_refs!(
+    #[derive(Debug, PartialEq, Clone)]
+    enum AnyConstraintRef {
+        // AllOf,
+        // AnnotationsV1,
+        AnnotationsV2Simple,
+        // AnnotationsV2Standard,
+        // AnyOf,
+        // ByteLength,
+        // CodepointLength,
+        // ContainerLength,
+        // Contains,
+        // ElementConstraint,
+        // Exponent,
+        // Fields,
+        // FieldNames,
+        // Ieee754Float,
+        // Not,
+        // OneOf,
+        // OrderedElements,
+        // Precision,
+        // Regex,
+        // Scale,
+        // TimestampOffset,
+        // TimestampPrecision,
+        // Type,
+        // Utf8ByteLength,
+        // ValidValues,
+    }
+);

--- a/ion-schema/src/model/constraints/mod.rs
+++ b/ion-schema/src/model/constraints/mod.rs
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod annotations_v2_simple;
+mod any_constraint;
+
+pub use annotations_v2_simple::*;
+pub use any_constraint::*;

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod builder;
+pub mod constraints;
+
+pub use builder::*;

--- a/ion-schema/src/violation_recorder.rs
+++ b/ion-schema/src/violation_recorder.rs
@@ -124,6 +124,7 @@ impl<'a> ViolationRecorder<'a> for Vec<ViolationInfo<'a>> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::model::constraints::AnyConstraintRef;
     use crate::violation_recorder::{ViolationInfo, ViolationRecorder};

--- a/ion-schema/src/violation_recorder.rs
+++ b/ion-schema/src/violation_recorder.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::constraint::Constraint;
+use crate::model::constraints::AnyConstraintRef;
 use crate::IonSchemaElement;
 use std::ops::ControlFlow;
 
@@ -61,7 +61,7 @@ pub trait ViolationRecorder<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ViolationInfo<'a> {
     /// The constraint that was violated.
-    constraint: &'a Constraint,
+    constraint: AnyConstraintRef<'a>,
     /// The value that failed to satisfy the constraint.
     value: IonSchemaElement<'a>,
     /// A human-readable description of why the value violated the constraint.
@@ -72,7 +72,7 @@ pub struct ViolationInfo<'a> {
 
 impl<'a> ViolationInfo<'a> {
     pub(crate) fn new(
-        constraint: &'a Constraint,
+        constraint: AnyConstraintRef<'a>,
         value: IonSchemaElement<'a>,
         message: String,
     ) -> Self {
@@ -86,8 +86,8 @@ impl<'a> ViolationInfo<'a> {
     /// Returns a reference to the constraint that was violated.
     ///
     /// This can be useful for programmatically categorizing or filtering violations.
-    pub fn constraint(&self) -> &'a Constraint {
-        self.constraint
+    pub fn constraint(&self) -> &AnyConstraintRef {
+        &self.constraint
     }
 
     /// Returns a reference to the value that failed validation.
@@ -125,20 +125,24 @@ impl<'a> ViolationRecorder<'a> for Vec<ViolationInfo<'a>> {
 }
 
 mod tests {
-    use crate::constraint::{AllOfConstraint, Constraint};
+    use crate::model::constraints::AnyConstraintRef;
     use crate::violation_recorder::{ViolationInfo, ViolationRecorder};
-    use crate::IonSchemaElement;
+    use crate::{model, IonSchemaElement};
     use ion_rs::Element;
+    use model::constraints::{AnnotationsV2Modifier, AnnotationsV2Simple};
     use std::ops::ControlFlow;
 
     #[test]
     fn impl_violation_recorder_for_vec_violation_info() {
         let mut recorder: Vec<ViolationInfo> = vec![];
 
-        let constraint = Constraint::AllOf(AllOfConstraint::new(vec![]));
+        let constraint = AnnotationsV2Simple {
+            modifier: AnnotationsV2Modifier::Closed,
+            annotations: vec![],
+        };
         let element = Element::string("hello world");
         let vi = ViolationInfo::new(
-            &constraint,
+            AnyConstraintRef::AnnotationsV2Simple(&constraint),
             IonSchemaElement::from(&element),
             "fake violation".to_string(),
         );
@@ -156,10 +160,13 @@ mod tests {
     fn impl_violation_recorder_for_option_violation_info() {
         let mut recorder: Option<ViolationInfo> = None;
 
-        let constraint = Constraint::AllOf(AllOfConstraint::new(vec![]));
+        let constraint = AnnotationsV2Simple {
+            modifier: AnnotationsV2Modifier::Closed,
+            annotations: vec![],
+        };
         let element = Element::string("hello world");
         let mut vi = ViolationInfo::new(
-            &constraint,
+            AnyConstraintRef::AnnotationsV2Simple(&constraint),
             IonSchemaElement::from(&element),
             "fake violation".to_string(),
         );


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* Adds definitions for internal traits with stubs of supporting structs
* Adds stub for `TypeDefinitionBuilder`
* Set up `AnyConstraint` and `AnyConstraintRef` enum
* Implements `annotations` for ISL 2.0 simplified syntax
* Updates `ViolationRecorder` to use `AnyConstraintRef`
* Updates `ion-rs` dependency to `1.0.0-rc.11`


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
