### PR TITLE
Adds ranges, utf8_byte_length, and timestamp_precision

### DIFF
--- a/ion-schema/src/internal_traits.rs
+++ b/ion-schema/src/internal_traits.rs
@@ -94,6 +94,19 @@ impl<V: IslVersion> WriteContext<V> {
 pub(crate) trait ReadFromIsl<V: IslVersion>: Sized {
     fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self>;
 }
+/// Macro for trivial implementations that can use `expect_*` functions on [`Element`].
+macro_rules! read_from_isl {
+    ($t:ty, $func:ident) => {
+        impl<V: IslVersion> ReadFromIsl<V> for $t {
+            fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+                let i = ion.$func()?;
+                Ok(i)
+            }
+        }
+    };
+}
+read_from_isl!(usize, expect_usize);
+read_from_isl!(i64, expect_i64);
 
 // TODO: fields/functions to support
 //    * looking up types/schemas that are already loaded

--- a/ion-schema/src/ion_extension.rs
+++ b/ion-schema/src/ion_extension.rs
@@ -18,6 +18,12 @@ pub(crate) trait ElementExtensions {
     /// _and_ it can be represented as (fits in) a `Decimal`. Returns `None` if `self` is not one
     /// of the Ion number types or not a finite value.
     fn any_number_as_decimal(&self) -> Option<Decimal>;
+    /// Get up to one annotation from this [`Element`]. If this [`Element`] has more than one
+    /// annotation, or if the only annotation has unknown text, returns [`Err`].
+    fn one_optional_annotation(&self) -> IonSchemaResult<Option<&str>>;
+    /// If this [`Element`] is an Ion symbol with known text, returns [`Some`] with that text.
+    /// Otherwise, returns [`None`].
+    fn as_symbol_text(&self) -> Option<&str>;
 }
 impl ElementExtensions for Element {
     fn as_usize(&self) -> Option<usize> {
@@ -39,6 +45,21 @@ impl ElementExtensions for Element {
             Value::Decimal(d) => Some(*d),
             _ => None,
         }
+    }
+    fn one_optional_annotation(&self) -> IonSchemaResult<Option<&str>> {
+        let mut annotations = self.annotations().iter();
+        let Some(symbol) = annotations.next() else {
+            return Ok(None);
+        };
+        let text = symbol.expect_text()?;
+        match annotations.next() {
+            None => Ok(Some(text)),
+            Some(_) => invalid_schema_error(format!("Unexpected annotations: {self}")),
+        }
+    }
+
+    fn as_symbol_text(&self) -> Option<&str> {
+        self.as_symbol().and_then(|s| s.text())
     }
 }
 

--- a/ion-schema/src/ion_schema_element.rs
+++ b/ion-schema/src/ion_schema_element.rs
@@ -1,6 +1,6 @@
 use crate::ion_path::IonPath;
 use crate::violation::{Violation, ViolationCode};
-use ion_rs::{Element, IonType, Struct};
+use ion_rs::{Element, IonType, Struct, Timestamp};
 use std::fmt::{Display, Formatter};
 
 /// Extends [IonType] by adding a "Document" variant for Ion Schema.
@@ -85,6 +85,15 @@ pub struct IonSchemaElement<'a> {
     content: IonSchemaElementKind<'a>,
 }
 
+/// Macro for delegating `as_*` functions to [`Element`].
+macro_rules! as_value {
+    ($fun:ident() -> $t:ty) => {
+        pub(crate) fn $fun(&self) -> Option<$t> {
+            self.as_element().and_then(Element::$fun)
+        }
+    };
+}
+
 impl<'a> IonSchemaElement<'a>
 where
     Self: 'a,
@@ -95,13 +104,6 @@ where
                 .as_sequence()
                 .map(|s| AsRef::<[Element]>::as_ref(s).iter()),
             IonSchemaElementKind::Document(d) => Some(d.iter()),
-        }
-    }
-
-    pub(crate) fn as_struct(&'a self) -> Option<&'a Struct> {
-        match self.content {
-            IonSchemaElementKind::SingleElement(e) => e.as_struct(),
-            _ => None,
         }
     }
 
@@ -165,6 +167,10 @@ where
             }
         }
     }
+
+    as_value!(as_timestamp() -> Timestamp);
+    as_value!(as_struct() -> &Struct);
+    as_value!(as_text() -> &str);
 }
 
 impl Display for IonSchemaElement<'_> {

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -39,8 +39,9 @@ pub mod violation;
 
 mod internal_traits;
 mod ion_schema_version;
-mod model;
 mod violation_recorder;
+
+pub mod model;
 
 pub use ion_schema_element::*;
 pub use ion_schema_version::*;

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -8,21 +8,21 @@ use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::ValueWriter;
 use std::ops::ControlFlow;
 
-macro_rules! any_of_these {
-    (#[$derives:meta] enum $super_:ident { $($name:ident,)+ }) => {
-        #[$derives]
-        pub enum $super_ {
+macro_rules! any_constraint {
+    ($($name:ident,)+) => {
+        #[derive(Debug, PartialEq, Clone)]
+        pub enum AnyConstraint {
             $($name($name)),*
         }
 
         $(
-        impl From<$name> for $super_ {
-            fn from(value: $name) -> Self { $super_::$name(value) }
+        impl From<$name> for AnyConstraint {
+            fn from(value: $name) -> Self { AnyConstraint::$name(value) }
         }
         )+
 
         // Any traits that should be implemented by delegating to the enum variants can be added here.
-        impl ValidateInternal for $super_ {
+        impl ValidateInternal for AnyConstraint {
             fn validate_internal<'top: 'call, 'call, R>(
                 &'top self,
                 value: &'top IonSchemaElement<'top>,
@@ -33,7 +33,7 @@ macro_rules! any_of_these {
                 R: ViolationRecorder<'top>,
             {
                 match self {
-                    $($super_::$name(constraint) => constraint.validate_internal(value, ctx, recorder),
+                    $(AnyConstraint::$name(constraint) => constraint.validate_internal(value, ctx, recorder),
                     )+
                 }
             }
@@ -46,7 +46,7 @@ macro_rules! any_of_these {
         {
             fn write_as_isl<W: ValueWriter>(&self, writer: W, ctx: &WriteContext<V>) -> IonSchemaResult<()> {
                 match self {
-                    $($super_::$name(constraint) => $name::write_as_isl(constraint, writer, ctx),
+                    $(AnyConstraint::$name(constraint) => $name::write_as_isl(constraint, writer, ctx),
                     )+
                 }
             }
@@ -55,89 +55,50 @@ macro_rules! any_of_these {
         impl AnyConstraint {
             pub(crate) const fn constraint_keyword(&self) -> &'static str {
                 match self {
-                    $($super_::$name(_) => $name::CONSTRAINT_NAME,
+                    $(AnyConstraint::$name(_) => $name::CONSTRAINT_NAME,
                     )+
                 }
             }
         }
-    }
-}
 
-any_of_these!(
-    #[derive(Debug, PartialEq, Clone)]
-    enum AnyConstraint {
-        // AllOf,
-        // AnnotationsV1,
-        AnnotationsV2Simple,
-        // AnnotationsV2Standard,
-        // AnyOf,
-        // ByteLength,
-        // CodepointLength,
-        // ContainerLength,
-        // Contains,
-        // ElementConstraint,
-        // Exponent,
-        // Fields,
-        // FieldNames,
-        // Ieee754Float,
-        // Not,
-        // OneOf,
-        // OrderedElements,
-        // Precision,
-        // Regex,
-        // Scale,
-        // TimestampOffset,
-        // TimestampPrecision,
-        TypeConstraint,
-        // Utf8ByteLength,
-        // ValidValues,
-    }
-);
-
-macro_rules! any_of_these_refs {
-    (#[$derives:meta] enum $super_:ident { $($name:ident,)+ }) => {
-        #[$derives]
-        pub enum $super_<'a> {
+        /// An enum over references to all types of constraints. See [`AnyConstraint`].
+        #[derive(Debug, PartialEq, Clone)]
+        pub enum AnyConstraintRef<'a> {
             $($name(&'a $name)),*
         }
 
         $(
-        impl<'a> From<&'a $name> for $super_<'a> {
-            fn from(value: &'a $name) -> Self { $super_::$name(value) }
+        impl<'a> From<&'a $name> for AnyConstraintRef<'a> {
+            fn from(value: &'a $name) -> Self { AnyConstraintRef::$name(value) }
         }
         )+
-
-        // Any traits that should be implemented by delegating to the enum variants can be added here.
     }
 }
 
-any_of_these_refs!(
-    #[derive(Debug, PartialEq, Clone)]
-    enum AnyConstraintRef {
-        // AllOf,
-        // AnnotationsV1,
-        AnnotationsV2Simple,
-        // AnnotationsV2Standard,
-        // AnyOf,
-        // ByteLength,
-        // CodepointLength,
-        // ContainerLength,
-        // Contains,
-        // ElementConstraint,
-        // Exponent,
-        // Fields,
-        // FieldNames,
-        // Ieee754Float,
-        // Not,
-        // OneOf,
-        // OrderedElements,
-        // Precision,
-        // Regex,
-        // Scale,
-        // TimestampOffset,
-        // TimestampPrecision,
-        TypeConstraint,
-        // Utf8ByteLength,
-        // ValidValues,
-    }
+any_constraint!(
+    // AllOf,
+    // AnnotationsV1,
+    AnnotationsV2Simple,
+    // AnnotationsV2Standard,
+    // AnyOf,
+    // ByteLength,
+    // CodepointLength,
+    // ContainerLength,
+    // Contains,
+    // ElementConstraint,
+    // Exponent,
+    // Fields,
+    // FieldNames,
+    // Ieee754Float,
+    // Not,
+    // OneOf,
+    // OrderedElements,
+    // Precision,
+    // Regex,
+    // Scale,
+    // TimestampOffset,
+    TimestampPrecision,
+    TypeConstraint,
+    Utf8ByteLength,
+    // ValidValues,
 );

--- a/ion-schema/src/model/constraints/mod.rs
+++ b/ion-schema/src/model/constraints/mod.rs
@@ -3,12 +3,17 @@
 
 mod annotations_v2_simple;
 mod any_constraint;
+mod timestamp_precision;
 mod type_constraint;
+mod utf8_byte_length;
 
 pub use annotations_v2_simple::*;
 pub use any_constraint::*;
+pub use timestamp_precision::*;
 pub use type_constraint::*;
+pub use utf8_byte_length::*;
 
+/// Provides the constraint's name (ISL keyword) for a given constraint implementation.
 pub(crate) trait ConstraintName {
     const CONSTRAINT_NAME: &'static str;
 }

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -13,11 +13,7 @@ use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder};
 use ion_rs::{Element, IonResult, TimestampPrecision as TSPrecision, ValueWriter, WriteAsIon};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::ControlFlow;
-
-// For brevity within this module.
 use TimestampPrecisionValue::*;
-// Associated constants still need to be qualified, even with a * import.
-use TimestampPrecisionValue as Tpv;
 
 /// Argument for the [TimestampPrecision] constraint.
 #[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
@@ -64,14 +60,14 @@ impl TimestampPrecisionValue {
 
     fn as_str(&self) -> &'static str {
         match self {
-            Year => Tpv::YEAR,
-            Month => Tpv::MONTH,
-            Day => Tpv::DAY,
-            Minute => Tpv::MINUTE,
-            Second => Tpv::SECOND,
-            Millisecond => Tpv::MILLIS,
-            Microsecond => Tpv::MICROS,
-            Nanosecond => Tpv::NANOS,
+            Year => TimestampPrecisionValue::YEAR,
+            Month => TimestampPrecisionValue::MONTH,
+            Day => TimestampPrecisionValue::DAY,
+            Minute => TimestampPrecisionValue::MINUTE,
+            Second => TimestampPrecisionValue::SECOND,
+            Millisecond => TimestampPrecisionValue::MILLIS,
+            Microsecond => TimestampPrecisionValue::MICROS,
+            Nanosecond => TimestampPrecisionValue::NANOS,
         }
     }
 }
@@ -79,14 +75,14 @@ impl TimestampPrecisionValue {
 impl<V: IslVersion> ReadFromIsl<V> for TimestampPrecisionValue {
     fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
         match ion.as_symbol_text() {
-            Some(Tpv::YEAR) => Ok(Year),
-            Some(Tpv::MONTH) => Ok(Month),
-            Some(Tpv::DAY) => Ok(Day),
-            Some(Tpv::MINUTE) => Ok(Minute),
-            Some(Tpv::SECOND) => Ok(Second),
-            Some(Tpv::MILLIS) => Ok(Millisecond),
-            Some(Tpv::MICROS) => Ok(Microsecond),
-            Some(Tpv::NANOS) => Ok(Nanosecond),
+            Some(TimestampPrecisionValue::YEAR) => Ok(Year),
+            Some(TimestampPrecisionValue::MONTH) => Ok(Month),
+            Some(TimestampPrecisionValue::DAY) => Ok(Day),
+            Some(TimestampPrecisionValue::MINUTE) => Ok(Minute),
+            Some(TimestampPrecisionValue::SECOND) => Ok(Second),
+            Some(TimestampPrecisionValue::MILLIS) => Ok(Millisecond),
+            Some(TimestampPrecisionValue::MICROS) => Ok(Microsecond),
+            Some(TimestampPrecisionValue::NANOS) => Ok(Nanosecond),
             _ => invalid_schema_error(format!("not a valid timestamp precision value: {ion}")),
         }
     }

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -1,0 +1,300 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{
+    LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::ion_extension::ElementExtensions;
+use crate::model::constraints::ConstraintName;
+use crate::model::ranges::IonSchemaRange;
+use crate::model::TypeDefinitionBuilder;
+use crate::result::{invalid_schema_error, IonSchemaResult};
+use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder};
+use ion_rs::{Element, IonResult, TimestampPrecision as TSPrecision, ValueWriter, WriteAsIon};
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::ControlFlow;
+
+// For brevity within this module.
+use TimestampPrecisionValue::*;
+// Associated constants still need to be qualified, even with a * import.
+use TimestampPrecisionValue as Tpv;
+
+/// Argument for the [TimestampPrecision] constraint.
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+pub enum TimestampPrecisionValue {
+    Year = -4,
+    Month = -3,
+    Day = -2,
+    Minute = -1,
+    Second = 0,
+    Millisecond = 3,
+    Microsecond = 6,
+    Nanosecond = 9,
+}
+impl TimestampPrecisionValue {
+    const YEAR: &'static str = "year";
+    const MONTH: &'static str = "month";
+    const DAY: &'static str = "day";
+    const MINUTE: &'static str = "minute";
+    const SECOND: &'static str = "second";
+    const MILLIS: &'static str = "millisecond";
+    const MICROS: &'static str = "microsecond";
+    const NANOS: &'static str = "nanosecond";
+
+    /// Returns the [TimestampPrecisionValue] corresponding to a given [i64] value.
+    ///
+    /// This is for internal use only, and will panic if used incorrectly.
+    fn from_i64(value: i64) -> Self {
+        match value {
+            -4 => Year,
+            -3 => Month,
+            -2 => Day,
+            -1 => Minute,
+            0 => Second,
+            3 => Millisecond,
+            6 => Microsecond,
+            9 => Nanosecond,
+            i => unreachable!("reaching this branch indicates a programming error; value was {i}"),
+        }
+    }
+
+    fn to_i64(self) -> i64 {
+        self as i64
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Year => Tpv::YEAR,
+            Month => Tpv::MONTH,
+            Day => Tpv::DAY,
+            Minute => Tpv::MINUTE,
+            Second => Tpv::SECOND,
+            Millisecond => Tpv::MILLIS,
+            Microsecond => Tpv::MICROS,
+            Nanosecond => Tpv::NANOS,
+        }
+    }
+}
+
+impl<V: IslVersion> ReadFromIsl<V> for TimestampPrecisionValue {
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        match ion.as_symbol_text() {
+            Some(Tpv::YEAR) => Ok(Year),
+            Some(Tpv::MONTH) => Ok(Month),
+            Some(Tpv::DAY) => Ok(Day),
+            Some(Tpv::MINUTE) => Ok(Minute),
+            Some(Tpv::SECOND) => Ok(Second),
+            Some(Tpv::MILLIS) => Ok(Millisecond),
+            Some(Tpv::MICROS) => Ok(Microsecond),
+            Some(Tpv::NANOS) => Ok(Nanosecond),
+            _ => invalid_schema_error(format!("not a valid timestamp precision value: {ion}")),
+        }
+    }
+}
+
+impl Display for TimestampPrecisionValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl WriteAsIon for TimestampPrecisionValue {
+    fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+        writer.write_symbol(self.as_str())
+    }
+}
+
+/// Represents the `timestamp_precision` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#timestamp_precision
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#timestamp_precision
+#[derive(Debug, PartialEq, Clone)]
+pub struct TimestampPrecision {
+    range: IonSchemaRange<i64>,
+}
+
+impl TimestampPrecision {
+    pub(crate) fn new<T: Into<IonSchemaRange<TimestampPrecisionValue>>>(range: T) -> Self {
+        let tsp_range: IonSchemaRange<TimestampPrecisionValue> = range.into();
+        Self {
+            range: tsp_range.map_bounds(|tsp| tsp.to_i64()),
+        }
+    }
+
+    fn new_unchecked<T: TryInto<IonSchemaRange<TimestampPrecisionValue>>>(range: T) -> Self
+    where
+        <T as TryInto<IonSchemaRange<TimestampPrecisionValue>>>::Error: Debug,
+    {
+        let tsp_range: IonSchemaRange<TimestampPrecisionValue> = range.try_into().unwrap();
+        Self {
+            range: tsp_range.map_bounds(|tsp| tsp.to_i64()),
+        }
+    }
+
+    pub fn range(&self) -> IonSchemaRange<TimestampPrecisionValue> {
+        self.range.map_bounds(TimestampPrecisionValue::from_i64)
+    }
+}
+
+impl ConstraintName for TimestampPrecision {
+    const CONSTRAINT_NAME: &'static str = "timestamp_precision";
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    pub fn timestamp_precision<T: Into<IonSchemaRange<TimestampPrecisionValue>>>(
+        mut self,
+        range: T,
+    ) -> Self {
+        let constraint = TimestampPrecision::new(range);
+        self.constraints.push(constraint.into());
+        self
+    }
+}
+
+impl ValidateInternal for TimestampPrecision {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        let Some(timestamp) = value.as_timestamp() else {
+            return recorder.accept(ViolationInfo::new(
+                self.into(),
+                value.clone(),
+                format!(
+                    "{} is invalid for 'timestamp_precision'",
+                    value.ion_schema_type()
+                ),
+            ));
+        };
+        let precision = match timestamp.precision() {
+            TSPrecision::Year => Year.to_i64(),
+            TSPrecision::Month => Month.to_i64(),
+            TSPrecision::Day => Day.to_i64(),
+            TSPrecision::HourAndMinute => Minute.to_i64(),
+            TSPrecision::Second => {
+                if let Some(fractional_precision) = timestamp.fractional_seconds_scale() {
+                    fractional_precision
+                } else {
+                    Second.to_i64()
+                }
+            }
+        };
+        let range = self.range;
+        if !range.contains(&precision) {
+            return recorder.accept(ViolationInfo::new(
+                self.into(),
+                value.clone(),
+                format!("expected a timestamp precision of {range}; found {timestamp}",),
+            ));
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for TimestampPrecision {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        self.range
+            .map_bounds(TimestampPrecisionValue::from_i64)
+            .write_as_isl(writer, ctx)
+    }
+}
+
+impl<V: IslVersion> ReadFromIsl<V> for TimestampPrecision {
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        let range = IonSchemaRange::try_read(ion, ctx)?;
+        Ok(TimestampPrecision::new(range))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::internal_traits::*;
+    use crate::internal_traits::{LoaderContext, WriteContext};
+    use crate::model::constraints::TimestampPrecisionValue::*;
+    use crate::model::constraints::{AnyConstraint, TimestampPrecision};
+    use std::collections::Bound;
+
+    use crate::model::ranges::IonSchemaRange;
+    use crate::model::TypeDefinitionBuilder;
+    use crate::result::IonSchemaResult;
+    use crate::{ISL_1_0, ISL_2_0};
+    use ion_rs::v1_0::Text;
+    use ion_rs::{Element, SequenceWriter, Writer};
+    use rstest::rstest;
+
+    // Most of the range logic is covered in IonSchemaRange test cases.
+    // These primarily cover the things that are specific to timestamp precision.
+    // Validation will be covered by ion-schema-tests
+
+    #[test]
+    fn test_builder() -> IonSchemaResult<()> {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .timestamp_precision(Year..=Day)
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AnyConstraint::TimestampPrecision(TimestampPrecision::new(
+                IonSchemaRange::try_new(Bound::Included(Year), Bound::Included(Day))?
+            ))]
+        );
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::year("year", TimestampPrecision::new_unchecked(Year))]
+    #[case::year("month", TimestampPrecision::new_unchecked(Month))]
+    #[case::year("day", TimestampPrecision::new_unchecked(Day))]
+    #[case::year("minute", TimestampPrecision::new_unchecked(Minute))]
+    #[case::year("second", TimestampPrecision::new_unchecked(Second))]
+    #[case::year("millisecond", TimestampPrecision::new_unchecked(Millisecond))]
+    #[case::year("microsecond", TimestampPrecision::new_unchecked(Microsecond))]
+    #[case::year("nanosecond", TimestampPrecision::new_unchecked(Nanosecond))]
+    #[case::year("range::[min, minute]", TimestampPrecision::new_unchecked(..=Minute))]
+    #[case::year("range::[minute, max]", TimestampPrecision::new_unchecked(Minute..))]
+    fn timestamp_precision_write_as_isl(
+        #[case] expected_ion: &str,
+        #[case] constraint: TimestampPrecision,
+    ) {
+        let buffer = Vec::new();
+        let mut writer = Writer::new(Text, buffer).unwrap();
+        let ctx = WriteContext::<ISL_2_0>::new();
+
+        constraint
+            .write_as_isl(writer.value_writer(), &ctx)
+            .unwrap();
+        let output = writer.close().unwrap();
+
+        let actual_element = Element::read_one(output);
+        let expected_element = Element::read_one(expected_ion);
+
+        assert_eq!(expected_element, actual_element);
+    }
+
+    #[rstest]
+    #[case::year("year", TimestampPrecision::new_unchecked(Year))]
+    #[case::year("month", TimestampPrecision::new_unchecked(Month))]
+    #[case::year("day", TimestampPrecision::new_unchecked(Day))]
+    #[case::year("minute", TimestampPrecision::new_unchecked(Minute))]
+    #[case::year("second", TimestampPrecision::new_unchecked(Second))]
+    #[case::year("millisecond", TimestampPrecision::new_unchecked(Millisecond))]
+    #[case::year("microsecond", TimestampPrecision::new_unchecked(Microsecond))]
+    #[case::year("nanosecond", TimestampPrecision::new_unchecked(Nanosecond))]
+    #[case::year("range::[min, minute]", TimestampPrecision::new_unchecked(..=Minute))]
+    #[case::year("range::[minute, max]", TimestampPrecision::new_unchecked(Minute..))]
+    fn timestamp_precision_try_read_ok(#[case] ion: &str, #[case] expected: TimestampPrecision) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result = TimestampPrecision::try_read(&element, &load_ctx);
+        assert_eq!(result, Ok(expected))
+    }
+}

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -226,7 +226,6 @@ mod tests {
     use ion_rs::v1_0::Text;
     use ion_rs::{Element, SequenceWriter, Writer};
     use rstest::rstest;
-
     // Most of the range logic is covered in IonSchemaRange test cases.
     // These primarily cover the things that are specific to timestamp precision.
     // Validation will be covered by ion-schema-tests
@@ -287,10 +286,33 @@ mod tests {
     #[case::year("nanosecond", TimestampPrecision::new_unchecked(Nanosecond))]
     #[case::year("range::[min, minute]", TimestampPrecision::new_unchecked(..=Minute))]
     #[case::year("range::[minute, max]", TimestampPrecision::new_unchecked(Minute..))]
+    #[case::year("range::[year, exclusive::minute]", TimestampPrecision::new_unchecked(Year..Minute))]
     fn timestamp_precision_try_read_ok(#[case] ion: &str, #[case] expected: TimestampPrecision) {
         let element = Element::read_one(ion).unwrap();
         let load_ctx = LoaderContext::<ISL_2_0>::new();
         let result = TimestampPrecision::try_read(&element, &load_ctx);
         assert_eq!(result, Ok(expected))
+    }
+
+    #[rstest]
+    #[case::cannot_use_min_outside_of_range("min")]
+    #[case::cannot_use_max_outside_of_range("max")]
+    #[case::single_precision_cannot_be_an_integer("0")]
+    #[case::precision_range_cannot_have_an_integer("range::[0, max]")]
+    #[case::range_may_not_be_repeated("range::range::[day, day]")]
+    #[case::no_extraneous_annotations("range::foo::[day, minute]")]
+    #[case::range_must_be_a_list("range::(day minute)")]
+    #[case::singleton_values_may_not_be_annotated("range::day")]
+    #[case::min_cannot_be_exclusive("range::[exclusive::min, day]")]
+    #[case::max_cannot_be_exclusive("range::[day, exclusive::max]")]
+    #[case::lower_bound_cannot_be_max("range::[max, day]")]
+    #[case::upper_bound_cannot_be_min("range::[day, min]")]
+    #[case::range_cannot_be_unbounded_at_both_ends("range::[min, max]")]
+    fn timestamp_precision_try_read_err(#[case] ion: &str) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result: IonSchemaResult<TimestampPrecision> =
+            TimestampPrecision::try_read(&element, &load_ctx);
+        assert!(result.is_err())
     }
 }

--- a/ion-schema/src/model/constraints/utf8_byte_length.rs
+++ b/ion-schema/src/model/constraints/utf8_byte_length.rs
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{
+    LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::model::constraints::ConstraintName;
+use crate::model::ranges::IonSchemaRange;
+use crate::model::TypeDefinitionBuilder;
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder};
+use ion_rs::{Element, ValueWriter};
+use std::ops::ControlFlow;
+
+/// Represents the `utf8_byte_length` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#utf8_byte_length
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#utf8_byte_length
+#[derive(Debug, PartialEq, Clone)]
+pub struct Utf8ByteLength {
+    pub(crate) range: IonSchemaRange<usize>,
+}
+
+impl Utf8ByteLength {
+    pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {
+        Self {
+            range: range.into(),
+        }
+    }
+
+    pub fn range(&self) -> IonSchemaRange<usize> {
+        self.range
+    }
+}
+
+impl ConstraintName for Utf8ByteLength {
+    const CONSTRAINT_NAME: &'static str = "utf8_byte_length";
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    pub fn utf8_byte_length<T: Into<IonSchemaRange<usize>>>(mut self, range: T) -> Self {
+        let constraint = Utf8ByteLength::new(range.into());
+        self.constraints.push(constraint.into());
+        self
+    }
+}
+
+impl ValidateInternal for Utf8ByteLength {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        let Some(text) = value.as_text() else {
+            return recorder.accept(ViolationInfo::new(
+                self.into(),
+                value.clone(),
+                format!(
+                    "{} is invalid for 'utf8_byte_length'",
+                    value.ion_schema_type()
+                ),
+            ));
+        };
+        let length = text.len();
+        if !self.range.contains(&length) {
+            return recorder.accept(ViolationInfo::new(
+                self.into(),
+                value.clone(),
+                format!(
+                    "expected a UTF-8 encoded byte length of {}; found {length}",
+                    self.range
+                ),
+            ));
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for Utf8ByteLength {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        self.range.write_as_isl(writer, ctx)
+    }
+}
+
+impl<V: IslVersion> ReadFromIsl<V> for Utf8ByteLength {
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        let range = IonSchemaRange::try_read(ion, ctx)?;
+        Ok(Utf8ByteLength { range })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::constraints::{AnyConstraint, Utf8ByteLength};
+    use crate::model::ranges::IonSchemaRange;
+    use crate::model::TypeDefinitionBuilder;
+    use crate::result::IonSchemaResult;
+    use crate::ISL_1_0;
+    use std::ops::Bound;
+
+    // Testing Note:
+    //   - ReadFromIsl and WriteToIsl delegate any of the non-trivial logic to `IonSchemaRange`.
+    //   - ValidateInternal is tested by ion-schema-tests
+
+    #[test]
+    fn test_builder() -> IonSchemaResult<()> {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .utf8_byte_length(1..10)
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AnyConstraint::Utf8ByteLength(Utf8ByteLength::new(
+                IonSchemaRange::try_new(Bound::Included(1), Bound::Excluded(10))?
+            ))]
+        );
+        Ok(())
+    }
+}

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod constraints;
+mod ranges;
 mod type_argument;
 mod type_definition;
 mod type_reference;

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -7,4 +7,7 @@ mod type_argument;
 mod type_definition;
 mod type_reference;
 
+pub use ranges::*;
+pub use type_argument::*;
 pub use type_definition::*;
+pub use type_reference::*;

--- a/ion-schema/src/model/ranges.rs
+++ b/ion-schema/src/model/ranges.rs
@@ -1,0 +1,347 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl, WriteContext};
+use crate::ion_extension::ElementExtensions;
+use crate::result::{
+    invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
+};
+use crate::{isl_require, IslVersion};
+use ion_rs::{Annotatable, Element, SequenceWriter, ValueWriter, WriteAsIon};
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::{
+    Bound, Bound::*, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive,
+};
+
+trait RangeBoundRequirements
+where
+    Self: PartialOrd + Debug + WriteAsIon + Clone + Display,
+{
+}
+impl<T> RangeBoundRequirements for T where T: PartialOrd + Debug + WriteAsIon + Clone + Display {}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct IonSchemaRange<T: RangeBoundRequirements> {
+    min: Bound<T>,
+    max: Bound<T>,
+}
+
+impl<T: RangeBoundRequirements> IonSchemaRange<T> {
+    pub fn try_new(min: Bound<T>, max: Bound<T>) -> Result<Self, IonSchemaError> {
+        match (&min, &max) {
+            (Unbounded, Unbounded) => Err(()),
+            (Excluded(x), Included(y)) if x >= y => Err(()),
+            (Included(x), Excluded(y)) if x >= y => Err(()),
+            (Excluded(x), Excluded(y)) if x >= y => Err(()),
+            (Included(x), Included(y)) if x > y => Err(()),
+            _ => Ok(()),
+        }
+        .map_err(|_| invalid_schema_error_raw(format!("Invalid range: {min:?} to {max:?}")))
+        .map(|_| IonSchemaRange { min, max })
+    }
+
+    // For testing only.
+    fn new_unchecked(min: Bound<T>, max: Bound<T>) -> Self {
+        Self::try_new(min, max).unwrap()
+    }
+
+    pub fn min(&self) -> &Bound<T> {
+        &self.min
+    }
+
+    pub fn max(&self) -> &Bound<T> {
+        &self.max
+    }
+}
+
+impl<T: RangeBoundRequirements> IonSchemaRange<T> {
+    pub(crate) fn map_bounds<F: Fn(T) -> U, U: RangeBoundRequirements>(
+        self,
+        transform: F,
+    ) -> IonSchemaRange<U> {
+        let IonSchemaRange { min, max } = self;
+        IonSchemaRange {
+            min: min.map(&transform),
+            max: max.map(&transform),
+        }
+    }
+}
+
+impl<T: RangeBoundRequirements> IonSchemaRange<T> {
+    pub fn contains(&self, value: &T) -> bool {
+        let is_above_min = match &self.min {
+            Unbounded => true,
+            Excluded(min) => value > min,
+            Included(min) => value >= min,
+        };
+        let is_below_max = match &self.max {
+            Unbounded => true,
+            Excluded(max) => value < max,
+            Included(max) => value <= max,
+        };
+        is_above_min && is_below_max
+    }
+}
+
+impl<T: RangeBoundRequirements> Display for IonSchemaRange<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        format_range(&self.min, &self.max, f)
+    }
+}
+
+fn format_range<T: PartialEq + Display>(
+    min: &Bound<T>,
+    max: &Bound<T>,
+    f: &mut Formatter<'_>,
+) -> std::fmt::Result {
+    if min == max {
+        if let Included(value) = min {
+            return value.fmt(f);
+        }
+    }
+    f.write_str("range::[")?;
+    format_bound(min, "min", f)?;
+    f.write_str(",")?;
+    format_bound(max, "max", f)?;
+    f.write_str("]")
+}
+
+fn format_bound<T: Display>(
+    b: &Bound<T>,
+    unbounded_token: &str,
+    f: &mut Formatter<'_>,
+) -> std::fmt::Result {
+    match b {
+        Unbounded => f.write_str(unbounded_token),
+        Included(x) => x.fmt(f),
+        Excluded(x) => f.write_fmt(format_args!("exclusive::{}", x)),
+    }
+}
+
+impl<V: IslVersion, T: RangeBoundRequirements> WriteAsIsl<V> for IonSchemaRange<T> {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        if self.min == self.max {
+            if let Included(value) = &self.min {
+                writer.write(value)?;
+            }
+        } else {
+            let mut list_writer = writer.with_annotations(["range"])?.list_writer()?;
+            match &self.min {
+                Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
+                Included(x) => list_writer.write(x)?,
+                Unbounded => list_writer.write_symbol("min")?,
+            };
+            match &self.max {
+                Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
+                Included(x) => list_writer.write(x)?,
+                Unbounded => list_writer.write_symbol("max")?,
+            };
+            list_writer.close()?;
+        }
+        Ok(())
+    }
+}
+
+const MIN: &str = "min";
+const MAX: &str = "max";
+const EXCLUSIVE: &str = "exclusive";
+const RANGE: &str = "range";
+
+impl<V: IslVersion, T: RangeBoundRequirements + ReadFromIsl<V>> ReadFromIsl<V>
+    for IonSchemaRange<T>
+{
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        let optional_annotation = ion.one_optional_annotation()?;
+        if optional_annotation == Some(RANGE) {
+            let Some(seq) = ion.as_list() else {
+                invalid_schema_error(format!("range must be a non-null list; found: {ion}"))?
+            };
+
+            isl_require!(seq.len() == 2 => "range must have a lower and upper bound; found: {ion}")?;
+            // We can unwrap these without panicking
+            let lower = seq.get(0).unwrap();
+            let upper = seq.get(1).unwrap();
+
+            let lower = match (lower.as_symbol_text(), lower.one_optional_annotation()?) {
+                (Some(MIN), Some(EXCLUSIVE)) => invalid_schema_error("'min' may not be exclusive")?,
+                (Some(MIN), None) => Unbounded,
+                (_, Some(EXCLUSIVE)) => Excluded(T::try_read(lower, ctx)?),
+                (_, None) => Included(T::try_read(lower, ctx)?),
+                _ => invalid_schema_error(format!("invalid annotation on range bound: {lower}"))?,
+            };
+            let upper = match (upper.as_symbol_text(), upper.one_optional_annotation()?) {
+                (Some(MAX), Some(EXCLUSIVE)) => invalid_schema_error("'max' may not be exclusive")?,
+                (Some(MAX), None) => Unbounded,
+                (_, Some(EXCLUSIVE)) => Excluded(T::try_read(upper, ctx)?),
+                (_, None) => Included(T::try_read(upper, ctx)?),
+                _ => invalid_schema_error(format!("invalid annotation on range bound: {upper}"))?,
+            };
+
+            Ok(IonSchemaRange::try_new(lower, upper)?)
+        } else {
+            isl_require!(optional_annotation.is_none() => "invalid annotation on range; found: {ion}")?;
+            let value: T = T::try_read(ion, ctx)
+                .map_err(|_| invalid_schema_error_raw(format!("invalid range value: {ion}")))?;
+            Ok(IonSchemaRange::from(value))
+        }
+    }
+}
+
+impl<T: RangeBoundRequirements> From<&T> for IonSchemaRange<T> {
+    fn from(value: &T) -> Self {
+        IonSchemaRange {
+            min: Included(value.clone()),
+            max: Included(value.clone()),
+        }
+    }
+}
+impl<T: RangeBoundRequirements> From<T> for IonSchemaRange<T> {
+    fn from(value: T) -> Self {
+        IonSchemaRange {
+            min: Included(value.clone()),
+            max: Included(value),
+        }
+    }
+}
+
+// Technically, the implementations this produces can construct empty ranges, which are not valid in
+// Ion Schema Language. This only affects programmatically constructed types. If we want to
+// completely prohibit empty ranges, it makes the programmatic builder a lot less ergonomic—e.g.:
+// ```
+// my_builder.timestamp_precision(Year..=Day)
+// my_builder.timestamp_precision((Year..=Day).try_into()?)
+// ```
+macro_rules! from_range {
+    ($range_type:ident) => {
+        impl<T: RangeBoundRequirements> From<$range_type<T>> for IonSchemaRange<T> {
+            fn from(value: $range_type<T>) -> Self {
+                let min = value.start_bound().cloned();
+                let max = value.end_bound().cloned();
+                IonSchemaRange { min, max }
+            }
+        }
+    };
+}
+from_range!(Range);
+from_range!(RangeTo);
+from_range!(RangeFrom);
+from_range!(RangeInclusive);
+from_range!(RangeToInclusive);
+
+#[cfg(test)]
+mod tests {
+    use crate::internal_traits::*;
+    use crate::model::ranges::IonSchemaRange;
+    use crate::result::IonSchemaResult;
+    use crate::ISL_2_0;
+    use ion_rs::v1_0::Text;
+    use ion_rs::{Element, SequenceWriter, Writer};
+    use rstest::rstest;
+    use std::ops::Bound;
+    use std::ops::Bound::*;
+
+    #[test]
+    fn from_range() {
+        let expected = IonSchemaRange::try_new(Included(1), Excluded(3)).unwrap();
+        let range = 1..3;
+        assert_eq!(expected, range.into())
+    }
+
+    #[test]
+    fn from_range_from() {
+        let expected = IonSchemaRange::try_new(Included(1), Unbounded).unwrap();
+        let range = 1..;
+        assert_eq!(expected, range.into())
+    }
+
+    #[test]
+    fn from_range_to() {
+        let expected = IonSchemaRange::try_new(Unbounded, Excluded(3)).unwrap();
+        let range = ..3;
+        assert_eq!(expected, range.into())
+    }
+
+    #[test]
+    fn from_range_inclusive() {
+        let expected = IonSchemaRange::try_new(Included(1), Included(3)).unwrap();
+        let range = 1..=3;
+        assert_eq!(expected, range.into())
+    }
+
+    #[test]
+    fn from_range_to_inclusive() {
+        let expected = IonSchemaRange::try_new(Unbounded, Included(3)).unwrap();
+        let range = ..=3;
+        assert_eq!(expected, range.into())
+    }
+
+    #[rstest]
+    #[case::simple("range::[1, 2]", Included(1), Included(2))]
+    #[case::exclusive_lower_bound("range::[exclusive::1, 2]", Excluded(1), Included(2))]
+    #[case::exclusive_upper_bound("range::[1, exclusive::2]", Included(1), Excluded(2))]
+    #[case::min_lower_bound("range::[min, 2]", Unbounded, Included(2))]
+    #[case::max_upper_bound("range::[1, max]", Included(1), Unbounded)]
+    #[case::singleton("1", Included(1), Included(1))]
+    fn range_write_as_isl(
+        #[case] expected_ion: &str,
+        #[case] min: Bound<isize>,
+        #[case] max: Bound<isize>,
+    ) {
+        let buffer = Vec::new();
+        let mut writer = Writer::new(Text, buffer).unwrap();
+        let ctx = WriteContext::<ISL_2_0>::new();
+
+        let range = IonSchemaRange::try_new(min, max).unwrap();
+        range.write_as_isl(writer.value_writer(), &ctx).unwrap();
+        let output = writer.close().unwrap();
+
+        let actual_element = Element::read_one(output);
+        let expected_element = Element::read_one(expected_ion);
+
+        assert_eq!(expected_element, actual_element);
+    }
+
+    #[rstest]
+    #[case::simple("range::[1, 2]", Included(1), Included(2))]
+    #[case::exclusive_lower_bound("range::[exclusive::1, 2]", Excluded(1), Included(2))]
+    #[case::exclusive_upper_bound("range::[1, exclusive::2]", Included(1), Excluded(2))]
+    #[case::min_lower_bound("range::[min, 2]", Unbounded, Included(2))]
+    #[case::max_upper_bound("range::[1, max]", Included(1), Unbounded)]
+    #[case::singleton("1", Included(1), Included(1))]
+    #[case::singleton_range("range::[1, 1]", Included(1), Included(1))]
+    fn range_try_read_ok(
+        #[case] ion: &str,
+        #[case] expected_min: Bound<usize>,
+        #[case] expected_max: Bound<usize>,
+    ) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result = IonSchemaRange::try_read(&element, &load_ctx);
+        assert_eq!(result, IonSchemaRange::try_new(expected_min, expected_max))
+    }
+
+    #[rstest]
+    #[case::range_must_have_a_range_annotation("[1, 2]")]
+    #[case::range_may_not_be_repeated("range::range::[1, 2]")]
+    #[case::no_extraneous_annotations("range::foo::[1, 2]")]
+    #[case::range_must_be_a_list("range::(1 2)")]
+    #[case::range_must_be_a_list("range::1")]
+    #[case::singleton_values_may_not_be_annotated("foo::1")]
+    #[case::min_cannot_be_exclusive("range::[exclusive::min, 2]")]
+    #[case::max_cannot_be_exclusive("range::[1, exclusive::max]")]
+    #[case::lower_bound_cannot_be_max("range::[max, 1]")]
+    #[case::upper_bound_cannot_be_min("range::[1, min]")]
+    #[case::min_cannot_be_greater_than_max("range::[2, 1]")]
+    #[case::range_cannot_be_unbounded_at_both_ends("range::[min, max]")]
+    fn range_try_read_err(#[case] ion: &str) {
+        let element = Element::read_one(ion).unwrap();
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result: IonSchemaResult<IonSchemaRange<usize>> =
+            IonSchemaRange::try_read(&element, &load_ctx);
+        assert!(result.is_err())
+    }
+}

--- a/ion-schema/src/model/ranges.rs
+++ b/ion-schema/src/model/ranges.rs
@@ -7,27 +7,36 @@ use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
 use crate::{isl_require, IslVersion};
-use ion_rs::{Annotatable, Element, SequenceWriter, ValueWriter, WriteAsIon};
+use hidden::RangeBoundType;
+use ion_rs::{Annotatable, Element, SequenceWriter, ValueWriter};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{
     Bound, Bound::*, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-trait RangeBoundRequirements
-where
-    Self: PartialOrd + Debug + WriteAsIon + Clone + Display,
-{
+/// RangeBoundType is a marker trait that can only be implemented in this crate.
+mod hidden {
+    use ion_rs::WriteAsIon;
+    use std::fmt::{Debug, Display};
+
+    pub trait RangeBoundType
+    where
+        Self: PartialOrd + Debug + WriteAsIon + Clone + Display,
+    {
+    }
+    impl<T> RangeBoundType for T where T: PartialOrd + Debug + WriteAsIon + Clone + Display {}
 }
-impl<T> RangeBoundRequirements for T where T: PartialOrd + Debug + WriteAsIon + Clone + Display {}
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct IonSchemaRange<T: RangeBoundRequirements> {
+pub struct IonSchemaRange<T> {
     min: Bound<T>,
     max: Bound<T>,
 }
 
-impl<T: RangeBoundRequirements> IonSchemaRange<T> {
-    pub fn try_new(min: Bound<T>, max: Bound<T>) -> Result<Self, IonSchemaError> {
+impl<T: RangeBoundType> IonSchemaRange<T> {
+    // See https://github.com/amazon-ion/ion-schema/issues/140, which should be resolved before we
+    // make this public.
+    pub(crate) fn try_new(min: Bound<T>, max: Bound<T>) -> Result<Self, IonSchemaError> {
         match (&min, &max) {
             (Unbounded, Unbounded) => Err(()),
             (Excluded(x), Included(y)) if x >= y => Err(()),
@@ -52,22 +61,7 @@ impl<T: RangeBoundRequirements> IonSchemaRange<T> {
     pub fn max(&self) -> &Bound<T> {
         &self.max
     }
-}
 
-impl<T: RangeBoundRequirements> IonSchemaRange<T> {
-    pub(crate) fn map_bounds<F: Fn(T) -> U, U: RangeBoundRequirements>(
-        self,
-        transform: F,
-    ) -> IonSchemaRange<U> {
-        let IonSchemaRange { min, max } = self;
-        IonSchemaRange {
-            min: min.map(&transform),
-            max: max.map(&transform),
-        }
-    }
-}
-
-impl<T: RangeBoundRequirements> IonSchemaRange<T> {
     pub fn contains(&self, value: &T) -> bool {
         let is_above_min = match &self.min {
             Unbounded => true,
@@ -81,9 +75,20 @@ impl<T: RangeBoundRequirements> IonSchemaRange<T> {
         };
         is_above_min && is_below_max
     }
+
+    pub(crate) fn map_bounds<F: Fn(T) -> U, U: RangeBoundType>(
+        self,
+        transform: F,
+    ) -> IonSchemaRange<U> {
+        let IonSchemaRange { min, max } = self;
+        IonSchemaRange {
+            min: min.map(&transform),
+            max: max.map(&transform),
+        }
+    }
 }
 
-impl<T: RangeBoundRequirements> Display for IonSchemaRange<T> {
+impl<T: RangeBoundType> Display for IonSchemaRange<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         format_range(&self.min, &self.max, f)
     }
@@ -118,7 +123,7 @@ fn format_bound<T: Display>(
     }
 }
 
-impl<V: IslVersion, T: RangeBoundRequirements> WriteAsIsl<V> for IonSchemaRange<T> {
+impl<V: IslVersion, T: RangeBoundType> WriteAsIsl<V> for IonSchemaRange<T> {
     fn write_as_isl<W: ValueWriter>(
         &self,
         writer: W,
@@ -151,9 +156,7 @@ const MAX: &str = "max";
 const EXCLUSIVE: &str = "exclusive";
 const RANGE: &str = "range";
 
-impl<V: IslVersion, T: RangeBoundRequirements + ReadFromIsl<V>> ReadFromIsl<V>
-    for IonSchemaRange<T>
-{
+impl<V: IslVersion, T: RangeBoundType + ReadFromIsl<V>> ReadFromIsl<V> for IonSchemaRange<T> {
     fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
         let optional_annotation = ion.one_optional_annotation()?;
         if optional_annotation == Some(RANGE) {
@@ -191,7 +194,7 @@ impl<V: IslVersion, T: RangeBoundRequirements + ReadFromIsl<V>> ReadFromIsl<V>
     }
 }
 
-impl<T: RangeBoundRequirements> From<&T> for IonSchemaRange<T> {
+impl<T: RangeBoundType> From<&T> for IonSchemaRange<T> {
     fn from(value: &T) -> Self {
         IonSchemaRange {
             min: Included(value.clone()),
@@ -199,7 +202,7 @@ impl<T: RangeBoundRequirements> From<&T> for IonSchemaRange<T> {
         }
     }
 }
-impl<T: RangeBoundRequirements> From<T> for IonSchemaRange<T> {
+impl<T: RangeBoundType> From<T> for IonSchemaRange<T> {
     fn from(value: T) -> Self {
         IonSchemaRange {
             min: Included(value.clone()),
@@ -208,16 +211,11 @@ impl<T: RangeBoundRequirements> From<T> for IonSchemaRange<T> {
     }
 }
 
-// Technically, the implementations this produces can construct empty ranges, which are not valid in
-// Ion Schema Language. This only affects programmatically constructed types. If we want to
-// completely prohibit empty ranges, it makes the programmatic builder a lot less ergonomic—e.g.:
-// ```
-// my_builder.timestamp_precision(Year..=Day)
-// my_builder.timestamp_precision((Year..=Day).try_into()?)
-// ```
+// TODO: Once https://github.com/amazon-ion/ion-schema/issues/140 is resolved, revisit this and
+//       possibly replace with a `TryFrom` implementation.
 macro_rules! from_range {
     ($range_type:ident) => {
-        impl<T: RangeBoundRequirements> From<$range_type<T>> for IonSchemaRange<T> {
+        impl<T: RangeBoundType> From<$range_type<T>> for IonSchemaRange<T> {
             fn from(value: $range_type<T>) -> Self {
                 let min = value.start_bound().cloned();
                 let max = value.end_bound().cloned();

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -173,7 +173,7 @@ impl PendingTypes {
         import_type_name: &str,
         type_store: &mut TypeStore,
     ) -> Option<IonSchemaResult<TypeDefinitionImpl>> {
-        return match self.ids_by_name.get(import_type_name) {
+        match self.ids_by_name.get(import_type_name) {
             Some(id) => self.types_by_id[*id]
                 .to_owned()
                 .map(|type_def| match type_def {
@@ -211,7 +211,7 @@ impl PendingTypes {
                     None => None,
                 }
             }
-        };
+        }
     }
 
     // helper method to update type store with all the types from this PendingTypes


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* Consolidates the `any_of_these` and `any_of_these_refs` macros (used for `AnyConstraint`) into one macro so that we only need one list of the constraints.
* Adds `ReadFromIsl` for `i64` and `usize` to support range types
* Adds `IonSchemaRange` that is somewhat compatible with the range types in the Rust standard library.
  * In order to avoid some ugly APIs, I've make the `IonSchemaRange` implement `From` instead of `TryFrom`. That means it's possible to programmatically construct an empty range (which is not valid ISL). However, parsing ISL files will still correctly raise an error for empty ranges. I'm willing to revisit that decision.
* Adds `TimestampPrecision` and `Utf8ByteLength` constraints.
* Adds some more extension functions for `Element`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
