### PR TITLE
Adds models for AllOf, Fields, and OrderedElements

### DIFF
--- a/ion-schema/src/ion_schema_version.rs
+++ b/ion-schema/src/ion_schema_version.rs
@@ -13,7 +13,7 @@ pub trait IslVersion: private::IslVersion + Clone {
 }
 
 /// Ion Schema Language 1.0
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum ISL_1_0 {}
 
@@ -24,7 +24,7 @@ impl IslVersion for ISL_1_0 {
 }
 
 /// Ion Schema Language 2.0
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum ISL_2_0 {}
 
@@ -44,3 +44,40 @@ pub(crate) trait SinceISL_2_0: IslVersion { }
 impl SinceISL_2_0 for ISL_2_0 {}
 
  */
+
+use std::marker::PhantomData;
+use std::ops::Deref;
+
+/// Wrapper for data that needs to be passed around with an ISL version—for example, builder methods
+/// for some constraints can accept `Versioned<TypeArgument>`s.
+///
+/// Technically, this is a smart pointer that (rather than managing the ownership or memory of the
+/// wrapped value) encodes Ion Schema version information along with the wrapped value.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Versioned<T, V: IslVersion>(T, PhantomData<V>);
+impl<T, V: IslVersion> Versioned<T, V> {
+    /// Creates a new [`Versioned`] instance, wrapping the given value.
+    pub(crate) fn new(value: T) -> Self {
+        Self(value, PhantomData)
+    }
+
+    /// Maps the value contained by this [`Versioned`] instance.
+    pub(crate) fn map<U, F: FnOnce(T) -> U>(
+        this: Versioned<T, V>,
+        transform: F,
+    ) -> Versioned<U, V> {
+        Versioned(transform(this.0), this.1)
+    }
+
+    /// Consumes this [`Versioned`] instance, return the value contained within.
+    pub(crate) fn into_inner(this: Versioned<T, V>) -> T {
+        this.0
+    }
+}
+impl<T, V: IslVersion> Deref for Versioned<T, V> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/ion-schema/src/model/constraints/all_of.rs
+++ b/ion-schema/src/model/constraints/all_of.rs
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{
+    LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::ion_schema_version::Versioned;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::type_argument::TypeArgument;
+use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
+use ion_rs::{Element, ValueWriter};
+use std::ops::ControlFlow;
+
+impl ConstraintName for AllOf {
+    const CONSTRAINT_NAME: &'static str = "all_of";
+}
+
+/// Represents the `all_of` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#all_of
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#all_of
+#[derive(Debug, PartialEq, Clone)]
+pub struct AllOf {
+    type_arguments: Vec<TypeArgument>,
+}
+
+impl AllOf {
+    fn new(mut type_arguments: Vec<TypeArgument>) -> Self {
+        // Sorting the vec allows us to get Bag-like equality semantics.
+        // TODO: Replace the vec with a bag or set, or come up with a less hacky way to sort the type arguments.
+        type_arguments.sort_by_cached_key(|item| format!("{item:?}"));
+
+        Self { type_arguments }
+    }
+
+    pub fn type_arguments(&self) -> impl Iterator<Item = &TypeArgument> {
+        self.type_arguments.iter()
+    }
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    pub fn all_of<T: Into<VersionedTypeArgumentList<V>>>(self, type_arguments: T) -> Self {
+        let type_arguments = Versioned::into_inner(type_arguments.into());
+        self.with_constraint(AllOf::new(type_arguments).into())
+    }
+}
+
+impl ValidateInternal for AllOf {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        todo!("Implement this once the ValidationContext allows looking up a type")
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for AllOf
+where
+    TypeArgument: WriteAsIsl<V>,
+{
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+impl<V: IslVersion> ReadConstraint<V> for AllOf {
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::{IntoTypeArgument, TypeDefinition, TypeReference};
+    use crate::{ISL_1_0, ISL_2_0};
+
+    use super::*;
+
+    #[test]
+    fn test_builder() {
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .all_of((
+                // This is a heterogeneous "list" (really a tuple) of things that can become a type arg.
+                "foo_type",
+                TypeDefinitionBuilder::new().build(),
+                TypeReference::imported("bar.isl", "baz"),
+                "quux_type".or_null(true),
+            ))
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AllOf::new(vec![
+                TypeArgument::from_type_ref(
+                    NullabilityModifier::Nothing,
+                    TypeReference::from("foo_type")
+                ),
+                TypeArgument::from_type_def(
+                    NullabilityModifier::Nothing,
+                    TypeDefinition::new(vec![], vec![])
+                ),
+                TypeArgument::from_type_ref(
+                    NullabilityModifier::Nothing,
+                    TypeReference::imported("bar.isl", "baz")
+                ),
+                TypeArgument::from_type_ref(
+                    NullabilityModifier::Nullable,
+                    TypeReference::from("quux_type")
+                ),
+            ],)
+            .into()]
+        );
+
+        let type_ = TypeDefinitionBuilder::<ISL_2_0>::new()
+            .all_of(("foo_type", "quux_type".or_null(true)))
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AllOf::new(vec![
+                TypeArgument::from_type_ref(
+                    NullabilityModifier::Nothing,
+                    TypeReference::from("foo_type")
+                ),
+                TypeArgument::from_type_ref(
+                    NullabilityModifier::NullOr,
+                    TypeReference::from("quux_type")
+                ),
+            ],)
+            .into()]
+        );
+    }
+
+    #[test]
+    fn test_equality() {
+        assert_eq!(
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("a", "b", "c"))
+                .build(),
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("b", "c", "a"))
+                .build(),
+        );
+        assert_eq!(
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("a", "b", "c", "a", "a"))
+                .build(),
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("a", "b", "a", "c", "a"))
+                .build(),
+        );
+        assert_ne!(
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("a", "b", "c", "a"))
+                .build(),
+            TypeDefinitionBuilder::<ISL_1_0>::new()
+                .all_of(("a", "b", "c", "b"))
+                .build(),
+        );
+    }
+}

--- a/ion-schema/src/model/constraints/all_of.rs
+++ b/ion-schema/src/model/constraints/all_of.rs
@@ -29,7 +29,7 @@ pub struct AllOf {
 impl AllOf {
     fn new(mut type_arguments: Vec<TypeArgument>) -> Self {
         // Sorting the vec allows us to get Bag-like equality semantics.
-        // TODO: Replace the vec with a bag or set, or come up with a less hacky way to sort the type arguments.
+        // TODO: Replace the vec with a HashBag or come up with a less hacky way to sort the type arguments.
         type_arguments.sort_by_cached_key(|item| format!("{item:?}"));
 
         Self { type_arguments }
@@ -145,6 +145,7 @@ mod tests {
 
     #[test]
     fn test_equality() {
+        // NOTE: this is checking for _bag_ equivalence.
         assert_eq!(
             TypeDefinitionBuilder::<ISL_1_0>::new()
                 .all_of(("a", "b", "c"))

--- a/ion-schema/src/model/constraints/annotations_v2_simple.rs
+++ b/ion-schema/src/model/constraints/annotations_v2_simple.rs
@@ -4,7 +4,7 @@
 use crate::internal_traits::*;
 use crate::ion_extension::SymbolExtensions;
 use crate::model::constraints::AnnotationsV2Modifier::{Closed, ClosedAndRequired, Required};
-use crate::model::constraints::ConstraintName;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::TypeDefinitionBuilder;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use crate::{IonSchemaElement, ViolationInfo, ViolationRecorder, ISL_1_0, ISL_2_0};
@@ -72,7 +72,7 @@ impl TypeDefinitionBuilder<ISL_2_0> {
     ///
     /// For standard syntax, see [annotations_type].
     pub fn annotations<S: Into<Symbol>, T: IntoIterator<Item = S>>(
-        mut self,
+        self,
         modifier: AnnotationsV2Modifier,
         annotations: T,
     ) -> Self {
@@ -80,8 +80,7 @@ impl TypeDefinitionBuilder<ISL_2_0> {
             modifier,
             annotations: annotations.into_iter().map(Into::into).collect(),
         };
-        self.constraints.push(constraint.into());
-        self
+        self.with_constraint(constraint.into())
     }
 }
 
@@ -158,8 +157,13 @@ impl WriteAsIsl<ISL_2_0> for AnnotationsV2Simple {
     }
 }
 
-impl ReadFromIsl<ISL_2_0> for AnnotationsV2Simple {
-    fn try_read(ion: &Element, ctx: &LoaderContext<ISL_2_0>) -> IonSchemaResult<Self> {
+impl ReadConstraint<ISL_1_0> for AnnotationsV2Simple {}
+
+impl ReadConstraint<ISL_2_0> for AnnotationsV2Simple {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_2_0>,
+    ) -> IonSchemaResult<Option<Self>> {
         let required = ion.annotations().contains("required");
         let closed = ion.annotations().contains("closed");
         let annotations_len = ion.annotations().len();
@@ -198,18 +202,17 @@ impl ReadFromIsl<ISL_2_0> for AnnotationsV2Simple {
             })
             .collect::<Result<Vec<Symbol>, _>>()?;
 
-        Ok(AnnotationsV2Simple {
+        Ok(Some(AnnotationsV2Simple {
             modifier,
             annotations,
-        })
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::AnnotationsV2Modifier;
-    use super::AnnotationsV2Simple;
-    use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl, WriteContext};
+    use super::*;
+    use crate::internal_traits::{LoaderContext, WriteAsIsl, WriteContext};
     use crate::ISL_2_0;
     use ion_rs::v1_0::Text;
     use ion_rs::{Element, SequenceWriter, Writer};
@@ -248,9 +251,9 @@ mod tests {
     #[case::empty_annotation_list("closed::[]", AnnotationsV2Simple::new(AnnotationsV2Modifier::Closed, Vec::<String>::new()))]
     fn annotations_v2_simple_try_read_ok(#[case] ion: &str, #[case] expected: AnnotationsV2Simple) {
         let element = Element::read_one(ion).unwrap();
-        let load_ctx = LoaderContext::new();
-        let result = AnnotationsV2Simple::try_read(&element, &load_ctx);
-        assert_eq!(result, Ok(expected))
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result = AnnotationsV2Simple::read_constraint(&element, &load_ctx);
+        assert_eq!(result, Ok(Some(expected)))
     }
 
     #[rstest]
@@ -264,8 +267,8 @@ mod tests {
     #[case::annotations_cannot_have_unknown_text("required::[$0]")]
     fn annotations_v2_simple_try_read_err(#[case] ion: &str) {
         let element = Element::read_one(ion).unwrap();
-        let load_ctx = LoaderContext::new();
-        let result = AnnotationsV2Simple::try_read(&element, &load_ctx);
+        let load_ctx = LoaderContext::<ISL_2_0>::new();
+        let result = AnnotationsV2Simple::read_constraint(&element, &load_ctx);
         assert!(result.is_err())
     }
 }

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -5,15 +5,28 @@ use crate::internal_traits::{ValidateInternal, ValidationContext, WriteAsIsl, Wr
 use crate::model::constraints::valid_values::ValidValues;
 use crate::model::constraints::*;
 use crate::result::IonSchemaResult;
-use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::ValueWriter;
 use std::ops::ControlFlow;
 
 macro_rules! any_constraint {
     ($($name:ident,)+) => {
         #[derive(Debug, PartialEq, Clone)]
+        #[non_exhaustive]
         pub enum AnyConstraint {
             $($name($name)),*
+        }
+
+        impl AnyConstraint {
+            pub(in crate::model) fn read_constraint<V: IslVersion>(name: &str, ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<AnyConstraint>>
+            where $($name : ReadConstraint<V>,)+
+            {
+                match name {
+                    $($name::CONSTRAINT_NAME => $name::read_constraint(ion, ctx).map(|opt| opt.map(|c| c.into())),
+                    )+
+                    _ => Ok(None),
+                }
+            }
         }
 
         $(
@@ -40,12 +53,17 @@ macro_rules! any_constraint {
             }
         }
 
-        impl<V: IslVersion> WriteAsIsl<V> for AnyConstraint
-        where
-            $(
-            $name: WriteAsIsl<V>,)+
-        {
-            fn write_as_isl<W: ValueWriter>(&self, writer: W, ctx: &WriteContext<V>) -> IonSchemaResult<()> {
+        // Version needs to be explicitly specified to avoid infinite recursion in the type checker.
+        impl WriteAsIsl<ISL_1_0> for AnyConstraint {
+            fn write_as_isl<W: ValueWriter>(&self, writer: W, ctx: &WriteContext<ISL_1_0>) -> IonSchemaResult<()> {
+                match self {
+                    $(AnyConstraint::$name(constraint) => $name::write_as_isl(constraint, writer, ctx),
+                    )+
+                }
+            }
+        }
+        impl WriteAsIsl<ISL_2_0> for AnyConstraint {
+            fn write_as_isl<W: ValueWriter>(&self, writer: W, ctx: &WriteContext<ISL_2_0>) -> IonSchemaResult<()> {
                 match self {
                     $(AnyConstraint::$name(constraint) => $name::write_as_isl(constraint, writer, ctx),
                     )+
@@ -77,7 +95,7 @@ macro_rules! any_constraint {
 }
 
 any_constraint!(
-    // AllOf,
+    AllOf,
     // AnnotationsV1,
     AnnotationsV2Simple,
     // AnnotationsV2Standard,
@@ -88,12 +106,12 @@ any_constraint!(
     // Contains,
     // ElementConstraint,
     // Exponent,
-    // Fields,
+    Fields,
     // FieldNames,
     // Ieee754Float,
     // Not,
     // OneOf,
-    // OrderedElements,
+    OrderedElements,
     // Precision,
     // Regex,
     // Scale,
@@ -103,3 +121,18 @@ any_constraint!(
     Utf8ByteLength,
     ValidValues,
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_harness::*;
+    use crate::{ISL_1_0, ISL_2_0};
+
+    // TODO: Include a trivial case for each constraint and ISL version.
+    test_harness!(
+        use write_as_isl;
+        ISL_1_0, ISL_2_0 {
+            #[case::utf8_byte_length(Ok("range::[1, 10]"), AnyConstraint::Utf8ByteLength(Utf8ByteLength::new(1..=10)))]
+        }
+    );
+}

--- a/ion-schema/src/model/constraints/fields.rs
+++ b/ion-schema/src/model/constraints/fields.rs
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{
+    LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::ion_schema_version::Versioned;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::type_argument::TypeArgument;
+use crate::model::variable_type_argument::{
+    VariablyOccurringTypeArgument, VersionedVariablyOccurringTypeArgument,
+};
+use crate::model::TypeDefinitionBuilder;
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
+use ion_rs::{Element, ValueWriter};
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+
+impl ConstraintName for Fields {
+    const CONSTRAINT_NAME: &'static str = "fields";
+}
+
+/// Represents the `fields` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#fields
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#fields
+#[derive(Debug, PartialEq, Clone)]
+pub struct Fields {
+    fields: HashMap<String, VariablyOccurringTypeArgument>,
+    is_closed: bool,
+}
+
+impl Fields {
+    pub fn fields(&self) -> impl Iterator<Item = (&str, &VariablyOccurringTypeArgument)> {
+        self.fields.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.is_closed
+    }
+}
+
+/// An argument for the `fields` constraint that represents a single field.
+pub type VersionedFieldTypeArgument<V> = Versioned<(String, VariablyOccurringTypeArgument), V>;
+
+impl<V: IslVersion, S: Into<String>, T: Into<VersionedVariablyOccurringTypeArgument<V>>>
+    From<(S, T)> for VersionedFieldTypeArgument<V>
+{
+    fn from(value: (S, T)) -> Self {
+        let name = value.0.into();
+        let type_ = value.1.into();
+        Versioned::map(type_, |t| (name, t))
+    }
+}
+
+/// A list of [`VersionedFieldTypeArgument`]s.
+///
+/// This type can be constructed from `Vec<T>`, `[T; N]`, or `(T₀, T₁, ...)`,
+/// where `T` (or `Tₙ`) implements `Into<VersionedFieldTypeArgument<V>>`.
+pub type VersionedFieldTypeArgumentList<V> =
+    Versioned<Vec<(String, VariablyOccurringTypeArgument)>, V>;
+
+impl<V: IslVersion, T: Into<VersionedFieldTypeArgument<V>>> From<Vec<T>>
+    for VersionedFieldTypeArgumentList<V>
+{
+    fn from(value: Vec<T>) -> Self {
+        let list: Vec<(String, VariablyOccurringTypeArgument)> = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedFieldTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+impl<const N: usize, V: IslVersion, T: Into<VersionedFieldTypeArgument<V>>> From<[T; N]>
+    for VersionedFieldTypeArgumentList<V>
+{
+    fn from(value: [T; N]) -> Self {
+        let list = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedFieldTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+/// Allows heterogeneous tuples to be converted to VersionedFieldTypeArgumentList
+/// Unfortunately, we have to manually include the indices of all the tuple members until
+/// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
+macro_rules! into_fields_arg_list {
+    ($($t:ident $i:tt),+) => {
+        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedFieldTypeArgumentList<V>
+        where $($t: Into<VersionedFieldTypeArgument<V>>,)+
+        {
+            fn from(value: ( $($t),+ )) -> Self {
+                Versioned::new(vec![
+                    $(Versioned::into_inner(value.$i.into()),)+
+                ])
+            }
+        }
+    };
+}
+
+into_fields_arg_list!(A 0, B 1);
+into_fields_arg_list!(A 0, B 1, C 2);
+into_fields_arg_list!(A 0, B 1, C 2, D 3);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8);
+into_fields_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FieldsContent {
+    Open,
+    Closed,
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    pub fn fields<T: Into<VersionedFieldTypeArgumentList<V>>>(
+        self,
+        content: FieldsContent,
+        type_arguments: T,
+    ) -> Self {
+        let fields: HashMap<String, VariablyOccurringTypeArgument> =
+            Versioned::into_inner(type_arguments.into())
+                .into_iter()
+                .collect();
+        let constraint = Fields {
+            fields,
+            is_closed: content == FieldsContent::Closed,
+        };
+        self.with_constraint(constraint.into())
+    }
+}
+
+impl ValidateInternal for Fields {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        todo!("Implement this once the ValidationContext allows looking up a type")
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for Fields
+where
+    TypeArgument: WriteAsIsl<V>,
+{
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+impl ReadConstraint<ISL_1_0> for Fields {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_1_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}
+
+impl ReadConstraint<ISL_2_0> for Fields {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_2_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::constraints::AnyConstraint;
+    use crate::model::variable_type_argument::IntoVariablyOccurringTypeArgument;
+    use crate::model::{IntoTypeArgument, TypeReference};
+
+    #[test]
+    fn test_builder() {
+        let type_ = TypeDefinitionBuilder::<ISL_2_0>::new()
+            .fields(
+                FieldsContent::Closed,
+                (
+                    ("a", "foo".optional()),
+                    ("b", (1..=1, "bar")),
+                    ("c", "baz".or_null(true).occurs(3)),
+                ),
+            )
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![AnyConstraint::Fields(Fields {
+                fields: vec![
+                    (
+                        "a".to_string(),
+                        VariablyOccurringTypeArgument::occurs(
+                            TypeArgument::from_type_ref(
+                                NullabilityModifier::Nothing,
+                                TypeReference::from("foo")
+                            ),
+                            0..=1
+                        )
+                    ),
+                    (
+                        "b".to_string(),
+                        VariablyOccurringTypeArgument::occurs(
+                            TypeArgument::from_type_ref(
+                                NullabilityModifier::Nothing,
+                                TypeReference::from("bar")
+                            ),
+                            1
+                        )
+                    ),
+                    (
+                        "c".to_string(),
+                        VariablyOccurringTypeArgument::occurs(
+                            TypeArgument::from_type_ref(
+                                NullabilityModifier::NullOr,
+                                TypeReference::from("baz")
+                            ),
+                            3
+                        )
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                is_closed: true
+            })]
+        )
+    }
+}

--- a/ion-schema/src/model/constraints/mod.rs
+++ b/ion-schema/src/model/constraints/mod.rs
@@ -1,15 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod all_of;
 mod annotations_v2_simple;
 mod any_constraint;
+mod fields;
+mod ordered_elements;
 mod timestamp_precision;
 mod type_constraint;
 mod utf8_byte_length;
 mod valid_values;
 
+use crate::internal_traits::*;
+use crate::result::IonSchemaResult;
+use crate::IslVersion;
+use ion_rs::Element;
+use std::fmt::Debug;
+
+pub use all_of::*;
 pub use annotations_v2_simple::*;
 pub use any_constraint::*;
+pub use fields::*;
+pub use ordered_elements::*;
 pub use timestamp_precision::*;
 pub use type_constraint::*;
 pub use utf8_byte_length::*;
@@ -18,4 +30,36 @@ pub use valid_values::*;
 /// Provides the constraint's name (ISL keyword) for a given constraint implementation.
 pub(crate) trait ConstraintName {
     const CONSTRAINT_NAME: &'static str;
+}
+
+pub(super) trait ReadConstraint<V: IslVersion>
+where
+    Self: Sized,
+{
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
+        // Default implementation indicates this is unsupported for a particular ISL version.
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+/// Runs a test case for [`ReadConstraint`](crate::model::constraints::ReadConstraint).
+fn test_read_constraint<V: IslVersion, T: ReadConstraint<V> + PartialEq + Debug>(
+    ion: &str,
+    expected: Result<Option<T>, ()>,
+    version: std::marker::PhantomData<V>,
+) {
+    use crate::internal_traits::LoaderContext;
+    use ion_rs::Element;
+
+    let element = Element::read_one(ion).unwrap();
+    let load_ctx = LoaderContext::<V>::new();
+    let result = T::read_constraint(&element, &load_ctx);
+
+    if let Ok(expected_constraint) = expected {
+        let actual_constraint = result.unwrap();
+        assert_eq!(expected_constraint, actual_constraint);
+    } else {
+        assert!(result.is_err())
+    }
 }

--- a/ion-schema/src/model/constraints/ordered_elements.rs
+++ b/ion-schema/src/model/constraints/ordered_elements.rs
@@ -1,0 +1,130 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{
+    LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::ion_schema_version::Versioned;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::type_argument::TypeArgument;
+use crate::model::variable_type_argument::{
+    VariablyOccurringTypeArgument, VersionedVariablyOccurringTypeArgumentList,
+};
+use crate::model::TypeDefinitionBuilder;
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
+use ion_rs::{Element, ValueWriter};
+use std::ops::ControlFlow;
+
+impl ConstraintName for OrderedElements {
+    const CONSTRAINT_NAME: &'static str = "ordered_elements";
+}
+
+/// Represents the `ordered_elements` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#ordered_elements
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#ordered_elements
+#[derive(Debug, PartialEq, Clone)]
+pub struct OrderedElements {
+    type_arguments: Vec<VariablyOccurringTypeArgument>,
+}
+
+impl OrderedElements {
+    pub fn elements(&self) -> impl Iterator<Item = &VariablyOccurringTypeArgument> {
+        self.type_arguments.iter()
+    }
+}
+
+impl<V: IslVersion> TypeDefinitionBuilder<V> {
+    pub fn ordered_elements<T: Into<VersionedVariablyOccurringTypeArgumentList<V>>>(
+        self,
+        type_arguments: T,
+    ) -> Self {
+        let type_arguments = Versioned::into_inner(type_arguments.into());
+        let constraint = OrderedElements { type_arguments };
+        self.with_constraint(constraint.into())
+    }
+}
+
+impl ValidateInternal for OrderedElements {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        todo!("Implement this once the ValidationContext allows looking up a type")
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for OrderedElements
+where
+    TypeArgument: WriteAsIsl<V>,
+{
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+impl<V: IslVersion> ReadConstraint<V> for OrderedElements {
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::variable_type_argument::IntoVariablyOccurringTypeArgument;
+    use crate::model::{IntoTypeArgument, TypeReference};
+    use crate::ISL_2_0;
+
+    #[test]
+    fn test_builder() {
+        let type_ = TypeDefinitionBuilder::<ISL_2_0>::new()
+            .ordered_elements((
+                (0..=1, "foo"),
+                "bar".required(),
+                "baz".or_null(true).occurs(3),
+            ))
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![OrderedElements {
+                type_arguments: vec![
+                    VariablyOccurringTypeArgument::occurs(
+                        TypeArgument::from_type_ref(
+                            NullabilityModifier::Nothing,
+                            TypeReference::from("foo")
+                        ),
+                        0..=1
+                    ),
+                    VariablyOccurringTypeArgument::occurs(
+                        TypeArgument::from_type_ref(
+                            NullabilityModifier::Nothing,
+                            TypeReference::from("bar")
+                        ),
+                        1
+                    ),
+                    VariablyOccurringTypeArgument::occurs(
+                        TypeArgument::from_type_ref(
+                            NullabilityModifier::NullOr,
+                            TypeReference::from("baz")
+                        ),
+                        3
+                    ),
+                ],
+            }
+            .into()]
+        );
+    }
+}

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -5,7 +5,7 @@ use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_extension::ElementExtensions;
-use crate::model::constraints::ConstraintName;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
 use crate::result::{invalid_schema_error, IonSchemaResult};
@@ -138,12 +138,11 @@ impl ConstraintName for TimestampPrecision {
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
     pub fn timestamp_precision<T: Into<IonSchemaRange<TimestampPrecisionValue>>>(
-        mut self,
+        self,
         range: T,
     ) -> Self {
         let constraint = TimestampPrecision::new(range);
-        self.constraints.push(constraint.into());
-        self
+        self.with_constraint(constraint.into())
     }
 }
 
@@ -204,19 +203,19 @@ impl<V: IslVersion> WriteAsIsl<V> for TimestampPrecision {
     }
 }
 
-impl<V: IslVersion> ReadFromIsl<V> for TimestampPrecision {
-    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+impl<V: IslVersion> ReadConstraint<V> for TimestampPrecision {
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
         let range = IonSchemaRange::try_read(ion, ctx)?;
-        Ok(TimestampPrecision::new(range))
+        Ok(Some(TimestampPrecision::new(range)))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::internal_traits::*;
+    use super::*;
+
     use crate::internal_traits::{LoaderContext, WriteContext};
-    use crate::model::constraints::TimestampPrecisionValue::*;
-    use crate::model::constraints::{AnyConstraint, TimestampPrecision};
+
     use std::collections::Bound;
 
     use crate::model::ranges::IonSchemaRange;
@@ -238,9 +237,11 @@ mod tests {
 
         assert_eq!(
             type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![AnyConstraint::TimestampPrecision(TimestampPrecision::new(
-                IonSchemaRange::try_new(Bound::Included(Year), Bound::Included(Day))?
-            ))]
+            vec![TimestampPrecision::new(IonSchemaRange::try_new(
+                Bound::Included(Year),
+                Bound::Included(Day)
+            )?)
+            .into()]
         );
         Ok(())
     }
@@ -290,8 +291,8 @@ mod tests {
     fn timestamp_precision_try_read_ok(#[case] ion: &str, #[case] expected: TimestampPrecision) {
         let element = Element::read_one(ion).unwrap();
         let load_ctx = LoaderContext::<ISL_2_0>::new();
-        let result = TimestampPrecision::try_read(&element, &load_ctx);
-        assert_eq!(result, Ok(expected))
+        let result = TimestampPrecision::read_constraint(&element, &load_ctx);
+        assert_eq!(result, Ok(Some(expected)))
     }
 
     #[rstest]
@@ -311,8 +312,8 @@ mod tests {
     fn timestamp_precision_try_read_err(#[case] ion: &str) {
         let element = Element::read_one(ion).unwrap();
         let load_ctx = LoaderContext::<ISL_2_0>::new();
-        let result: IonSchemaResult<TimestampPrecision> =
-            TimestampPrecision::try_read(&element, &load_ctx);
+        let result: IonSchemaResult<Option<TimestampPrecision>> =
+            TimestampPrecision::read_constraint(&element, &load_ctx);
         assert!(result.is_err())
     }
 }

--- a/ion-schema/src/model/constraints/type_constraint.rs
+++ b/ion-schema/src/model/constraints/type_constraint.rs
@@ -4,9 +4,10 @@
 use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
-use crate::model::constraints::ConstraintName;
-use crate::model::type_argument::{TypeArgument, TypeArgumentBuilder};
-use crate::model::TypeDefinitionBuilder;
+use crate::ion_schema_version::Versioned;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::type_argument::TypeArgument;
+use crate::model::{TypeDefinition, TypeDefinitionBuilder, VersionedTypeArgument};
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -42,10 +43,11 @@ impl ConstraintName for TypeConstraint {
 }
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
-    pub fn type_constraint(mut self, type_argument: TypeArgument) -> Self {
-        let constraint = TypeConstraint { type_argument };
-        self.constraints.push(constraint.into());
-        self
+    pub fn type_constraint(self, type_argument: VersionedTypeArgument<V>) -> Self {
+        let constraint = TypeConstraint {
+            type_argument: Versioned::into_inner(type_argument),
+        };
+        self.with_constraint(constraint.into())
     }
 }
 
@@ -76,14 +78,14 @@ where
     }
 }
 
-impl<V: IslVersion> ReadFromIsl<V> for TypeConstraint
+impl<V: IslVersion> ReadConstraint<V> for TypeConstraint
 where
-    TypeArgumentBuilder<V>: ReadFromIsl<V>,
+    TypeDefinition: ReadFromIsl<V>,
 {
-    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
-        Ok(TypeConstraint {
-            type_argument: TypeArgumentBuilder::try_read(ion, ctx)?.build(),
-        })
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
+        Ok(Some(TypeConstraint {
+            type_argument: TypeArgument::try_read(ion, ctx)?,
+        }))
     }
 }
 

--- a/ion-schema/src/model/constraints/utf8_byte_length.rs
+++ b/ion-schema/src/model/constraints/utf8_byte_length.rs
@@ -4,7 +4,7 @@
 use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
-use crate::model::constraints::ConstraintName;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
 use crate::result::IonSchemaResult;
@@ -38,10 +38,9 @@ impl ConstraintName for Utf8ByteLength {
 }
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
-    pub fn utf8_byte_length<T: Into<IonSchemaRange<usize>>>(mut self, range: T) -> Self {
+    pub fn utf8_byte_length<T: Into<IonSchemaRange<usize>>>(self, range: T) -> Self {
         let constraint = Utf8ByteLength::new(range.into());
-        self.constraints.push(constraint.into());
-        self
+        self.with_constraint(constraint.into())
     }
 }
 
@@ -90,10 +89,10 @@ impl<V: IslVersion> WriteAsIsl<V> for Utf8ByteLength {
     }
 }
 
-impl<V: IslVersion> ReadFromIsl<V> for Utf8ByteLength {
-    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+impl<V: IslVersion> ReadConstraint<V> for Utf8ByteLength {
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
         let range = IonSchemaRange::try_read(ion, ctx)?;
-        Ok(Utf8ByteLength { range })
+        Ok(Some(Utf8ByteLength { range }))
     }
 }
 

--- a/ion-schema/src/model/constraints/valid_values.rs
+++ b/ion-schema/src/model/constraints/valid_values.rs
@@ -2,7 +2,7 @@ use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_extension::ElementExtensions;
-use crate::model::constraints::ConstraintName;
+use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
 use crate::result::{invalid_schema_error, IonSchemaResult};
@@ -35,13 +35,12 @@ impl ValidValues {
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
     /// Adds a `valid_values` constraint to this type definition.
     pub fn valid_values<T: Into<ValidValuesArgument>, I: IntoIterator<Item = T>>(
-        mut self,
+        self,
         values: I,
     ) -> Self {
         let values = values.into_iter().map(|it| it.into()).collect();
         let constraint = ValidValues { values };
-        self.constraints.push(constraint.into());
-        self
+        self.with_constraint(constraint.into())
     }
 
     /// Adds a `valid_values` constraint with a single range argument to this type definition.
@@ -111,8 +110,8 @@ impl<V: IslVersion> WriteAsIsl<V> for ValidValues {
     }
 }
 
-impl<V: IslVersion> ReadFromIsl<V> for ValidValues {
-    fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
+impl<V: IslVersion> ReadConstraint<V> for ValidValues {
+    fn read_constraint(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Option<Self>> {
         // It can be a single range, or a list of arguments. Either way, it must be a list.
         // First, we'll try reading it as a range.
         let values = if (ion.one_optional_annotation()?).is_some() {
@@ -125,7 +124,7 @@ impl<V: IslVersion> ReadFromIsl<V> for ValidValues {
                 .collect();
             c?
         };
-        Ok(ValidValues { values })
+        Ok(Some(ValidValues { values }))
     }
 }
 
@@ -218,7 +217,7 @@ impl<V: IslVersion> ReadFromIsl<V> for NumberRangeValue {
 mod tests {
     use super::*;
 
-    use crate::model::constraints::valid_values::ValidValues;
+    use crate::model::constraints::test_read_constraint;
     use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
     use crate::test_harness::*;
     use crate::{ISL_1_0, ISL_2_0};
@@ -314,50 +313,50 @@ mod tests {
     );
 
     test_harness!(
-        use read_from_isl;
+        use test_read_constraint;
         ISL_1_0, ISL_2_0 {
-            #[case::empty("[]", Ok(ValidValues { values: vec![] }))]
-            #[case::empty_list_annotated_with_range("range::[]", err::<ValidValues>())]
-            #[case::annotated_value_in_list("[foo::1]", err::<ValidValues>())]
+            #[case::empty("[]", Ok(Some(ValidValues { values: vec![] })))]
+            #[case::empty_list_annotated_with_range("range::[]", err::<Option<ValidValues>>())]
+            #[case::annotated_value_in_list("[foo::1]", err::<Option<ValidValues>>())]
             #[case::single_int_value(
                 "[1]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::from(1)] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from(1)] }))
             )]
             #[case::single_string_value(
                 "[\"abc\"]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::from("abc")] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from("abc")] }))
             )]
             #[case::multiple_values(
                 "[\"abc\", 1, null]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }))
             )]
             #[case::multiple_values_with_range(
                 "[\"abc\", 1, range::[1., 2.]]",
-                Ok(ValidValues { values: vec![
+                Ok(Some(ValidValues { values: vec![
                     ValidValuesArgument::from("abc"),
                     ValidValuesArgument::from(1),
                     ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())
-                ]})
+                ]}))
             )]
             #[case::single_number_range_in_a_list(
                 "[range::[1., 2.]]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_not_in_a_list(
                 "range::[1., 2.]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_with_ints(
                 "range::[1, 2]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_with_floats(
                 "range::[1e0, 2e0]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_timestamp_range(
                 "range::[2024T, 2025T]",
-                Ok(ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] })
+                Ok(Some(ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }))
             )]
         }
     );

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -6,6 +6,7 @@ mod ranges;
 mod type_argument;
 mod type_definition;
 mod type_reference;
+mod variable_type_argument;
 
 pub use ranges::*;
 pub use type_argument::*;

--- a/ion-schema/src/model/type_argument.rs
+++ b/ion-schema/src/model/type_argument.rs
@@ -2,22 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl, WriteContext};
+use crate::ion_schema_version::Versioned;
 use crate::isl::isl_type_reference::NullabilityModifier;
 use crate::model::type_definition::TypeDefinition;
 use crate::model::type_reference::TypeReference;
-use crate::model::TypeDefinitionBuilder;
+use crate::model::VersionedTypeDefinition;
 use crate::result::{invalid_schema_error, IonSchemaResult};
-use crate::IslVersion;
+use crate::{IslVersion, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, Value, ValueWriter};
-use std::marker::PhantomData;
 
-/// Represents the argument for a constraint where that argument is an Ion Schema type.
-///
-///
+/// An argument for a constraint where that argument is an Ion Schema type.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeArgument {
     nullability_modifier: NullabilityModifier,
     kind: TypeArgumentKind,
+}
+
+impl TypeArgument {
+    /// Constructs a new TypeArgument from a TypeDefinition.
+    ///
+    /// Do not expose publicly because that would allow users to mix ISL versions.
+    pub(crate) fn from_type_def(
+        nullability_modifier: NullabilityModifier,
+        type_definition: TypeDefinition,
+    ) -> Self {
+        TypeArgument {
+            nullability_modifier,
+            kind: TypeArgumentKind::InlineType(type_definition),
+        }
+    }
+
+    /// Constructs a new TypeArgument from a TypeReference.
+    pub(crate) fn from_type_ref(
+        nullability_modifier: NullabilityModifier,
+        type_reference: TypeReference,
+    ) -> Self {
+        TypeArgument {
+            nullability_modifier,
+            kind: TypeArgumentKind::TypeReference(type_reference),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -37,7 +61,7 @@ where
     ) -> IonSchemaResult<()> {
         let writer = match (self.nullability_modifier, V::MAJOR_MINOR) {
             (NullabilityModifier::Nothing, _) => writer.with_annotations([] as [&'static str; 0]),
-            (NullabilityModifier::NullOr, (1, _)) => todo!("Implement down-conversion to ISL 2.0 by wrapping in `type: $any, any_of: [$null,  T]`"),
+            (NullabilityModifier::NullOr, (1, _)) => todo!("Implement down-conversion to ISL 1.0 by wrapping in `type: $any, any_of: [$null,  T]`"),
             (NullabilityModifier::NullOr, (2, _)) => writer.with_annotations(["$null_or"]),
             (NullabilityModifier::Nullable, (1, _)) => writer.with_annotations(["nullable"]),
             (NullabilityModifier::Nullable, (2, _)) => return invalid_schema_error("'nullable::' is not valid for Ion Schema 2.0 and higher"),
@@ -52,50 +76,9 @@ where
     }
 }
 
-#[derive(Clone)]
-pub struct TypeArgumentBuilder<V: IslVersion> {
-    _version: PhantomData<V>,
-    nullability_modifier: NullabilityModifier,
-    kind: TypeArgumentKind,
-}
-impl<V: IslVersion> TypeArgumentBuilder<V> {
-    pub fn type_reference<T: Into<TypeReference>>(type_reference: T) -> Self {
-        TypeArgumentBuilder {
-            _version: PhantomData,
-            nullability_modifier: NullabilityModifier::Nothing,
-            kind: TypeArgumentKind::TypeReference(type_reference.into()),
-        }
-    }
-
-    pub fn inline(inline: TypeDefinitionBuilder<V>) -> Self {
-        TypeArgumentBuilder {
-            _version: PhantomData,
-            nullability_modifier: NullabilityModifier::Nothing,
-            kind: TypeArgumentKind::InlineType(inline.build()),
-        }
-    }
-
-    pub fn nullable(mut self, b: bool) -> Self {
-        let new_nullability = match (b, V::MAJOR_MINOR) {
-            (false, _) => NullabilityModifier::Nothing,
-            (_, (1, _)) => NullabilityModifier::Nullable,
-            (_, _) => NullabilityModifier::NullOr,
-        };
-        self.nullability_modifier = new_nullability;
-        self
-    }
-
-    pub(crate) fn build(self) -> TypeArgument {
-        TypeArgument {
-            nullability_modifier: self.nullability_modifier,
-            kind: self.kind,
-        }
-    }
-}
-
-impl<V: IslVersion> ReadFromIsl<V> for TypeArgumentBuilder<V>
+impl<V: IslVersion> ReadFromIsl<V> for TypeArgument
 where
-    TypeDefinitionBuilder<V>: ReadFromIsl<V>,
+    TypeDefinition: ReadFromIsl<V>,
 {
     fn try_read(ion: &Element, ctx: &LoaderContext<V>) -> IonSchemaResult<Self> {
         let nullability_modifier = ReadFromIsl::try_read(ion, ctx)?;
@@ -105,16 +88,138 @@ where
                 if let Some(id) = s.get("id") {
                     TypeArgumentKind::TypeReference(TypeReference::try_read(ion, ctx)?)
                 } else {
-                    let ty: TypeDefinitionBuilder<V> = ReadFromIsl::try_read(ion, ctx)?;
-                    TypeArgumentKind::InlineType(ty.build())
+                    let ty: TypeDefinition = TypeDefinition::try_read(ion, ctx)?;
+                    TypeArgumentKind::InlineType(ty)
                 }
             }
             other => invalid_schema_error(format!("not a type argument: {other}"))?,
         };
-        Ok(TypeArgumentBuilder {
+        Ok(TypeArgument {
             nullability_modifier,
             kind,
-            _version: PhantomData,
         })
     }
 }
+
+/// A [`TypeArgument`] with attached metadata indicating an ISL version in which it can be represented.
+pub type VersionedTypeArgument<V> = Versioned<TypeArgument, V>;
+
+impl<V: IslVersion> From<VersionedTypeDefinition<V>> for VersionedTypeArgument<V> {
+    fn from(value: VersionedTypeDefinition<V>) -> Self {
+        Versioned::new(TypeArgument {
+            nullability_modifier: NullabilityModifier::Nothing,
+            kind: TypeArgumentKind::InlineType(Versioned::into_inner(value)),
+        })
+    }
+}
+
+impl<V: IslVersion, R: Into<TypeReference>> From<R> for VersionedTypeArgument<V> {
+    fn from(value: R) -> Self {
+        Versioned::new(TypeArgument {
+            nullability_modifier: NullabilityModifier::Nothing,
+            kind: TypeArgumentKind::TypeReference(value.into()),
+        })
+    }
+}
+
+pub trait IntoTypeArgument<V: IslVersion> {
+    fn or_null(self, n: bool) -> VersionedTypeArgument<V>;
+}
+impl<T: Into<VersionedTypeArgument<ISL_1_0>>> IntoTypeArgument<ISL_1_0> for T {
+    fn or_null(self, n: bool) -> VersionedTypeArgument<ISL_1_0> {
+        Versioned::map(self.into(), |mut inner| {
+            inner.nullability_modifier = if n {
+                NullabilityModifier::Nullable
+            } else {
+                NullabilityModifier::Nothing
+            };
+            inner
+        })
+    }
+}
+impl<T: Into<VersionedTypeArgument<ISL_2_0>>> IntoTypeArgument<ISL_2_0> for T {
+    fn or_null(self, n: bool) -> VersionedTypeArgument<ISL_2_0> {
+        Versioned::map(self.into(), |mut inner| {
+            inner.nullability_modifier = if n {
+                NullabilityModifier::NullOr
+            } else {
+                NullabilityModifier::Nothing
+            };
+            inner
+        })
+    }
+}
+
+/// A list of [`VersionedTypeArgument`]s.
+///
+/// This type can be constructed from `Vec<T>`, `[T; N]`, or `(T₀, T₁, ...)`,
+/// where `T` (or `Tₙ`) implements `Into<VersionedTypeArgument<V>>`.
+pub type VersionedTypeArgumentList<V> = Versioned<Vec<TypeArgument>, V>;
+
+// Unfortunately, we cannot have this:
+// impl<V, T, I> From<I> for VersionedTypeArgumentList<V>
+// where V : IslVersion,
+//       T: Into<VersionedTypeArgument<V>>,
+//       I: IntoIterator<Item=T> { ... }
+//
+// because:
+// note: upstream crates may add a new impl of trait `std::iter::IntoIterator` for type `(_, _)` in future versions
+//
+// So, we'll implement this conversion only for [T; N], Vec<T>, and tuples.
+
+impl<V: IslVersion, T: Into<VersionedTypeArgument<V>>> From<Vec<T>>
+    for VersionedTypeArgumentList<V>
+{
+    fn from(value: Vec<T>) -> Self {
+        let list = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+impl<const N: usize, V: IslVersion, T: Into<VersionedTypeArgument<V>>> From<[T; N]>
+    for VersionedTypeArgumentList<V>
+{
+    fn from(value: [T; N]) -> Self {
+        let list = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+/// Allows heterogeneous tuples to be converted to VersionedTypeArgumentList
+/// Unfortunately, we have to manually include the indices of all the tuple members until
+/// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
+macro_rules! into_type_arg_list {
+    ($($t:ident $i:tt),+) => {
+        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedTypeArgumentList<V>
+        where $($t: Into<VersionedTypeArgument<V>>,)+
+        {
+            fn from(value: ( $($t),+ )) -> Self {
+                Versioned::new(vec![
+                    $(Versioned::into_inner(value.$i.into()),)+
+                ])
+            }
+        }
+    };
+}
+
+into_type_arg_list!(A 0, B 1);
+into_type_arg_list!(A 0, B 1, C 2);
+into_type_arg_list!(A 0, B 1, C 2, D 3);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8);
+into_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9);

--- a/ion-schema/src/model/type_definition.rs
+++ b/ion-schema/src/model/type_definition.rs
@@ -4,12 +4,15 @@
 use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
-use crate::model::constraints::{AnnotationsV2Simple, AnyConstraint, TypeConstraint};
+use crate::ion_schema_version::Versioned;
+use crate::model::constraints::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
-use ion_rs::{Element, IonData, IonType, StructWriter, Symbol, ValueWriter};
+use ion_rs::{Element, IonData, StructWriter, Symbol, ValueWriter};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
+
+pub type VersionedTypeDefinition<V> = Versioned<TypeDefinition, V>;
 
 /// A TypeDefinition is a set of constraints and (optionally) additional user content.
 #[derive(Debug, Clone, PartialEq)]
@@ -46,7 +49,8 @@ impl TypeDefinition {
 /// A version-safe builder for Ion Schema type definitions.
 #[derive(Debug, Clone)]
 pub struct TypeDefinitionBuilder<V: IslVersion> {
-    pub(crate) constraints: Vec<AnyConstraint>,
+    constraints: Vec<AnyConstraint>,
+    // FIXME: Should probably be (String, IonData<Element>)
     open_content: Vec<(Symbol, IonData<Element>)>,
     isl_version: PhantomData<V>,
 }
@@ -60,11 +64,17 @@ impl<V: IslVersion> TypeDefinitionBuilder<V> {
         }
     }
 
-    // This is intentionally pub(crate) because we don't want people to build an ISL 1.0 type and
-    // inline it into an ISL 2.0 type. Constraints that have type arguments should accept a
-    // TypeDefinitionBuilder or a TypeReference.
-    pub(crate) fn build(self) -> TypeDefinition {
-        TypeDefinition::new(self.constraints, self.open_content)
+    /// Adds a constraint to this type definition.
+    ///
+    /// This is pub(crate) so that users cannot add a combination of constraints that is not
+    /// valid for any ISL version.
+    pub(crate) fn with_constraint(mut self, constraint: AnyConstraint) -> Self {
+        self.constraints.push(constraint);
+        self
+    }
+
+    pub fn build(self) -> VersionedTypeDefinition<V> {
+        Versioned::new(TypeDefinition::new(self.constraints, self.open_content))
     }
 
     pub fn with_open_content<S: Into<Symbol>, E: Into<Element>>(
@@ -119,56 +129,39 @@ where
     }
 }
 
-impl ReadFromIsl<ISL_1_0> for TypeDefinitionBuilder<ISL_1_0> {
+impl ReadFromIsl<ISL_1_0> for TypeDefinition {
     fn try_read(ion: &Element, ctx: &LoaderContext<ISL_1_0>) -> IonSchemaResult<Self> {
         let struct_ = ion.expect_struct()?;
-        let mut builder = TypeDefinitionBuilder::new();
-
+        let mut builder = TypeDefinitionBuilder::<ISL_1_0>::new();
         for (name, value) in struct_.fields() {
-            match name.expect_text()? {
-                "type" => builder
-                    .constraints
-                    .push(TypeConstraint::try_read(value, ctx)?.into()),
-                // TODO: Other constraints
-                // TODO: ignore "name" iff this is a top level type definition
-                other => builder
+            let constraint_name = name.expect_text()?;
+            match AnyConstraint::read_constraint(constraint_name, value, ctx)? {
+                Some(constraint) => builder.constraints.push(constraint),
+                None => builder
                     .open_content
                     .push((name.clone(), IonData::from(value.clone()))),
             }
         }
-        Ok(builder)
+        Ok(Versioned::into_inner(builder.build()))
     }
 }
 
-impl ReadFromIsl<ISL_2_0> for TypeDefinitionBuilder<ISL_2_0> {
+impl ReadFromIsl<ISL_2_0> for TypeDefinition {
     fn try_read(ion: &Element, ctx: &LoaderContext<ISL_2_0>) -> IonSchemaResult<Self> {
         let struct_ = ion.expect_struct()?;
-        let mut builder = TypeDefinitionBuilder::new();
-
+        let mut builder = TypeDefinitionBuilder::<ISL_2_0>::new();
         for (name, value) in struct_.fields() {
-            match name.expect_text()? {
-                "annotations" => {
-                    if value.ion_type() == IonType::List {
-                        builder
-                            .constraints
-                            .push(AnnotationsV2Simple::try_read(value, ctx)?.into())
-                    } else {
-                        todo!("standard syntax")
-                    }
-                }
-                "type" => builder
-                    .constraints
-                    .push(TypeConstraint::try_read(value, ctx)?.into()),
-                // TODO: Other constraints
-                // TODO: ignore "name" iff this is a top level type definition
-                other => {
-                    // TODO: Check to make sure that this is valid open content before adding.
+            let constraint_name = name.expect_text()?;
+            match AnyConstraint::read_constraint(constraint_name, value, ctx)? {
+                Some(constraint) => builder.constraints.push(constraint),
+                None => {
+                    // TODO: Check if this particular open content is legal
                     builder
                         .open_content
                         .push((name.clone(), IonData::from(value.clone())))
                 }
             }
         }
-        Ok(builder)
+        Ok(Versioned::into_inner(builder.build()))
     }
 }

--- a/ion-schema/src/model/type_definition.rs
+++ b/ion-schema/src/model/type_definition.rs
@@ -50,7 +50,6 @@ impl TypeDefinition {
 #[derive(Debug, Clone)]
 pub struct TypeDefinitionBuilder<V: IslVersion> {
     constraints: Vec<AnyConstraint>,
-    // FIXME: Should probably be (String, IonData<Element>)
     open_content: Vec<(Symbol, IonData<Element>)>,
     isl_version: PhantomData<V>,
 }

--- a/ion-schema/src/model/variable_type_argument.rs
+++ b/ion-schema/src/model/variable_type_argument.rs
@@ -1,0 +1,165 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::{WriteAsIsl, WriteContext};
+use crate::ion_schema_version::Versioned;
+use crate::model::type_definition::TypeDefinition;
+use crate::model::{IonSchemaRange, TypeArgument, VersionedTypeArgument};
+use crate::result::IonSchemaResult;
+use crate::IslVersion;
+use ion_rs::ValueWriter;
+
+/// A [`TypeArgument`] that can occur a specific number of times in a container.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariablyOccurringTypeArgument {
+    occurs: IonSchemaRange<usize>,
+    type_argument: TypeArgument,
+}
+
+impl VariablyOccurringTypeArgument {
+    pub fn occurs<R: Into<IonSchemaRange<usize>>>(
+        type_argument: TypeArgument,
+        range: R,
+    ) -> VariablyOccurringTypeArgument {
+        VariablyOccurringTypeArgument {
+            type_argument,
+            occurs: range.into(),
+        }
+    }
+}
+
+/// A [`VariablyOccurringTypeArgument`] with attached metadata indicating an ISL version in which it can be represented.
+pub type VersionedVariablyOccurringTypeArgument<V> = Versioned<VariablyOccurringTypeArgument, V>;
+
+pub trait IntoVariablyOccurringTypeArgument<V: IslVersion>: Sized {
+    fn optional(self) -> VersionedVariablyOccurringTypeArgument<V> {
+        self.occurs(0..=1)
+    }
+    fn required(self) -> VersionedVariablyOccurringTypeArgument<V> {
+        self.occurs(1)
+    }
+    fn occurs<R: Into<IonSchemaRange<usize>>>(
+        self,
+        range: R,
+    ) -> VersionedVariablyOccurringTypeArgument<V>;
+}
+impl<V: IslVersion, T: Into<VersionedTypeArgument<V>>> IntoVariablyOccurringTypeArgument<V> for T {
+    fn occurs<R: Into<IonSchemaRange<usize>>>(
+        self,
+        range: R,
+    ) -> VersionedVariablyOccurringTypeArgument<V> {
+        Versioned::map(self.into(), |t| {
+            VariablyOccurringTypeArgument::occurs(t, range.into())
+        })
+    }
+}
+
+impl<R: Into<IonSchemaRange<usize>>, T: Into<TypeArgument>> From<(R, T)>
+    for VariablyOccurringTypeArgument
+{
+    fn from(value: (R, T)) -> Self {
+        VariablyOccurringTypeArgument {
+            occurs: value.0.into(),
+            type_argument: value.1.into(),
+        }
+    }
+}
+
+impl<V: IslVersion, R: Into<IonSchemaRange<usize>>, T: Into<VersionedTypeArgument<V>>> From<(R, T)>
+    for VersionedVariablyOccurringTypeArgument<V>
+{
+    fn from(value: (R, T)) -> Self {
+        Versioned::new(VariablyOccurringTypeArgument {
+            occurs: value.0.into(),
+            type_argument: Versioned::into_inner(value.1.into()),
+        })
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for VariablyOccurringTypeArgument
+where
+    TypeDefinition: WriteAsIsl<V>,
+{
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+/// A list of [`VersionedVariablyOccurringTypeArgument`]s.
+///
+/// This type can be constructed from `Vec<T>`, `[T; N]`, or `(T₀, T₁, ...)`,
+/// where `T` (or `Tₙ`) implements `Into<VariablyOccurringTypeArgument<V>>`.
+pub type VersionedVariablyOccurringTypeArgumentList<V> =
+    Versioned<Vec<VariablyOccurringTypeArgument>, V>;
+
+// Unfortunately, we cannot have this:
+// impl<V, T, I> From<I> for VersionedVariablyOccurringTypeArgumentList<V>
+// where V : IslVersion,
+//       T: Into<VersionedVariablyOccurringTypeArgument<V>>,
+//       I: IntoIterator<Item=T> { ... }
+//
+// because:
+// note: upstream crates may add a new impl of trait `std::iter::IntoIterator` for type `(_, _)` in future versions
+//
+// So, we'll implement this conversion only for [T; N], Vec<T>, and tuples.
+
+impl<V: IslVersion, T: Into<VersionedVariablyOccurringTypeArgument<V>>> From<Vec<T>>
+    for VersionedVariablyOccurringTypeArgumentList<V>
+{
+    fn from(value: Vec<T>) -> Self {
+        let list = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedVariablyOccurringTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+impl<const N: usize, V: IslVersion, T: Into<VersionedVariablyOccurringTypeArgument<V>>> From<[T; N]>
+    for VersionedVariablyOccurringTypeArgumentList<V>
+{
+    fn from(value: [T; N]) -> Self {
+        let list = value
+            .into_iter()
+            .map(|it| {
+                let arg: VersionedVariablyOccurringTypeArgument<V> = it.into();
+                Versioned::into_inner(arg)
+            })
+            .collect();
+        Versioned::new(list)
+    }
+}
+
+/// Allows heterogeneous tuples to be converted to VersionedVariablyOccurringTypeArgumentList
+/// Unfortunately, we have to manually include the indices of all the tuple members until
+/// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
+macro_rules! into_var_type_arg_list {
+    ($($t:ident $i:tt),+) => {
+        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedVariablyOccurringTypeArgumentList<V>
+        where $($t: Into<VersionedVariablyOccurringTypeArgument<V>>,)+
+        {
+            fn from(value: ( $($t),+ )) -> Self {
+                Versioned::new(vec![
+                    $(Versioned::into_inner(value.$i.into()),)+
+                ])
+            }
+        }
+    };
+}
+
+into_var_type_arg_list!(A 0, B 1);
+into_var_type_arg_list!(A 0, B 1, C 2);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8);
+into_var_type_arg_list!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9);


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

Adds data models, builder methods, and stubbed trait implementations for `Fields`, `AllOf`, and `OrderedElements`

As I was working on that change, I ran into some issues that prompted some refactoring. There were things that were unergonomic and there was a circular type requirement that was causing infinite recursion in the type checker.

* Adds `Versioned`, a wrapper for other things that can pass the ISL version as part of the type.
* Updates `TypeArgument` significantly so that it's considerable more ergonomic to use, and gets rid of a bunch of unneeded code.
* Updates `TypeDefinitionBuilder` to be better encapsulated.
* Simplified `ReadFromIsl` for `TypeDefinition` by introducing a `ReadConstraint` trait, which can return `Ok(None)` if the constraint is not supported for a given ISL version.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
