### PR TITLE
Adds Bag type

### DIFF
--- a/ion-schema/src/model/bag.rs
+++ b/ion-schema/src/model/bag.rs
@@ -40,7 +40,7 @@ impl<T: PartialEq + Debug> Bag<T> {
 }
 
 impl<T> Bag<T> {
-    /// Returns the number of elements in the vector, also referred to
+    /// Returns the number of elements in the bag, also referred to
     /// as its 'length'.
     pub fn len(&self) -> usize {
         self.items.len()

--- a/ion-schema/src/model/bag.rs
+++ b/ion-schema/src/model/bag.rs
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Debug;
+use std::slice;
+
+/// An (internal only) bag implementation.
+///
+/// This naive implementation is backed by a sorted vec to have the same equality semantics as a bag.
+/// However, this relies on having a total ordering that is consistent with `Eq`.
+///
+/// The current implementation sorts by the `Debug` representation of the value. This is not
+/// particularly efficient, but until we have a better total ordering we can use, it will do.
+///
+/// Because of the sortedness invariant, adding or removing items one at a time is very inefficient,
+/// and unsupported. Any modifications should be done by trivially converting to a `Vec`, applying
+/// the modifications, and then converting back to a `Bag`.
+///
+/// TODO: Replace the vec with a HashBag or come up with a less hacky way to sort the type arguments.
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct Bag<T> {
+    items: Vec<T>,
+}
+
+impl<T: PartialEq + Debug> Bag<T> {
+    /// Constructs a new bag from the given items.
+    pub fn from_items(items: impl IntoIterator<Item = T>) -> Self {
+        let mut new = Self {
+            items: items.into_iter().collect(),
+        };
+        new.sort_items();
+        new
+    }
+
+    /// This is required to be performed after any add/remove operation in order to maintain the
+    /// invariant that the items are sorted.
+    fn sort_items(&mut self) {
+        self.items.sort_by_key(|item| format!("{item:?}"));
+    }
+}
+
+impl<T> Bag<T> {
+    /// Returns the number of elements in the vector, also referred to
+    /// as its 'length'.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns the _only_ element in the bag, or `None` if the bag has more than one element or is empty.
+    pub fn single(&self) -> Option<&T> {
+        if self.len() == 1 {
+            Some(&self.items[0])
+        } else {
+            None
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+}
+
+impl<T> IntoIterator for Bag<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Bag<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<T> FromIterator<T> for Bag<T>
+where
+    T: PartialEq + Debug,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut new = Self {
+            items: iter.into_iter().collect(),
+        };
+        new.sort_items();
+        new
+    }
+}
+
+impl<T: PartialEq + Debug> From<Vec<T>> for Bag<T> {
+    fn from(items: Vec<T>) -> Self {
+        let mut new = Self { items };
+        new.sort_items();
+        new
+    }
+}
+
+impl<T> From<Bag<T>> for Vec<T> {
+    fn from(bag: Bag<T>) -> Self {
+        bag.items
+    }
+}
+
+macro_rules! bag {
+    ($($tt:tt)*) => {
+        crate::model::Bag::from(vec![$($tt)*])
+    };
+}
+pub(crate) use bag;

--- a/ion-schema/src/model/constraints/all_of.rs
+++ b/ion-schema/src/model/constraints/all_of.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::{
     LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_schema_version::Versioned;
+use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
@@ -23,16 +24,14 @@ impl ConstraintName for AllOf {
 /// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#all_of
 #[derive(Debug, PartialEq, Clone)]
 pub struct AllOf {
-    type_arguments: Vec<TypeArgument>,
+    type_arguments: Bag<TypeArgument>,
 }
 
 impl AllOf {
-    fn new(mut type_arguments: Vec<TypeArgument>) -> Self {
-        // Sorting the vec allows us to get Bag-like equality semantics.
-        // TODO: Replace the vec with a HashBag or come up with a less hacky way to sort the type arguments.
-        type_arguments.sort_by_cached_key(|item| format!("{item:?}"));
-
-        Self { type_arguments }
+    fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {
+        Self {
+            type_arguments: type_arguments.into(),
+        }
     }
 
     pub fn type_arguments(&self) -> impl Iterator<Item = &TypeArgument> {
@@ -82,11 +81,11 @@ impl<V: IslVersion> ReadConstraint<V> for AllOf {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::bag::bag;
     use crate::model::{IntoTypeArgument, TypeDefinition, TypeReference};
     use crate::{ISL_1_0, ISL_2_0};
-
-    use super::*;
 
     #[test]
     fn test_builder() {
@@ -101,15 +100,15 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![AllOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![AllOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")
                 ),
                 TypeArgument::from_type_def(
                     NullabilityModifier::Nothing,
-                    TypeDefinition::new(vec![], vec![])
+                    TypeDefinition::new(bag![], bag![])
                 ),
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
@@ -128,8 +127,8 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![AllOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![AllOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")

--- a/ion-schema/src/model/constraints/any_of.rs
+++ b/ion-schema/src/model/constraints/any_of.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::{
     LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_schema_version::Versioned;
+use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
@@ -23,16 +24,14 @@ impl ConstraintName for AnyOf {
 /// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#any_of
 #[derive(Debug, PartialEq, Clone)]
 pub struct AnyOf {
-    type_arguments: Vec<TypeArgument>,
+    type_arguments: Bag<TypeArgument>,
 }
 
 impl AnyOf {
-    fn new(mut type_arguments: Vec<TypeArgument>) -> Self {
-        // Sorting the vec allows us to get Bag-like equality semantics.
-        // TODO: Replace the vec with a HashBag or come up with a less hacky way to sort the type arguments.
-        type_arguments.sort_by_cached_key(|item| format!("{item:?}"));
-
-        Self { type_arguments }
+    fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {
+        Self {
+            type_arguments: type_arguments.into(),
+        }
     }
 
     pub fn type_arguments(&self) -> impl Iterator<Item = &TypeArgument> {
@@ -82,11 +81,11 @@ impl<V: IslVersion> ReadConstraint<V> for AnyOf {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::bag::bag;
     use crate::model::{IntoTypeArgument, TypeDefinition, TypeReference};
     use crate::{ISL_1_0, ISL_2_0};
-
-    use super::*;
 
     #[test]
     fn test_builder() {
@@ -101,15 +100,15 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![AnyOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![AnyOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")
                 ),
                 TypeArgument::from_type_def(
                     NullabilityModifier::Nothing,
-                    TypeDefinition::new(vec![], vec![])
+                    TypeDefinition::new(bag![], bag![])
                 ),
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
@@ -128,8 +127,8 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![AnyOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![AnyOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")

--- a/ion-schema/src/model/constraints/one_of.rs
+++ b/ion-schema/src/model/constraints/one_of.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::{
     LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_schema_version::Versioned;
+use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
@@ -23,16 +24,14 @@ impl ConstraintName for OneOf {
 /// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#one_of
 #[derive(Debug, PartialEq, Clone)]
 pub struct OneOf {
-    type_arguments: Vec<TypeArgument>,
+    type_arguments: Bag<TypeArgument>,
 }
 
 impl OneOf {
-    fn new(mut type_arguments: Vec<TypeArgument>) -> Self {
-        // Sorting the vec allows us to get Bag-like equality semantics.
-        // TODO: Replace the vec with a HashBag or come up with a less hacky way to sort the type arguments.
-        type_arguments.sort_by_cached_key(|item| format!("{item:?}"));
-
-        Self { type_arguments }
+    fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {
+        Self {
+            type_arguments: type_arguments.into(),
+        }
     }
 
     pub fn type_arguments(&self) -> impl Iterator<Item = &TypeArgument> {
@@ -82,11 +81,11 @@ impl<V: IslVersion> ReadConstraint<V> for OneOf {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::isl::isl_type_reference::NullabilityModifier;
+    use crate::model::bag::bag;
     use crate::model::{IntoTypeArgument, TypeDefinition, TypeReference};
     use crate::{ISL_1_0, ISL_2_0};
-
-    use super::*;
 
     #[test]
     fn test_builder() {
@@ -101,15 +100,15 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![OneOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![OneOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")
                 ),
                 TypeArgument::from_type_def(
                     NullabilityModifier::Nothing,
-                    TypeDefinition::new(vec![], vec![])
+                    TypeDefinition::new(bag![], bag![])
                 ),
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
@@ -128,8 +127,8 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![OneOf::new(vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![OneOf::new(bag![
                 TypeArgument::from_type_ref(
                     NullabilityModifier::Nothing,
                     TypeReference::from("foo_type")

--- a/ion-schema/src/model/constraints/valid_values.rs
+++ b/ion-schema/src/model/constraints/valid_values.rs
@@ -2,6 +2,7 @@ use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_extension::ElementExtensions;
+use crate::model::bag::{bag, Bag};
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
@@ -23,7 +24,7 @@ impl ConstraintName for ValidValues {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ValidValues {
     // TODO: Use a Set once Timestamp and Decimal implement Hash
-    values: Vec<ValidValuesArgument>,
+    values: Bag<ValidValuesArgument>,
 }
 
 impl ValidValues {
@@ -86,8 +87,7 @@ impl<V: IslVersion> WriteAsIsl<V> for ValidValues {
         ctx.minimize_ranges = false;
 
         // If it's just a single range, skip the containing list.
-        if self.values.len() == 1 {
-            let the_value = self.values.first().unwrap();
+        if let Some(the_value) = self.values.single() {
             match the_value {
                 ValidValuesArgument::TimestampRange(range) => {
                     range.write_as_isl(writer, &ctx)?;
@@ -115,7 +115,7 @@ impl<V: IslVersion> ReadConstraint<V> for ValidValues {
         // It can be a single range, or a list of arguments. Either way, it must be a list.
         // First, we'll try reading it as a range.
         let values = if (ion.one_optional_annotation()?).is_some() {
-            vec![read_one_range(ion, ctx)?]
+            bag![read_one_range(ion, ctx)?]
         } else {
             let c: IonSchemaResult<_> = ion
                 .expect_list()?
@@ -229,9 +229,9 @@ mod tests {
             .valid_values([Value::Float(1.0), Value::String("foo".into())])
             .build();
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![ValidValues {
-                values: vec![Value::Float(1.0).into(), Value::String("foo".into()).into(),]
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![ValidValues {
+                values: bag![Value::Float(1.0).into(), Value::String("foo".into()).into(),]
             }
             .into()]
         );
@@ -240,9 +240,9 @@ mod tests {
             .valid_values(["foo", "bar"])
             .build();
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![ValidValues {
-                values: vec![
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![ValidValues {
+                values: bag![
                     Value::String("foo".into()).into(),
                     Value::String("bar".into()).into(),
                 ]
@@ -258,9 +258,9 @@ mod tests {
             .build();
 
         assert_eq!(
-            type_.constraints().cloned().collect::<Vec<_>>(),
-            vec![ValidValues {
-                values: vec![IonSchemaRange::from(Decimal::from(1)..=Decimal::from(10)).into()]
+            type_.constraints().cloned().collect::<Bag<_>>(),
+            bag![ValidValues {
+                values: bag![IonSchemaRange::from(Decimal::from(1)..=Decimal::from(10)).into()]
             }
             .into()]
         );
@@ -271,23 +271,23 @@ mod tests {
         ISL_1_0, ISL_2_0 {
             #[case::empty(
                 Ok("[]"),
-                ValidValues { values: vec![] }
+                ValidValues { values: bag![] }
             )]
             #[case::single_int_value(
                 Ok("[1]"),
-                ValidValues { values: vec![ValidValuesArgument::from(1)] }
+                ValidValues { values: bag![ValidValuesArgument::from(1)] }
             )]
             #[case::single_string_value(
                 Ok("[\"abc\"]"),
-                ValidValues { values: vec![ValidValuesArgument::from("abc")] }
+                ValidValues { values: bag![ValidValuesArgument::from("abc")] }
             )]
             #[case::multiple_values(
-                Ok("[\"abc\", 1, null]"),
-                ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }
+                Ok("[1, null, \"abc\"]"),
+                ValidValues { values: bag![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }
             )]
             #[case::multiple_values_with_range(
-                Ok("[\"abc\", 1, range::[1., 2.]]"),
-                ValidValues { values: vec![
+                Ok("[range::[1., 2.], 1, \"abc\"]"),
+                ValidValues { values: bag![
                     ValidValuesArgument::from("abc"),
                     ValidValuesArgument::from(1),
                     ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())
@@ -295,19 +295,19 @@ mod tests {
             )]
             #[case::single_number_range_should_not_be_in_a_list(
                 Ok("range::[1., 2.]"),
-                ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }
+                ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }
             )]
             #[case::single_timestamp_range_should_not_be_in_a_list(
                 Ok("range::[2024T, 2025T]"),
-                ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
+                ValidValues { values: bag![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
             )]
             #[case::singleton_number_range_should_not_be_minimized(
                 Ok("range::[1., 1.]"),
-                ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(1)).into())] }
+                ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(1)).into())] }
             )]
             #[case::singleton_timestamp_range_should_not_be_minimized(
                 Ok("range::[2025T, 2025T]"),
-                ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2025).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
+                ValidValues { values: bag![ValidValuesArgument::TimestampRange((Timestamp::with_year(2025).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }
             )]
         }
     );
@@ -315,24 +315,24 @@ mod tests {
     test_harness!(
         use test_read_constraint;
         ISL_1_0, ISL_2_0 {
-            #[case::empty("[]", Ok(Some(ValidValues { values: vec![] })))]
+            #[case::empty("[]", Ok(Some(ValidValues { values: bag![] })))]
             #[case::empty_list_annotated_with_range("range::[]", err::<Option<ValidValues>>())]
             #[case::annotated_value_in_list("[foo::1]", err::<Option<ValidValues>>())]
             #[case::single_int_value(
                 "[1]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from(1)] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::from(1)] }))
             )]
             #[case::single_string_value(
                 "[\"abc\"]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from("abc")] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::from("abc")] }))
             )]
             #[case::multiple_values(
                 "[\"abc\", 1, null]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::from("abc"), ValidValuesArgument::from(1), ValidValuesArgument::from(IonType::Null)] }))
             )]
             #[case::multiple_values_with_range(
                 "[\"abc\", 1, range::[1., 2.]]",
-                Ok(Some(ValidValues { values: vec![
+                Ok(Some(ValidValues { values: bag![
                     ValidValuesArgument::from("abc"),
                     ValidValuesArgument::from(1),
                     ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())
@@ -340,23 +340,23 @@ mod tests {
             )]
             #[case::single_number_range_in_a_list(
                 "[range::[1., 2.]]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_not_in_a_list(
                 "range::[1., 2.]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_with_ints(
                 "range::[1, 2]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_number_range_with_floats(
                 "range::[1e0, 2e0]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::NumericRange((Decimal::from(1)..=Decimal::from(2)).into())] }))
             )]
             #[case::single_timestamp_range(
                 "range::[2024T, 2025T]",
-                Ok(Some(ValidValues { values: vec![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }))
+                Ok(Some(ValidValues { values: bag![ValidValuesArgument::TimestampRange((Timestamp::with_year(2024).build().unwrap()..=Timestamp::with_year(2025).build().unwrap()).into())] }))
             )]
         }
     );

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod bag;
 pub mod constraints;
 mod ranges;
 mod type_argument;
@@ -8,6 +9,7 @@ mod type_definition;
 mod type_reference;
 mod variable_type_argument;
 
+use bag::*;
 pub use ranges::*;
 pub use type_argument::*;
 pub use type_definition::*;

--- a/ion-schema/src/model/type_definition.rs
+++ b/ion-schema/src/model/type_definition.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::{
     LoaderContext, ReadFromIsl, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
 };
 use crate::ion_schema_version::Versioned;
+use crate::model::bag::Bag;
 use crate::model::constraints::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
@@ -17,21 +18,18 @@ pub type VersionedTypeDefinition<V> = Versioned<TypeDefinition, V>;
 /// A TypeDefinition is a set of constraints and (optionally) additional user content.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeDefinition {
-    // FIXME: Replace these with bags or use a set and decide that this implementation of Ion
-    //        Schema does not preserve duplicate name/value pairs for open content. That
-    //        may be an acceptable limitation.
-    constraints: Vec<AnyConstraint>,
-    open_content: Vec<(Symbol, IonData<Element>)>,
+    constraints: Bag<AnyConstraint>,
+    open_content: Bag<(Symbol, IonData<Element>)>,
 }
 
 impl TypeDefinition {
     pub(crate) fn new(
-        constraints: Vec<AnyConstraint>,
-        open_content: Vec<(Symbol, IonData<Element>)>,
+        constraints: Bag<AnyConstraint>,
+        open_content: Bag<(Symbol, IonData<Element>)>,
     ) -> Self {
         Self {
-            constraints: constraints.into_iter().collect(),
-            open_content: open_content.into_iter().collect(),
+            constraints,
+            open_content,
         }
     }
 
@@ -49,6 +47,8 @@ impl TypeDefinition {
 /// A version-safe builder for Ion Schema type definitions.
 #[derive(Debug, Clone)]
 pub struct TypeDefinitionBuilder<V: IslVersion> {
+    // TypeDefinitionBuilder uses `Vec` because our naive implementation of `Bag` does not support
+    // modifying the collection.
     constraints: Vec<AnyConstraint>,
     open_content: Vec<(Symbol, IonData<Element>)>,
     isl_version: PhantomData<V>,
@@ -73,7 +73,10 @@ impl<V: IslVersion> TypeDefinitionBuilder<V> {
     }
 
     pub fn build(self) -> VersionedTypeDefinition<V> {
-        Versioned::new(TypeDefinition::new(self.constraints, self.open_content))
+        Versioned::new(TypeDefinition::new(
+            self.constraints.into(),
+            self.open_content.into(),
+        ))
     }
 
     pub fn with_open_content<S: Into<Symbol>, E: Into<Element>>(


### PR DESCRIPTION
### Issue #, if available:

#228 
Suggested in https://github.com/amazon-ion/ion-schema-rust/pull/238#discussion_r2001290273

### Description of changes:

Adds a naive `Bag` implementation and switches `ValidValues`, `AnyOf`, `OneOf`, `AllOf`, and `TypeDefinition` to use rather than having them all sort their own `Vec` or have incorrect equality.

I tried to minimize the diff as best as I could. The interesting changes are entirely in `bag.rs`. The rest of the changes are switching `vec` -> `bag`, updating related comments, and updating some constructor signatures.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
