### PR TITLE
Fix 'annotations' to support multiple versions of the constraint

### DIFF
--- a/ion-schema/src/model/constraints/annotations/mod.rs
+++ b/ion-schema/src/model/constraints/annotations/mod.rs
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod v1;
+mod v2_simple;
+mod v2_standard;
+
+pub use v1::*;
+pub use v2_simple::*;
+pub use v2_standard::*;
+
+use crate::internal_traits::{
+    LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
+use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::type_argument::TypeArgument;
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder, ISL_1_0, ISL_2_0};
+use ion_rs::{Element, IonType, ValueWriter};
+use std::ops::ControlFlow;
+
+impl ConstraintName for Annotations {
+    const CONSTRAINT_NAME: &'static str = "annotations";
+}
+
+/// Represents the `annotations` constraint (ref. [ISL 1.0], [ISL 2.0]).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#annotations
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#annotations
+#[derive(Debug, PartialEq, Clone)]
+pub struct Annotations {
+    variant: AnnotationsVariant,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+enum AnnotationsVariant {
+    V1(AnnotationsV1),
+    V2Standard(AnnotationsV2Standard),
+    V2Simple(AnnotationsV2Simple),
+}
+
+impl ValidateInternal for Annotations {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &'top IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        let mut wrapped_recorder =
+            |el, msg| recorder.accept(ViolationInfo::new(self.into(), el, msg));
+        match &self.variant {
+            AnnotationsVariant::V1(variant) => {
+                variant.validate_internal(value, ctx, &mut wrapped_recorder)
+            }
+            AnnotationsVariant::V2Standard(variant) => {
+                variant.validate_internal(value, ctx, &mut wrapped_recorder)
+            }
+            AnnotationsVariant::V2Simple(variant) => {
+                variant.validate_internal(value, ctx, &mut wrapped_recorder)
+            }
+        }
+    }
+}
+
+impl<V: IslVersion> WriteAsIsl<V> for Annotations
+where
+    TypeArgument: WriteAsIsl<V>,
+    AnnotationsV1: WriteAsIsl<V>,
+    AnnotationsV2Simple: WriteAsIsl<V>,
+    AnnotationsV2Standard: WriteAsIsl<V>,
+{
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<V>,
+    ) -> IonSchemaResult<()> {
+        match &self.variant {
+            AnnotationsVariant::V1(variant) => variant.write_as_isl(writer, ctx),
+            AnnotationsVariant::V2Standard(variant) => variant.write_as_isl(writer, ctx),
+            AnnotationsVariant::V2Simple(variant) => variant.write_as_isl(writer, ctx),
+        }
+    }
+}
+
+impl ReadConstraint<ISL_1_0> for Annotations {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_1_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        match v1::AnnotationsV1::read_constraint(ion, ctx) {
+            Ok(Some(v1)) => Ok(Some(Annotations {
+                variant: AnnotationsVariant::V1(v1),
+            })),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl ReadConstraint<ISL_2_0> for Annotations {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_2_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        if ion.ion_type() == IonType::List {
+            match AnnotationsV2Simple::read_constraint(ion, ctx) {
+                Ok(Some(v2_simple)) => Ok(Some(Annotations {
+                    variant: AnnotationsVariant::V2Simple(v2_simple),
+                })),
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            }
+        } else {
+            match AnnotationsV2Standard::read_constraint(ion, ctx) {
+                Ok(Some(v2_standard)) => Ok(Some(Annotations {
+                    variant: AnnotationsVariant::V2Standard(v2_standard),
+                })),
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}

--- a/ion-schema/src/model/constraints/annotations/v1.rs
+++ b/ion-schema/src/model/constraints/annotations/v1.rs
@@ -1,0 +1,247 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::*;
+use crate::model::constraints::annotations::AnnotationsVariant;
+use crate::model::constraints::{Annotations, ReadConstraint};
+use crate::model::TypeDefinitionBuilder;
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, ISL_1_0, ISL_2_0};
+use ion_rs::{Element, Symbol, ValueWriter};
+use std::ops::ControlFlow;
+
+/// Represents a single annotation for the [`annotations`](AnnotationsV1) constraint in Ion Schema 1.0.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AnnotationV1<T: Into<Symbol>> {
+    Optional(T),
+    Required(T),
+}
+
+pub type AnnotationSymbol = AnnotationV1<Symbol>;
+
+/// Represents the [annotations] constraint in Ion Schema 1.0
+///
+/// [annotations]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#annotations
+#[derive(Debug, PartialEq, Clone)]
+pub struct AnnotationsV1 {
+    annotations: Vec<AnnotationSymbol>,
+    closed: bool,
+    ordered: bool,
+}
+
+impl AnnotationsV1 {
+    pub fn annotations(&self) -> &[AnnotationSymbol] {
+        &self.annotations
+    }
+
+    pub fn closed(&self) -> bool {
+        self.closed
+    }
+
+    pub fn ordered(&self) -> bool {
+        self.ordered
+    }
+
+    pub(super) fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: FnMut(IonSchemaElement<'top>, String) -> ControlFlow<()>,
+    {
+        todo!()
+    }
+}
+
+pub trait IntoAnnotationSymbol {
+    fn into_annotation_symbol(self) -> AnnotationSymbol;
+}
+
+impl<S: Into<Symbol>> IntoAnnotationSymbol for AnnotationV1<S> {
+    fn into_annotation_symbol(self) -> AnnotationSymbol {
+        match self {
+            AnnotationV1::Optional(s) => AnnotationV1::Optional(s.into()),
+            AnnotationV1::Required(s) => AnnotationV1::Required(s.into()),
+        }
+    }
+}
+
+pub trait AnnotationsV1Source {
+    /// Configures whether the annotations are closed.
+    ///
+    /// When set to `true`, only the specified annotations are allowed.
+    /// When `false`, additional annotations beyond those specified are permitted.
+    ///
+    /// # Arguments
+    /// * `yes` - If true, restricts to only specified annotations
+    ///
+    /// # Returns
+    /// * An implementation of `AnnotationsV1Source` with the closed setting configured
+    fn closed(self, yes: bool) -> impl AnnotationsV1Source;
+
+    /// Configures whether the annotations must maintain their specified order.
+    ///
+    /// When set to `true`, annotations must appear in the same order as specified.
+    /// When `false`, annotations can appear in any order.
+    ///
+    /// # Arguments
+    /// * `yes` - If true, enforces the order of annotations
+    ///
+    /// # Returns
+    /// * An implementation of `AnnotationsV1Source` with the ordered setting configured
+    fn ordered(self, yes: bool) -> impl AnnotationsV1Source;
+
+    /// Builds and returns the final AnnotationsV1 instance.
+    ///
+    /// # Returns
+    /// * The constructed `AnnotationsV1` with all configured settings
+    fn build(self) -> AnnotationsV1;
+}
+
+#[derive(Default, Debug, Clone)]
+struct AnnotationsV1Builder {
+    annotations: Vec<AnnotationSymbol>,
+    closed: bool,
+    ordered: bool,
+}
+impl AnnotationsV1Builder {
+    fn from_iter<T: IntoAnnotationSymbol, I: IntoIterator<Item = T>>(iter: I) -> Self {
+        AnnotationsV1Builder {
+            annotations: iter
+                .into_iter()
+                .map(|i| i.into_annotation_symbol())
+                .collect(),
+            closed: false,
+            ordered: false,
+        }
+    }
+}
+
+impl AnnotationsV1Source for AnnotationsV1Builder {
+    fn closed(mut self, yes: bool) -> impl AnnotationsV1Source {
+        self.closed = yes;
+        self
+    }
+
+    fn ordered(mut self, yes: bool) -> impl AnnotationsV1Source {
+        self.ordered = yes;
+        self
+    }
+
+    fn build(self) -> AnnotationsV1 {
+        AnnotationsV1 {
+            annotations: self.annotations,
+            closed: self.closed,
+            ordered: self.ordered,
+        }
+    }
+}
+
+impl<I> AnnotationsV1Source for I
+where
+    I: IntoIterator,
+    I::Item: IntoAnnotationSymbol,
+{
+    fn closed(self, yes: bool) -> impl AnnotationsV1Source {
+        let b: AnnotationsV1Builder = AnnotationsV1Builder::from_iter(self);
+        b.closed(yes)
+    }
+
+    fn ordered(self, yes: bool) -> impl AnnotationsV1Source {
+        let b: AnnotationsV1Builder = AnnotationsV1Builder::from_iter(self);
+        b.ordered(yes)
+    }
+
+    fn build(self) -> AnnotationsV1 {
+        let b: AnnotationsV1Builder = AnnotationsV1Builder::from_iter(self);
+        b.build()
+    }
+}
+
+impl TypeDefinitionBuilder<ISL_1_0> {
+    /// Adds an annotations constraint to the type definition being built.
+    ///
+    /// This method allows adding annotations validation rules to an Ion Schema 1.0 type definition.
+    /// It accepts any source that implements the `AnnotationsV1Source` trait to configure
+    /// the annotation constraints.
+    ///
+    /// # Arguments
+    /// * `source` - The source of annotation constraints implementing `AnnotationsV1Source`
+    ///
+    /// # Returns
+    /// * Returns `Self` (the builder) to allow for method chaining
+    ///
+    /// # Examples
+    /// ```
+    /// # use ion_schema::ISL_1_0;
+    /// # use ion_schema::model::constraints::AnnotationsV1Source;
+    /// use ion_schema::model::TypeDefinition;
+    /// use ion_schema::model::constraints::AnnotationV1::*;
+    /// let type_def = TypeDefinition::builder::<ISL_1_0>()
+    ///     .annotations(
+    ///         [Required("foo"), Optional("bar")]
+    ///             .closed(true)
+    ///     )
+    ///     .build();
+    /// ```
+    pub fn annotations<T: AnnotationsV1Source>(self, source: T) -> Self {
+        let constraint = Annotations {
+            variant: AnnotationsVariant::V1(source.build()),
+        };
+        self.with_constraint(constraint.into())
+    }
+}
+
+impl WriteAsIsl<ISL_1_0> for AnnotationsV1 {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<ISL_1_0>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+// Default implementation returns Err to indicate that this is unsupported.
+impl WriteAsIsl<ISL_2_0> for AnnotationsV1 {
+    // TODO: Implement up-conversion to ISL 2.0 when possible.
+}
+
+impl ReadConstraint<ISL_1_0> for AnnotationsV1 {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_1_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}
+
+impl ReadConstraint<ISL_2_0> for AnnotationsV1 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder() {
+        use AnnotationV1::*;
+
+        let type_ = TypeDefinitionBuilder::<ISL_1_0>::new()
+            .annotations([Optional("a"), Required("b")].closed(true).ordered(true))
+            .build();
+
+        assert_eq!(
+            type_.constraints().cloned().collect::<Vec<_>>(),
+            vec![Annotations {
+                variant: AnnotationsVariant::V1(AnnotationsV1 {
+                    annotations: vec![Optional("a".into()), Required("b".into()),],
+                    closed: true,
+                    ordered: true,
+                })
+            }
+            .into()]
+        )
+    }
+}

--- a/ion-schema/src/model/constraints/annotations/v2_simple.rs
+++ b/ion-schema/src/model/constraints/annotations/v2_simple.rs
@@ -3,11 +3,12 @@
 
 use crate::internal_traits::*;
 use crate::ion_extension::SymbolExtensions;
+use crate::model::constraints::annotations::AnnotationsVariant;
 use crate::model::constraints::AnnotationsV2Modifier::{Closed, ClosedAndRequired, Required};
-use crate::model::constraints::{ConstraintName, ReadConstraint};
+use crate::model::constraints::{Annotations, ReadConstraint};
 use crate::model::TypeDefinitionBuilder;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
-use crate::{IonSchemaElement, ViolationInfo, ViolationRecorder, ISL_1_0, ISL_2_0};
+use crate::{IonSchemaElement, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, Symbol, ValueWriter};
 use std::ops::ControlFlow;
 
@@ -30,25 +31,14 @@ impl AnnotationsV2Modifier {
 /// Represents the [annotations] constraint, simple syntax, in Ion Schema 2.0
 ///
 /// [annotations]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#annotations
-///
-/// TODO: Merge with other annotations constraints to form an enum
-/// enum Annotations {
-///     AnnotationsV1(...),
-///     AnnotationsV2Simple(...),
-///     AnnotationsV2Standard(...),
-/// }
-///
 #[derive(Debug, PartialEq, Clone)]
 pub struct AnnotationsV2Simple {
-    pub(crate) modifier: AnnotationsV2Modifier,
-    pub(crate) annotations: Vec<Symbol>,
+    modifier: AnnotationsV2Modifier,
+    annotations: Vec<Symbol>,
 }
 
 impl AnnotationsV2Simple {
-    pub(crate) fn new<T: Into<Symbol>>(
-        modifier: AnnotationsV2Modifier,
-        annotations: Vec<T>,
-    ) -> Self {
+    fn new<T: Into<Symbol>>(modifier: AnnotationsV2Modifier, annotations: Vec<T>) -> Self {
         Self {
             modifier,
             annotations: annotations.into_iter().map(|it| it.into()).collect(),
@@ -61,45 +51,21 @@ impl AnnotationsV2Simple {
     pub fn annotations(&self) -> &[Symbol] {
         self.annotations.as_slice()
     }
-}
 
-impl ConstraintName for AnnotationsV2Simple {
-    const CONSTRAINT_NAME: &'static str = "annotations";
-}
-
-impl TypeDefinitionBuilder<ISL_2_0> {
-    /// Adds an Ion Schema 2.0 `annotations` constraint using the simple syntax.
-    ///
-    /// For standard syntax, see [annotations_type].
-    pub fn annotations<S: Into<Symbol>, T: IntoIterator<Item = S>>(
-        self,
-        modifier: AnnotationsV2Modifier,
-        annotations: T,
-    ) -> Self {
-        let constraint = AnnotationsV2Simple {
-            modifier,
-            annotations: annotations.into_iter().map(Into::into).collect(),
-        };
-        self.with_constraint(constraint.into())
-    }
-}
-
-impl ValidateInternal for AnnotationsV2Simple {
-    fn validate_internal<'top: 'call, 'call, R>(
+    pub(super) fn validate_internal<'top: 'call, 'call, R>(
         &'top self,
         value: &IonSchemaElement<'top>,
         ctx: &ValidationContext,
         recorder: &'call mut R,
     ) -> ControlFlow<()>
     where
-        R: ViolationRecorder<'top>,
+        R: FnMut(IonSchemaElement<'top>, String) -> ControlFlow<()>,
     {
         let Some(element) = value.as_element() else {
-            return recorder.accept(ViolationInfo::new(
-                self.into(),
+            return recorder(
                 value.clone(),
                 "document type is always invalid for annotations constraint".to_string(),
-            ));
+            );
         };
 
         let actual_annotations: Vec<&Symbol> = element.annotations().iter().collect();
@@ -112,11 +78,10 @@ impl ValidateInternal for AnnotationsV2Simple {
                 }
             }
             if !extra_anns.is_empty() {
-                recorder.accept(ViolationInfo::new(
-                    self.into(),
+                recorder(
                     value.clone(),
                     format!("Unexpected extra annotations: {:?}", extra_anns),
-                ))?
+                )?
             }
         }
         if self.modifier.is_required() {
@@ -127,14 +92,56 @@ impl ValidateInternal for AnnotationsV2Simple {
                 }
             }
             if !missing_annotations.is_empty() {
-                recorder.accept(ViolationInfo::new(
-                    self.into(),
+                recorder(
                     value.clone(),
                     format!("Missing required annotations: {:?}", missing_annotations),
-                ))?
+                )?
             }
         }
         ControlFlow::Continue(())
+    }
+}
+
+impl TypeDefinitionBuilder<ISL_2_0> {
+    /// Adds an annotations constraint to the type definition using Ion Schema 2.0 simple annotation syntax.
+    ///
+    /// This method creates an annotations constraint that validates the presence and/or absence of
+    /// annotations on Ion values. It supports Ion Schema 2.0's annotation modifiers for more
+    /// fine-grained control over annotation validation.
+    ///
+    /// # Arguments
+    /// * `modifier` - An [`AnnotationsV2Modifier`] that specifies how the annotations should be applied
+    ///               (e.g., required, closed, or both)
+    /// * `annotations` - An iterable collection of items that can be converted into [`Symbol`],
+    ///                  representing the annotation names
+    ///
+    /// # Returns
+    /// * Returns `Self` to allow for method chaining in the builder pattern
+    ///
+    /// # Examples
+    /// ```
+    /// # use ion_schema::ISL_2_0;
+    /// # use ion_schema::model::TypeDefinition;
+    /// use ion_schema::model::constraints::AnnotationsV2Modifier::*;
+    /// let type_def = TypeDefinition::builder::<ISL_2_0>()
+    ///     .annotations(Closed, ["foo", "bar"])
+    ///     .build();
+    /// ```
+    pub fn annotations<S: Into<Symbol>, T: IntoIterator<Item = S>>(
+        self,
+        modifier: AnnotationsV2Modifier,
+        annotations: T,
+    ) -> Self {
+        let constraint = AnnotationsV2Simple {
+            modifier,
+            annotations: annotations.into_iter().map(Into::into).collect(),
+        };
+        self.with_constraint(
+            Annotations {
+                variant: AnnotationsVariant::V2Simple(constraint),
+            }
+            .into(),
+        )
     }
 }
 

--- a/ion-schema/src/model/constraints/annotations/v2_standard.rs
+++ b/ion-schema/src/model/constraints/annotations/v2_standard.rs
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::internal_traits::*;
+use crate::model::constraints::annotations::AnnotationsVariant;
+use crate::model::constraints::{Annotations, ReadConstraint};
+use crate::model::{TypeArgument, TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::result::IonSchemaResult;
+use crate::{IonSchemaElement, Versioned, ViolationRecorder, ISL_1_0, ISL_2_0};
+use ion_rs::{Element, ValueWriter};
+use std::ops::ControlFlow;
+
+/// Represents the [annotations] constraint, standard syntax, in Ion Schema 2.0
+///
+/// [annotations]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#annotations
+#[derive(Debug, PartialEq, Clone)]
+pub struct AnnotationsV2Standard {
+    annotations_type: TypeArgument,
+}
+
+impl AnnotationsV2Standard {
+    pub fn annotations_type(&self) -> &TypeArgument {
+        &self.annotations_type
+    }
+
+    pub(super) fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: FnMut(IonSchemaElement<'top>, String) -> ControlFlow<()>,
+    {
+        todo!()
+    }
+}
+
+impl TypeDefinitionBuilder<ISL_2_0> {
+    /// Adds an Ion Schema 2.0 `annotations` constraint using the standard syntax.
+    pub fn annotations_type(self, annotations_type: VersionedTypeArgument<ISL_2_0>) -> Self {
+        let constraint = AnnotationsV2Standard {
+            annotations_type: Versioned::into_inner(annotations_type),
+        };
+        self.with_constraint(
+            Annotations {
+                variant: AnnotationsVariant::V2Standard(constraint),
+            }
+            .into(),
+        )
+    }
+}
+
+impl ValidateInternal for AnnotationsV2Standard {
+    fn validate_internal<'top: 'call, 'call, R>(
+        &'top self,
+        value: &IonSchemaElement<'top>,
+        ctx: &ValidationContext,
+        recorder: &'call mut R,
+    ) -> ControlFlow<()>
+    where
+        R: ViolationRecorder<'top>,
+    {
+        todo!()
+    }
+}
+
+impl WriteAsIsl<ISL_1_0> for AnnotationsV2Standard {}
+
+impl WriteAsIsl<ISL_2_0> for AnnotationsV2Standard {
+    fn write_as_isl<W: ValueWriter>(
+        &self,
+        writer: W,
+        ctx: &WriteContext<ISL_2_0>,
+    ) -> IonSchemaResult<()> {
+        todo!()
+    }
+}
+
+impl ReadConstraint<ISL_2_0> for AnnotationsV2Standard {
+    fn read_constraint(
+        ion: &Element,
+        ctx: &LoaderContext<ISL_2_0>,
+    ) -> IonSchemaResult<Option<Self>> {
+        todo!()
+    }
+}

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -96,9 +96,7 @@ macro_rules! any_constraint {
 
 any_constraint!(
     AllOf,
-    // AnnotationsV1,
-    AnnotationsV2Simple,
-    // AnnotationsV2Standard,
+    Annotations,
     AnyOf,
     ByteLength,
     CodepointLength,

--- a/ion-schema/src/model/constraints/mod.rs
+++ b/ion-schema/src/model/constraints/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod all_of;
-mod annotations_v2_simple;
+mod annotations;
 mod any_constraint;
 mod any_of;
 mod byte_length;
@@ -33,7 +33,7 @@ use ion_rs::Element;
 use std::fmt::Debug;
 
 pub use all_of::*;
-pub use annotations_v2_simple::*;
+pub use annotations::*;
 pub use any_constraint::*;
 pub use any_of::*;
 pub use byte_length::*;

--- a/ion-schema/src/model/type_definition.rs
+++ b/ion-schema/src/model/type_definition.rs
@@ -23,6 +23,10 @@ pub struct TypeDefinition {
 }
 
 impl TypeDefinition {
+    pub fn builder<V: IslVersion>() -> TypeDefinitionBuilder<V> {
+        TypeDefinitionBuilder::new()
+    }
+
     pub(crate) fn new(
         constraints: Bag<AnyConstraint>,
         open_content: Bag<(Symbol, IonData<Element>)>,

--- a/ion-schema/src/violation_recorder.rs
+++ b/ion-schema/src/violation_recorder.rs
@@ -126,24 +126,20 @@ impl<'a> ViolationRecorder<'a> for Vec<ViolationInfo<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::model::constraints::AnyConstraintRef;
+    use crate::model::constraints::{AnyConstraintRef, ContainerLength};
     use crate::violation_recorder::{ViolationInfo, ViolationRecorder};
-    use crate::{model, IonSchemaElement};
+    use crate::IonSchemaElement;
     use ion_rs::Element;
-    use model::constraints::{AnnotationsV2Modifier, AnnotationsV2Simple};
     use std::ops::ControlFlow;
 
     #[test]
     fn impl_violation_recorder_for_vec_violation_info() {
         let mut recorder: Vec<ViolationInfo> = vec![];
 
-        let constraint = AnnotationsV2Simple {
-            modifier: AnnotationsV2Modifier::Closed,
-            annotations: vec![],
-        };
+        let constraint = ContainerLength::new(1..);
         let element = Element::string("hello world");
         let vi = ViolationInfo::new(
-            AnyConstraintRef::AnnotationsV2Simple(&constraint),
+            AnyConstraintRef::ContainerLength(&constraint),
             IonSchemaElement::from(&element),
             "fake violation".to_string(),
         );
@@ -161,13 +157,10 @@ mod tests {
     fn impl_violation_recorder_for_option_violation_info() {
         let mut recorder: Option<ViolationInfo> = None;
 
-        let constraint = AnnotationsV2Simple {
-            modifier: AnnotationsV2Modifier::Closed,
-            annotations: vec![],
-        };
+        let constraint = ContainerLength::new(1..);
         let element = Element::string("hello world");
         let mut vi = ViolationInfo::new(
-            AnyConstraintRef::AnnotationsV2Simple(&constraint),
+            AnyConstraintRef::ContainerLength(&constraint),
             IonSchemaElement::from(&element),
             "fake violation".to_string(),
         );


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

I've changed the strategy for dealing with the `annotations` constraint. Instead of having 3 possible constraints, we now have one constraint which internally has 3 variants.

The tests in `violation_recorder.rs` used the `annotations` constraint; rather than updating them to use the new annotations constraint implementation, I switched them to use a simpler constraint.

I also added a `pub builder()` function to `TypeDefinition`.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
