### PR TITLE
Fixes all clippy warnings

### DIFF
--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -3,15 +3,13 @@
 //! This module consists of three submodules that help constructing ISL types/constraint:
 //!
 //! * `isl_type` module represents a schema type [IslType] which converts given ion content in the schema file
-//! into an ISL types(not-yet-resolved types). It stores `IslConstraint`s defined within the given type.
-//!
+//!   into an ISL types(not-yet-resolved types). It stores `IslConstraint`s defined within the given type.
 //! * `isl_import` module represents a schema import [IslImport] which converts given ion content in the schema file
-//! into an ISL import. It stores schema id, an optional type that needs to be imported and an optional alias to that type.
-//!
+//!   into an ISL import. It stores schema id, an optional type that needs to be imported and an optional alias to that type.
 //! * `isl_constraint` module represents schema constraints [IslConstraint]
-//! which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
-//!
+//!   which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
 //! * `isl_type_reference` module provides a schema type reference.
+//!
 //! The type reference grammar is defined in the [Ion Schema Specification]
 //!
 //! [IslConstraint]: isl_constraint::IslConstraint
@@ -555,6 +553,7 @@ impl<'a> Iterator for SchemaIterator<'a> {
 }
 
 #[cfg(test)]
+#[allow(unused_must_use)]
 mod isl_tests {
     use crate::authority::FileSystemDocumentAuthority;
     use crate::ion_extension::ElementExtensions;

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -209,9 +209,15 @@ impl ValidValue {
         if element.annotations().contains("range") {
             isl_require!(annotation.len() == 1 => "Unexpected annotation(s) on valid values argument: {element}")?;
             // Does it contain any timestamps
-            let has_timestamp = element.as_sequence().map_or(false, |s| {
-                s.elements().any(|it| it.ion_type() == IonType::Timestamp)
-            });
+            let has_timestamp = {
+                if let Some(sequence) = element.as_sequence() {
+                    sequence
+                        .elements()
+                        .any(|it| it.ion_type() == IonType::Timestamp)
+                } else {
+                    false
+                }
+            };
             let range = if has_timestamp {
                 ValidValue::TimestampRange(TimestampRange::from_ion_element(element, |e| {
                     e.as_timestamp()

--- a/ion-schema/src/ordered_elements_nfa.rs
+++ b/ion-schema/src/ordered_elements_nfa.rs
@@ -218,7 +218,7 @@ impl OrderedElementsNfa {
                     edges.clone()
                 } else {
                     // The only state without edges is `Final`, which cannot be exited.
-                    invalid_transitions.insert(TraversalError::CannotExitState(from_state_id));
+                    invalid_transitions.insert(TraversalError::Exiting(from_state_id));
                     break;
                 };
 
@@ -231,7 +231,7 @@ impl OrderedElementsNfa {
                     let is_loop = to_state_id == from_state_id;
 
                     if !is_loop && !can_exit {
-                        invalid_transitions.insert(TraversalError::CannotExitState(from_state_id));
+                        invalid_transitions.insert(TraversalError::Exiting(from_state_id));
                         // We haven't reached the min_occurs of the current state. Any further
                         // transitions will also suffer from the same problem. No need to report
                         // this same problem repeatedly, so we break here.
@@ -245,9 +245,9 @@ impl OrderedElementsNfa {
 
                     if let Err(violation) = can_enter {
                         invalid_transitions
-                            .insert(TraversalError::CannotEnterState(to_state_id, violation));
+                            .insert(TraversalError::Entering(to_state_id, violation));
                     } else if is_loop && !can_reenter {
-                        invalid_transitions.insert(TraversalError::CannotReEnterState(to_state_id));
+                        invalid_transitions.insert(TraversalError::ReEntering(to_state_id));
                     } else {
                         let new_num_visits = if is_loop { num_visits + 1 } else { 1 };
                         new_states.insert((to_state_id, new_num_visits));
@@ -284,19 +284,19 @@ impl OrderedElementsNfa {
         let reasons = reasons
             .into_iter()
             .map(|it| match it {
-                TraversalError::CannotExitState(s) => Violation::new(
+                TraversalError::Exiting(s) => Violation::new(
                     "ordered_elements",
                     ViolationCode::ElementMismatched,
                     format!("{}: min occurs not reached", &self.states[s]),
                     ion_path,
                 ),
-                TraversalError::CannotReEnterState(s) => Violation::new(
+                TraversalError::ReEntering(s) => Violation::new(
                     "ordered_elements",
                     ViolationCode::ElementMismatched,
                     format!("{}: max occurs already reached", &self.states[s],),
                     ion_path,
                 ),
-                TraversalError::CannotEnterState(s, v) => Violation::with_violations(
+                TraversalError::Entering(s, v) => Violation::with_violations(
                     "ordered_elements",
                     ViolationCode::ElementMismatched,
                     format!("{}: does not match type", &self.states[s]),
@@ -424,9 +424,9 @@ impl Display for State {
 /// The reason why a transition (or edge) in the state machine graph cannot be traversed.
 #[derive(Debug)]
 enum TraversalError {
-    CannotEnterState(StateId, Violation),
-    CannotExitState(StateId),
-    CannotReEnterState(StateId),
+    Entering(StateId, Violation),
+    Exiting(StateId),
+    ReEntering(StateId),
 }
 
 impl PartialOrd for TraversalError {
@@ -438,14 +438,14 @@ impl PartialOrd for TraversalError {
 impl Ord for TraversalError {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_id = match self {
-            TraversalError::CannotEnterState(id, _)
-            | TraversalError::CannotExitState(id)
-            | TraversalError::CannotReEnterState(id) => id,
+            TraversalError::Entering(id, _)
+            | TraversalError::Exiting(id)
+            | TraversalError::ReEntering(id) => id,
         };
         let other_id = match other {
-            TraversalError::CannotEnterState(id, _)
-            | TraversalError::CannotExitState(id)
-            | TraversalError::CannotReEnterState(id) => id,
+            TraversalError::Entering(id, _)
+            | TraversalError::Exiting(id)
+            | TraversalError::ReEntering(id) => id,
         };
         self_id.cmp(other_id)
     }
@@ -456,22 +456,19 @@ impl Eq for TraversalError {}
 impl PartialEq for TraversalError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (
-                TraversalError::CannotExitState(self_id),
-                TraversalError::CannotExitState(other_id),
-            ) => self_id == other_id,
-            (
-                TraversalError::CannotReEnterState(self_id),
-                TraversalError::CannotReEnterState(other_id),
-            ) => self_id == other_id,
+            (TraversalError::Exiting(self_id), TraversalError::Exiting(other_id)) => {
+                self_id == other_id
+            }
+            (TraversalError::ReEntering(self_id), TraversalError::ReEntering(other_id)) => {
+                self_id == other_id
+            }
             // It is okay to ignore the violation here because we only consider one event/element at
             // any given point in the state machine. Since that is the case, if the IDs are the same,
             // then they must represent the same destination state (type reference), and so the
             // violations must be equal.
-            (
-                TraversalError::CannotEnterState(self_id, _),
-                TraversalError::CannotEnterState(other_id, _),
-            ) => self_id == other_id,
+            (TraversalError::Entering(self_id, _), TraversalError::Entering(other_id, _)) => {
+                self_id == other_id
+            }
             (_, _) => false,
         }
     }
@@ -484,9 +481,9 @@ impl Hash for TraversalError {
         // between the prime numbers makes it even more unlikely that a collision would occur since
         // the first IDs that could have a collision with each other would be 107 and 307.
         state.write_usize(match self {
-            TraversalError::CannotEnterState(id, _) => id * 503,
-            TraversalError::CannotExitState(id) => id * 307,
-            TraversalError::CannotReEnterState(id) => id * 107,
+            TraversalError::Entering(id, _) => id * 503,
+            TraversalError::Exiting(id) => id * 307,
+            TraversalError::ReEntering(id) => id * 107,
         })
     }
 }

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -3,6 +3,7 @@
 //!
 //! * `get_types`: This function returns an [`SchemaTypeIterator`] which can be used to iterate over the [`TypeDefinition`]s.
 //! * `get_type`: This function requires to pass the name of a type definition that you want to use for validation.
+//!
 //! It returns the [`TypeDefinition`] if it is defined in the [`Schema`] otherwise returns [`None`].
 //!
 

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 /// * A nested anonymous type definition.
 /// * A reference to type definition that is followed by current type definition. These type references
 ///   will be deferred to later check if a type definition with that name exists in the schema.
+///
 /// Because the [`SchemaSystem`] does not yet know the complete definition
 /// of these types, it cannot find them in the [`TypeStore`].
 /// An instance of [`PendingTypes`] is used to track information about types
@@ -92,6 +93,7 @@ impl PendingTypes {
     ///                      exists in [`PendingTypes`] it would have been added as a deferred type definition.
     ///                      This deferred type will be loaded into [`TypeStore`] as it is and will be replaced with a type definition
     ///                      once it is resolved.
+    ///
     /// Returns true, if this update is not for an isl import type or it is for an isl import type but it is added to the type_store
     /// Otherwise, returns false if this update is for an isl import type and it is not yet added to the type_store.
     pub fn update_type_store(

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -210,10 +210,9 @@ macro_rules! assert_equivalent_violations {
     };
 }
 
-#[macro_export]
-
 /// Equivalence for `Violation`s is not supported due to its tree structure of having children violations.
 /// This macro can be used for comparing if two violations are not equal and uses `flattened_violations` for the comparison.
+#[macro_export]
 macro_rules! assert_non_equivalent_violations {
     ($left:expr, $right:expr $(,)?) => {
         let mut left_strings: Vec<String> = $left


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

This fixes all of the clippy warnings in `ion-schema-rust`.
Most of them had to do with formatting in the rustdoc comments.
See PR comments for the others.


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
