### PR TITLE
Adds ValidValues constraint

### DIFF
--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.10"}
+ion-rs = { git = "https://github.com/amazon-ion/ion-rust.git", branch = "main", features = ["experimental-reader-writer"] }
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental-reader-writer"] }
+# TODO: Ensure `ion-rust` has released all changes and then switch this back to the latest published version on
+#       crates.io before merging this to `main`.
+ion-rs = { git = "https://github.com/amazon-ion/ion-rust.git", branch = "main", features = ["experimental-reader-writer"] }
 thiserror = "1.0"
 num-traits = "0.2"
 regex = "1.5.6"
@@ -32,3 +34,4 @@ half = "2.2.1"
 rstest = "0.9"
 clap = { version = "2.33.3", features = ["yaml"] }
 test-generator = "0.3.0"
+paste = "1.0.15"

--- a/ion-schema/src/internal_traits.rs
+++ b/ion-schema/src/internal_traits.rs
@@ -79,13 +79,18 @@ pub(crate) trait WriteAsIsl<V: IslVersion>: Debug {
 /// In the future, it may include things such as:
 ///  - options to allow lossy conversion between ISL versions
 ///  - stylistic choices for writing as Ion
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct WriteContext<V> {
     version: PhantomData<V>,
+    /// Indicates whether ranges may be "minimized" into single values.
+    /// E.g.: writing `range::[1, 1]` as `1`.
+    pub(crate) minimize_ranges: bool,
 }
 impl<V: IslVersion> WriteContext<V> {
     pub fn new() -> Self {
         WriteContext {
             version: PhantomData::<V>,
+            minimize_ranges: true,
         }
     }
 }
@@ -107,6 +112,8 @@ macro_rules! read_from_isl {
 }
 read_from_isl!(usize, expect_usize);
 read_from_isl!(i64, expect_i64);
+read_from_isl!(ion_rs::Decimal, expect_decimal);
+read_from_isl!(ion_rs::Timestamp, expect_timestamp);
 
 // TODO: fields/functions to support
 //    * looking up types/schemas that are already loaded

--- a/ion-schema/src/ion_schema_version.rs
+++ b/ion-schema/src/ion_schema_version.rs
@@ -8,11 +8,12 @@ mod private {
 }
 
 /// Trait for ISL version marker types.
-pub trait IslVersion: private::IslVersion {
+pub trait IslVersion: private::IslVersion + Clone {
     const MAJOR_MINOR: (u8, u8);
 }
 
 /// Ion Schema Language 1.0
+#[derive(Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum ISL_1_0 {}
 
@@ -23,6 +24,7 @@ impl IslVersion for ISL_1_0 {
 }
 
 /// Ion Schema Language 2.0
+#[derive(Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum ISL_2_0 {}
 

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -43,6 +43,9 @@ mod violation_recorder;
 
 pub mod model;
 
+#[cfg(test)]
+mod test_harness;
+
 pub use ion_schema_element::*;
 pub use ion_schema_version::*;
 pub use violation_recorder::*;

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::internal_traits::{ValidateInternal, ValidationContext, WriteAsIsl, WriteContext};
+use crate::model::constraints::valid_values::ValidValues;
 use crate::model::constraints::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
@@ -100,5 +101,5 @@ any_constraint!(
     TimestampPrecision,
     TypeConstraint,
     Utf8ByteLength,
-    // ValidValues,
+    ValidValues,
 );

--- a/ion-schema/src/model/constraints/mod.rs
+++ b/ion-schema/src/model/constraints/mod.rs
@@ -6,12 +6,14 @@ mod any_constraint;
 mod timestamp_precision;
 mod type_constraint;
 mod utf8_byte_length;
+mod valid_values;
 
 pub use annotations_v2_simple::*;
 pub use any_constraint::*;
 pub use timestamp_precision::*;
 pub use type_constraint::*;
 pub use utf8_byte_length::*;
+pub use valid_values::*;
 
 /// Provides the constraint's name (ISL keyword) for a given constraint implementation.
 pub(crate) trait ConstraintName {

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -185,7 +185,7 @@ impl ValidateInternal for TimestampPrecision {
             return recorder.accept(ViolationInfo::new(
                 self.into(),
                 value.clone(),
-                format!("expected a timestamp precision of {range}; found {timestamp}",),
+                format!("expected a timestamp precision of {range:?}; found {timestamp:?}",),
             ));
         }
         ControlFlow::Continue(())

--- a/ion-schema/src/model/constraints/utf8_byte_length.rs
+++ b/ion-schema/src/model/constraints/utf8_byte_length.rs
@@ -71,7 +71,7 @@ impl ValidateInternal for Utf8ByteLength {
                 self.into(),
                 value.clone(),
                 format!(
-                    "expected a UTF-8 encoded byte length of {}; found {length}",
+                    "expected a UTF-8 encoded byte length of {:?}; found {length}",
                     self.range
                 ),
             ));
@@ -112,6 +112,16 @@ mod tests {
 
     #[test]
     fn test_builder() -> IonSchemaResult<()> {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .utf8_byte_length(5)
+            .build();
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AnyConstraint::Utf8ByteLength(Utf8ByteLength::new(
+                IonSchemaRange::try_new(Bound::Included(5), Bound::Included(5))?
+            ))]
+        );
+
         let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
             .utf8_byte_length(1..10)
             .build();

--- a/ion-schema/src/model/constraints/valid_values.rs
+++ b/ion-schema/src/model/constraints/valid_values.rs
@@ -1,0 +1,363 @@
+use crate::internal_traits::{
+    LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::ion_extension::ElementExtensions;
+use crate::model::constraints::ConstraintName;
+use crate::model::ranges::IonSchemaRange;
+use crate::model::TypeDefinitionBuilder;
+use crate::result::{invalid_schema_error, IonSchemaResult};
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
+use ion_rs::{Decimal, Element, SequenceWriter, Timestamp, ValueWriter};
+use ion_rs::{Value as IonValue, Value};
+use std::fmt::Debug;
+use std::ops::{ControlFlow, RangeBounds};
+
+impl ConstraintName for ValidValues {
+    const CONSTRAINT_NAME: &'static str = "valid_values";
+}
+
+/// The `valid_values` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#valid_values
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#valid_values
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValidValues {
+    // TODO: Use a Set once Timestamp and Decimal implement Hash
+    values: Vec<ValidValuesArgument>,
+}
+
+impl ValidValues {
+    pub fn values(&self) -> impl Iterator<Item = &ValidValuesArgument> {
+        self.values.iter()
+    }
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    /// Adds a `valid_values` constraint to this type definition.
+    pub fn valid_values<T: Into<ValidValuesArgument>, I: IntoIterator<Item = T>>(
+        mut self,
+        values: I,
+    ) -> Self {
+        let values = values.into_iter().map(|it| it.into()).collect();
+        let constraint = ValidValues { values };
+        self.constraints.push(constraint.into());
+        self
+    }
+
+    /// Adds a `valid_values` constraint with a single range argument to this type definition.
+    pub fn valid_number_range<
+        T: Into<Decimal> + Clone,
+        R: RangeBounds<T> + Into<IonSchemaRange<T>>,
+    >(
+        self,
+        range: R,
+    ) -> Self {
+        let isl_range = range.into();
+        let arg = ValidValuesArgument::NumericRange(isl_range.map_bounds(T::into));
+        self.valid_values([arg])
+    }
+}
+
+impl ValidateInternal for ValidValues {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &'top IonSchemaElement,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        todo!()
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for ValidValues {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        // Decimal Ranges cannot be collapsed to a single value because they are used in
+        // ValidValues, where `1.` requires an exact match, whereas `range::[1., 1.]`
+        // allows any numeric value that would be placed at 1 on a number line. Timestamp ranges
+        // cannot be collapsed for the same reason.
+        // Hence, we create a copy of the context for passing to the write implementation for ranges.
+        let mut ctx = WriteContext::clone(ctx);
+        ctx.minimize_ranges = false;
+
+        // If it's just a single range, skip the containing list.
+        if self.values.len() == 1 {
+            let the_value = self.values.first().unwrap();
+            match the_value {
+                ValidValuesArgument::TimestampRange(range) => {
+                    range.write_as_isl(writer, &ctx)?;
+                    return Ok(());
+                }
+                ValidValuesArgument::NumericRange(range) => {
+                    range.write_as_isl(writer, &ctx)?;
+                    return Ok(());
+                }
+                ValidValuesArgument::Value(_) => {}
+            }
+        }
+
+        let mut list = writer.list_writer()?;
+        for v in self.values() {
+            v.write_as_isl(list.value_writer(), &ctx)?;
+        }
+        list.close()?;
+        Ok(())
+    }
+}
+
+impl<V: IslVersion> ReadFromIsl<V> for ValidValues {
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        // It can be a single range, or a list of arguments. Either way, it must be a list.
+        // First, we'll try reading it as a range.
+        let values = if (ion.one_optional_annotation()?).is_some() {
+            vec![read_one_range(ion, ctx)?]
+        } else {
+            let c: IonSchemaResult<_> = ion
+                .expect_list()?
+                .elements()
+                .map(|ion| read_one_argument(ion, ctx))
+                .collect();
+            c?
+        };
+        Ok(ValidValues { values })
+    }
+}
+
+fn read_one_argument<V: IslVersion>(
+    ion: &Element,
+    ctx: &LoaderContext<V>,
+) -> IonSchemaResult<ValidValuesArgument> {
+    if (ion.one_optional_annotation()?).is_some() {
+        read_one_range(ion, ctx)
+    } else {
+        Ok(ValidValuesArgument::Value(ion.value().clone()))
+    }
+}
+
+fn read_one_range<V: IslVersion>(
+    ion: &Element,
+    ctx: &LoaderContext<V>,
+) -> IonSchemaResult<ValidValuesArgument> {
+    let range = if let Ok(range) = IonSchemaRange::try_read(ion, ctx) {
+        ValidValuesArgument::TimestampRange(range)
+    } else {
+        let range = IonSchemaRange::try_read(ion, ctx)?.map_bounds(|NumberRangeValue(dec)| dec);
+        ValidValuesArgument::NumericRange(range)
+    };
+    Ok(range)
+}
+
+// ValidValuesArgument
+
+/// An argument for the [`ValidValues`] constraint.
+///
+/// This implementation does not preserve the original encoding of number ranges. They are always
+/// converted to decimal ranges even if the source ISL uses float or integer values.
+#[derive(Debug, PartialEq, Clone)]
+pub enum ValidValuesArgument {
+    Value(IonValue),
+    TimestampRange(IonSchemaRange<Timestamp>),
+    NumericRange(IonSchemaRange<Decimal>),
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for ValidValuesArgument {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        use ValidValuesArgument::*;
+        match self {
+            Value(v) => writer.write(v)?,
+            TimestampRange(range) => range.write_as_isl(writer, ctx)?,
+            NumericRange(range) => range.write_as_isl(writer, ctx)?,
+        };
+        Ok(())
+    }
+}
+
+impl<T: Into<IonValue>> From<T> for ValidValuesArgument {
+    fn from(value: T) -> Self {
+        ValidValuesArgument::Value(value.into())
+    }
+}
+impl From<IonSchemaRange<Decimal>> for ValidValuesArgument {
+    fn from(value: IonSchemaRange<Decimal>) -> Self {
+        ValidValuesArgument::NumericRange(value)
+    }
+}
+impl From<IonSchemaRange<Timestamp>> for ValidValuesArgument {
+    fn from(value: IonSchemaRange<Timestamp>) -> Self {
+        ValidValuesArgument::TimestampRange(value)
+    }
+}
+
+/// Helper type to allow reading any type of numeric value for valid values number ranges.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+struct NumberRangeValue(Decimal);
+
+impl<V: IslVersion> ReadFromIsl<V> for NumberRangeValue {
+    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+        let value = match ion.value() {
+            Value::Int(i) => NumberRangeValue(Decimal::from(*i)),
+            Value::Float(f) if f.is_finite() => NumberRangeValue(Decimal::try_from(*f)?),
+            Value::Decimal(d) => NumberRangeValue(*d),
+            other => invalid_schema_error(format!("Not a valid number range boundary: {other}"))?,
+        };
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::model::constraints::valid_values::ValidValues;
+    use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+    use crate::test_harness::*;
+    use crate::{ISL_1_0, ISL_2_0};
+    use ion_rs::{Decimal, IonType, Value};
+
+    #[test]
+    fn test_builder_valid_values() {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .valid_values([Value::Float(1.0), Value::String("foo".into())])
+            .build();
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![ValidValues {
+                values: vec![Value::Float(1.0).into(), Value::String("foo".into()).into(),]
+            }
+            .into()]
+        );
+
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .valid_values(["foo", "bar"])
+            .build();
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![ValidValues {
+                values: vec![
+                    Value::String("foo".into()).into(),
+                    Value::String("bar".into()).into(),
+                ]
+            }
+            .into()]
+        );
+    }
+
+    #[test]
+    fn test_builder_valid_number_range() {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .valid_number_range(1..=10)
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![ValidValues {
+                values: vec![IonSchemaRange::from(Decimal::from(1)..=Decimal::from(10)).into()]
+            }
+            .into()]
+        );
+    }
+
+    test_harness!(write_as_isl:
+        ISL_1_0, ISL_2_0 {
+            #[case::empty(
+                Ok("[]"),
+                ValidValues { values: vec![] }
+            )]
+            #[case::single_int_value(
+                Ok("[1]"),
+                ValidValues { values: vec![ValidValuesArgument::from(1)] }
+            )]
+            #[case::single_string_value(
+                Ok("[\"abc\"]"),
+                ValidValues { values: vec![ValidValuesArgument::from("abc")] }
+            )]
+            #[case::multiple_values(
+                Ok("[\"abc\", 1, null]"),
+                ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }
+            )]
+            #[case::multiple_values_with_range(
+                Ok("[\"abc\", 1, range::[1., 2.]]"),
+                ValidValues { values: vec![
+                    ValidValuesArgument::from("abc"),
+                    ValidValuesArgument::from(1),
+                    ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())
+                ]}
+            )]
+            #[case::single_number_range_should_not_be_in_a_list(
+                Ok("range::[1., 2.]"),
+                ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }
+            )]
+            #[case::single_timestamp_range_should_not_be_in_a_list(
+                Ok("range::[2024T, 2025T]"),
+                ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
+            )]
+            #[case::singleton_number_range_should_not_be_minimized(
+                Ok("range::[1., 1.]"),
+                ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(1)).into())] }
+            )]
+            #[case::singleton_timestamp_range_should_not_be_minimized(
+                Ok("range::[2025T, 2025T]"),
+                ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2025).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
+            )]
+        }
+    );
+
+    test_harness!(
+        read_from_isl:
+        ISL_1_0, ISL_2_0 {
+            #[case::empty("[]", Ok(ValidValues { values: vec![] }))]
+            #[case::empty_list_annotated_with_range("range::[]", err::<ValidValues>())]
+            #[case::annotated_value_in_list("[foo::1]", err::<ValidValues>())]
+            #[case::single_int_value(
+                "[1]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::from(1)] })
+            )]
+            #[case::single_string_value(
+                "[\"abc\"]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::from("abc")] })
+            )]
+            #[case::multiple_values(
+                "[\"abc\", 1, null]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] })
+            )]
+            #[case::multiple_values_with_range(
+                "[\"abc\", 1, range::[1., 2.]]",
+                Ok(ValidValues { values: vec![
+                    ValidValuesArgument::from("abc"),
+                    ValidValuesArgument::from(1),
+                    ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())
+                ]})
+            )]
+            #[case::single_number_range_in_a_list(
+                "[range::[1., 2.]]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+            )]
+            #[case::single_number_range_not_in_a_list(
+                "range::[1., 2.]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+            )]
+            #[case::single_number_range_with_ints(
+                "range::[1, 2]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+            )]
+            #[case::single_number_range_with_floats(
+                "range::[1e0, 2e0]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+            )]
+            #[case::single_timestamp_range(
+                "range::[2024T, 2025T]",
+                Ok(ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] })
+            )]
+        }
+    );
+}

--- a/ion-schema/src/model/constraints/valid_values.rs
+++ b/ion-schema/src/model/constraints/valid_values.rs
@@ -267,7 +267,8 @@ mod tests {
         );
     }
 
-    test_harness!(write_as_isl:
+    test_harness!(
+        use write_as_isl;
         ISL_1_0, ISL_2_0 {
             #[case::empty(
                 Ok("[]"),
@@ -313,7 +314,7 @@ mod tests {
     );
 
     test_harness!(
-        read_from_isl:
+        use read_from_isl;
         ISL_1_0, ISL_2_0 {
             #[case::empty("[]", Ok(ValidValues { values: vec![] }))]
             #[case::empty_list_annotated_with_range("range::[]", err::<ValidValues>())]

--- a/ion-schema/src/model/ranges.rs
+++ b/ion-schema/src/model/ranges.rs
@@ -8,23 +8,22 @@ use crate::result::{
 };
 use crate::{isl_require, IslVersion};
 use hidden::RangeBoundType;
-use ion_rs::{Annotatable, Element, SequenceWriter, ValueWriter};
-use std::fmt::{Debug, Display, Formatter};
+use ion_rs::{Annotatable, Element, SequenceWriter, ValueWriter, WriteAsIon};
+use std::fmt::Debug;
 use std::ops::{
     Bound, Bound::*, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
 /// RangeBoundType is a marker trait that can only be implemented in this crate.
 mod hidden {
-    use ion_rs::WriteAsIon;
-    use std::fmt::{Debug, Display};
+    use std::fmt::Debug;
 
     pub trait RangeBoundType
     where
-        Self: PartialOrd + Debug + WriteAsIon + Clone + Display,
+        Self: PartialOrd + Debug + Clone,
     {
     }
-    impl<T> RangeBoundType for T where T: PartialOrd + Debug + WriteAsIon + Clone + Display {}
+    impl<T> RangeBoundType for T where T: PartialOrd + Debug + Clone {}
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -75,7 +74,9 @@ impl<T: RangeBoundType> IonSchemaRange<T> {
         };
         is_above_min && is_below_max
     }
+}
 
+impl<T> IonSchemaRange<T> {
     pub(crate) fn map_bounds<F: Fn(T) -> U, U: RangeBoundType>(
         self,
         transform: F,
@@ -88,65 +89,31 @@ impl<T: RangeBoundType> IonSchemaRange<T> {
     }
 }
 
-impl<T: RangeBoundType> Display for IonSchemaRange<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        format_range(&self.min, &self.max, f)
-    }
-}
-
-fn format_range<T: PartialEq + Display>(
-    min: &Bound<T>,
-    max: &Bound<T>,
-    f: &mut Formatter<'_>,
-) -> std::fmt::Result {
-    if min == max {
-        if let Included(value) = min {
-            return value.fmt(f);
-        }
-    }
-    f.write_str("range::[")?;
-    format_bound(min, "min", f)?;
-    f.write_str(",")?;
-    format_bound(max, "max", f)?;
-    f.write_str("]")
-}
-
-fn format_bound<T: Display>(
-    b: &Bound<T>,
-    unbounded_token: &str,
-    f: &mut Formatter<'_>,
-) -> std::fmt::Result {
-    match b {
-        Unbounded => f.write_str(unbounded_token),
-        Included(x) => x.fmt(f),
-        Excluded(x) => f.write_fmt(format_args!("exclusive::{}", x)),
-    }
-}
-
-impl<V: IslVersion, T: RangeBoundType> WriteAsIsl<V> for IonSchemaRange<T> {
+impl<V: IslVersion, T: RangeBoundType + WriteAsIon> WriteAsIsl<V> for IonSchemaRange<T> {
     fn write_as_isl<W: ValueWriter>(
         &self,
         writer: W,
         ctx: &WriteContext<V>,
     ) -> IonSchemaResult<()> {
-        if self.min == self.max {
+        if ctx.minimize_ranges && self.min == self.max {
             if let Included(value) = &self.min {
                 writer.write(value)?;
+                return Ok(());
             }
-        } else {
-            let mut list_writer = writer.with_annotations(["range"])?.list_writer()?;
-            match &self.min {
-                Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
-                Included(x) => list_writer.write(x)?,
-                Unbounded => list_writer.write_symbol("min")?,
-            };
-            match &self.max {
-                Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
-                Included(x) => list_writer.write(x)?,
-                Unbounded => list_writer.write_symbol("max")?,
-            };
-            list_writer.close()?;
         }
+        let mut list_writer = writer.with_annotations(["range"])?.list_writer()?;
+        match &self.min {
+            Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
+            Included(x) => list_writer.write(x)?,
+            Unbounded => list_writer.write_symbol("min")?,
+        };
+        match &self.max {
+            Excluded(x) => list_writer.write(x.annotated_with(["exclusive"]))?,
+            Included(x) => list_writer.write(x)?,
+            Unbounded => list_writer.write_symbol("max")?,
+        };
+        list_writer.close()?;
+
         Ok(())
     }
 }

--- a/ion-schema/src/test_harness.rs
+++ b/ion-schema/src/test_harness.rs
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Debug;
+
+/// Macro that can take rstest-like cases and inject necessary information to run for multiple
+/// Ion Schema versions.
+///
+/// Example usage (marked `does_not_compile` because the macro is not pub, which means it will not work as a doc test):
+/// ```does_not_compile
+/// test_harness!(
+///     write_as_isl:
+///     ISL_1_0 {
+///         #[case::foo_case("arg1", "arg2")]
+///     }
+///     ISL_1_0, ISL_2_0 {
+///         #[case::bar_case("arg1", "arg2")]
+///     }
+/// )
+/// ```
+///
+/// To be compatible with this test harness, the last parameter of the test function must be a
+/// `PhantomData<V: IslVersion>`.
+///
+///
+macro_rules! test_harness {
+    // The entry point for the macro.
+    ($test:ident: $($versions:ident),+ { $(#[case::$case_name:ident($($arg:expr),+)])+ }$(;$($tt:tt)*)?) => {
+        #[cfg(test)]
+        paste::paste!(
+            mod [<test_ $test>] {
+                use super::*;
+                use paste::paste;
+                use crate::test_harness::$test as the_test_fn;
+
+                test_harness!(__goto__ __loop__: $($versions),* {$(#[case::$case_name($($arg),+)])+} $(;$($tt)*)?);
+            }
+        );
+    };
+    (__goto__ __loop__: $version:ident $(,$other_versions:ident)* { $(#[case::$case_name:ident($($args:expr),+)])+ }$(;$($tt:tt)*)?) => {
+        test_harness!(__goto__ __emitfn__: $($case_name, $version, $($args),+)+);
+        test_harness!(__goto__ __loop__: $($other_versions),* { $(#[case::$case_name($($args),+)])+ $(;$($tt)*)?} );
+    };
+    (__goto__ __loop__: { $(#[case::$case_name:ident($($args:expr),+)])+ }$(;$($tt:tt)*)?) => {
+        test_harness!(__goto__ __loop__: $($($tt)*)?);
+    };
+    (__goto__ __loop__:) => {
+        // No more groups
+    };
+    (__goto__ __emitfn__: $($case_name:ident, $version:ident, $($args:expr),+)+) => {
+        paste!(
+            $(
+            #[test]
+            fn [< $case_name _ $version:lower >]() {
+                the_test_fn($($args,)+ std::marker::PhantomData::<$version>::default())
+            }
+            )+
+        );
+    }
+}
+pub(crate) use test_harness;
+
+pub(crate) fn err<T>() -> Result<T, ()> {
+    Err(())
+}
+
+/// Runs a test case for [`WriteAsIsl`](crate::internal_traits::WriteAsIsl).
+pub(crate) fn write_as_isl<V: crate::IslVersion, T: crate::internal_traits::WriteAsIsl<V>>(
+    expected_ion: Result<&str, ()>,
+    constraint: T,
+    version: std::marker::PhantomData<V>,
+) {
+    use crate::internal_traits::WriteContext;
+    use ion_rs::v1_0::Text;
+    use ion_rs::{Element, SequenceWriter, Writer};
+    let buffer = Vec::new();
+    let mut writer = Writer::new(Text, buffer).unwrap();
+    let ctx = WriteContext::<V>::new();
+    let result = constraint.write_as_isl(writer.value_writer(), &ctx);
+
+    if let Ok(expected_ion) = expected_ion {
+        let output = writer.close().unwrap();
+        let actual_element = Element::read_one(output);
+        let expected_element = Element::read_one(expected_ion);
+        assert_eq!(expected_element, actual_element);
+    } else {
+        assert!(result.is_err())
+    }
+}
+
+/// Runs a test case for [`ReadFromIsl`](crate::internal_traits::ReadFromIsl).
+pub(crate) fn read_from_isl<
+    V: crate::IslVersion,
+    T: crate::internal_traits::ReadFromIsl<V> + PartialEq + Debug,
+>(
+    ion: &str,
+    expected: Result<T, ()>,
+    version: std::marker::PhantomData<V>,
+) {
+    use crate::internal_traits::LoaderContext;
+    use ion_rs::Element;
+
+    let element = Element::read_one(ion).unwrap();
+    let load_ctx = LoaderContext::<V>::new();
+    let result = T::try_read(&element, &load_ctx);
+
+    if let Ok(expected_constraint) = expected {
+        let actual_constraint = result.unwrap();
+        assert_eq!(expected_constraint, actual_constraint);
+    } else {
+        assert!(result.is_err())
+    }
+}

--- a/ion-schema/src/test_harness.rs
+++ b/ion-schema/src/test_harness.rs
@@ -22,32 +22,48 @@ use std::fmt::Debug;
 /// To be compatible with this test harness, the last parameter of the test function must be a
 /// `PhantomData<V: IslVersion>`.
 ///
+/// This macro makes uses the "Incremental TT Muncher" pattern to create a cartesian product of ISL
+/// versions and test case inputs. See https://veykril.github.io/tlborm/decl-macros/patterns/tt-muncher.html
+/// for details about this pattern.
+///
+/// Steps/Cases:
+///   1. The entry point—this sets up the enclosing module, and matches all the "case groups" (a
+///      set of ISL versions and a set of test cases for those versions). Each matched case group
+///      is handed off to the version muncher (step 2).
+///   2. For a given case group, the first ISL version _and_ all the test case inputs are passed to
+///      step 3. The remaining ISL versions _and_ all test case inputs are passed to a recursive
+///      invocation of the version muncher. If there are no more ISL versions left to match, then it
+///      will match step 2B, ending the recursion. In essence, this is loop over the ISL versions,
+///      implemented using tail recursion (the opposite of tail-call loop optimization).
+///   3. For a given ISL version, emits a `#[test]` function for each test-case input.
 ///
 macro_rules! test_harness {
-    // The entry point for the macro.
-    ($test:ident: $($versions:ident),+ { $(#[case::$case_name:ident($($arg:expr),+)])+ }$(;$($tt:tt)*)?) => {
+    // STEP 1
+    (use $test:ident; $( $($versions:ident),+ { $(#[case::$case_name:ident($($args:expr),+)])+ } )+) => {
         #[cfg(test)]
         paste::paste!(
             mod [<test_ $test>] {
                 use super::*;
                 use paste::paste;
-                use crate::test_harness::$test as the_test_fn;
+                use $test as the_test_fn;
 
-                test_harness!(__goto__ __loop__: $($versions),* {$(#[case::$case_name($($arg),+)])+} $(;$($tt)*)?);
+                $(
+                test_harness!(@munch_version $($versions),+ { $(#[case::$case_name($($args),+)])+} );
+                )+
             }
         );
     };
-    (__goto__ __loop__: $version:ident $(,$other_versions:ident)* { $(#[case::$case_name:ident($($args:expr),+)])+ }$(;$($tt:tt)*)?) => {
-        test_harness!(__goto__ __emitfn__: $($case_name, $version, $($args),+)+);
-        test_harness!(__goto__ __loop__: $($other_versions),* { $(#[case::$case_name($($args),+)])+ $(;$($tt)*)?} );
+    // STEP 2A
+    (@munch_version $version:ident $(,$other_versions:ident)* { $(#[case::$case_name:ident($($args:expr),+)])+ }) => {
+        test_harness!(@emit_fn $($case_name, $version, $($args),+)+);
+        test_harness!(@munch_version $($other_versions),* { $(#[case::$case_name($($args),+)])+} );
     };
-    (__goto__ __loop__: { $(#[case::$case_name:ident($($args:expr),+)])+ }$(;$($tt:tt)*)?) => {
-        test_harness!(__goto__ __loop__: $($($tt)*)?);
+    // STEP 2B
+    (@munch_version { $(#[case::$case_name:ident($($args:expr),+)])+ }) => {
+        // No more versions; end the version munching
     };
-    (__goto__ __loop__:) => {
-        // No more groups
-    };
-    (__goto__ __emitfn__: $($case_name:ident, $version:ident, $($args:expr),+)+) => {
+    // STEP 3
+    (@emit_fn $($case_name:ident, $version:ident, $($args:expr),+)+) => {
         paste!(
             $(
             #[test]
@@ -56,7 +72,7 @@ macro_rules! test_harness {
             }
             )+
         );
-    }
+    };
 }
 pub(crate) use test_harness;
 

--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -13,7 +13,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 js-sys = "0.3.61"
 ion-schema = { path="../ion-schema" }
-ion-rs = { version = "1.0.0-rc.10", features = ["experimental-reader-writer"] }
+# Use whatever version of `ion-rs` that `ion-schema` is using.
+ion-rs = { git = "https://github.com/amazon-ion/ion-rust.git", branch = "main", features = ["experimental-reader-writer"] }
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* Adds `valid_values` data model, builder functions, and read and write implementations. `ValidateInternal` impl is `todo!()`.
* Removes some of the trait bounds from `IonSchemaRange` to make it easier to work with.
* Adds a field to `WriteContext` that sets whether ranges are allowed to be written out as a single value.
* Switches the `ion-rs` dependency to depend directly on the `main` branch of `amazon-ion/ion-rust` so that we can make small fixes in `ion-rust` and immediately use them without having to create a new release of `ion-rust`.
* Adds a test harness for `WriteAsIsl` and `ReadFromIsl` test cases.

See PR tour comments (🗺️) for more details.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
