### PR TITLE
Adds SchemaDocument and builder

### DIFF
--- a/ion-schema/src/ion_schema_version.rs
+++ b/ion-schema/src/ion_schema_version.rs
@@ -46,7 +46,6 @@ impl SinceISL_2_0 for ISL_2_0 {}
  */
 
 use std::marker::PhantomData;
-use std::ops::Deref;
 
 /// Wrapper for data that needs to be passed around with an ISL version—for example, builder methods
 /// for some constraints can accept `Versioned<TypeArgument>`s.
@@ -70,10 +69,15 @@ impl<T, V: IslVersion> Versioned<T, V> {
     }
 
     /// Consumes this [`Versioned`] instance, return the value contained within.
-    pub(crate) fn into_inner(this: Versioned<T, V>) -> T {
-        this.0
+    pub(crate) fn into_inner(self) -> T {
+        self.0
     }
 }
+
+// For testing-convenience only, we make this wrapper non-opaque.
+#[cfg(test)]
+use std::ops::Deref;
+#[cfg(test)]
 impl<T, V: IslVersion> Deref for Versioned<T, V> {
     type Target = T;
 

--- a/ion-schema/src/model/constraints/fields.rs
+++ b/ion-schema/src/model/constraints/fields.rs
@@ -96,10 +96,10 @@ impl<const N: usize, V: IslVersion, T: Into<VersionedFieldTypeArgument<V>>> From
 /// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
 macro_rules! into_fields_arg_list {
     ($($t:ident $i:tt),+) => {
-        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedFieldTypeArgumentList<V>
+        impl<V: IslVersion, $($t),+> From<( $($t,)+ )> for VersionedFieldTypeArgumentList<V>
         where $($t: Into<VersionedFieldTypeArgument<V>>,)+
         {
-            fn from(value: ( $($t),+ )) -> Self {
+            fn from(value: ( $($t,)+ )) -> Self {
                 Versioned::new(vec![
                     $(Versioned::into_inner(value.$i.into()),)+
                 ])
@@ -108,6 +108,7 @@ macro_rules! into_fields_arg_list {
     };
 }
 
+into_fields_arg_list!(A 0);
 into_fields_arg_list!(A 0, B 1);
 into_fields_arg_list!(A 0, B 1, C 2);
 into_fields_arg_list!(A 0, B 1, C 2, D 3);

--- a/ion-schema/src/model/constraints/regex.rs
+++ b/ion-schema/src/model/constraints/regex.rs
@@ -109,6 +109,7 @@ impl<V: IslVersion> IonSchemaRegexSource<V> for IonSchemaRegexBuilder<V> {
 
 impl<V: IslVersion> From<Versioned<Regex, V>> for IonSchemaRegexBuilder<V> {
     fn from(value: Versioned<Regex, V>) -> Self {
+        let value = value.into_inner();
         IonSchemaRegexBuilder {
             _version: Default::default(),
             case_insensitive: value.case_insensitive,

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -4,6 +4,8 @@
 mod bag;
 pub mod constraints;
 mod ranges;
+mod schema;
+mod schema_header;
 mod type_argument;
 mod type_definition;
 mod type_reference;
@@ -11,6 +13,8 @@ mod variable_type_argument;
 
 use bag::*;
 pub use ranges::*;
+pub use schema::*;
+pub use schema_header::*;
 pub use type_argument::*;
 pub use type_definition::*;
 pub use type_reference::*;

--- a/ion-schema/src/model/schema.rs
+++ b/ion-schema/src/model/schema.rs
@@ -1,0 +1,236 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::schema::schema_doc_builder_state::{BeforeHeader, HasFooter, Types};
+use crate::model::{SchemaHeader, TypeDefinition, VersionedTypeDefinition};
+use crate::{IslVersion, Versioned};
+use ion_rs::Element;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SchemaItem {
+    Header(SchemaHeader),
+    Type(String, TypeDefinition),
+    OpenContent(Element),
+    Footer(SchemaFooter),
+}
+impl From<SchemaHeader> for SchemaItem {
+    fn from(value: SchemaHeader) -> Self {
+        SchemaItem::Header(value)
+    }
+}
+impl From<SchemaFooter> for SchemaItem {
+    fn from(value: SchemaFooter) -> Self {
+        SchemaItem::Footer(value)
+    }
+}
+impl From<Element> for SchemaItem {
+    fn from(value: Element) -> Self {
+        SchemaItem::OpenContent(value)
+    }
+}
+
+/// Represents an Ion Schema document.
+///
+/// A schema is a collection of types that can be used to constrain the Ion data model.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaDocument {
+    /// The version in which this schema was created, but not necessarily the only version for which it is valid.
+    isl_version: (u8, u8),
+    items: Vec<SchemaItem>,
+    types_by_name: HashMap<String, usize>,
+}
+
+impl SchemaDocument {
+    pub fn builder<V: IslVersion>() -> SchemaDocumentBuilder<V, BeforeHeader> {
+        SchemaDocumentBuilder::new()
+    }
+
+    fn new<V: IslVersion>(items: Vec<SchemaItem>) -> Self {
+        let types_by_name = items
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| match item {
+                SchemaItem::Type(name, _) => Some((name.clone(), idx)),
+                _ => None,
+            })
+            .collect();
+        let isl_version = V::MAJOR_MINOR;
+        SchemaDocument {
+            isl_version,
+            items,
+            types_by_name,
+        }
+    }
+
+    /// The ISL version with which this `SchemaDocument` was constructed.
+    pub fn source_version(&self) -> (u8, u8) {
+        self.isl_version
+    }
+
+    /// Iterate all items in this schema definition
+    pub fn items(&self) -> impl Iterator<Item = &SchemaItem> {
+        self.items.iter()
+    }
+
+    /// Get a type from the schema, by name.
+    pub fn get_type(&self, name: &str) -> Option<&TypeDefinition> {
+        self.items.iter().find_map(|item| match item {
+            SchemaItem::Type(type_name, type_def) if name == type_name => Some(type_def),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn get_type_idx_by_name(&self, name: &str) -> Option<usize> {
+        self.items
+            .iter()
+            .enumerate()
+            .find_map(|(idx, item)| match item {
+                SchemaItem::Type(type_name, _) if name == type_name => Some(idx),
+                _ => None,
+            })
+    }
+
+    pub(crate) fn get_type_by_idx(&self, id: usize) -> Option<&TypeDefinition> {
+        let item = self.items.get(id);
+        match item {
+            Some(SchemaItem::Type(_, type_def)) => Some(type_def),
+            _ => None,
+        }
+    }
+}
+
+/// Holds empty types that are states for [`SchemaDocumentBuilder`].
+/// This module is _not_ `pub` so that the type-states are not nameable (for now).
+mod schema_doc_builder_state {
+    pub enum BeforeHeader {}
+    pub enum Types {}
+    pub enum HasFooter {}
+}
+
+#[derive(Debug, Clone)]
+pub struct SchemaDocumentBuilder<V: IslVersion, State> {
+    version: PhantomData<V>,
+    state: PhantomData<State>,
+    items: Vec<SchemaItem>,
+}
+impl<V: IslVersion> SchemaDocumentBuilder<V, BeforeHeader> {
+    fn new() -> Self {
+        SchemaDocumentBuilder {
+            version: PhantomData,
+            state: PhantomData,
+            items: vec![],
+        }
+    }
+
+    pub fn header(mut self, header: Versioned<SchemaHeader, V>) -> SchemaDocumentBuilder<V, Types> {
+        self.items.push(header.into_inner().into());
+        self.change_state()
+    }
+
+    pub fn type_definition(
+        self,
+        name: String,
+        type_def: VersionedTypeDefinition<V>,
+    ) -> SchemaDocumentBuilder<V, Types> {
+        self.change_state::<Types>().type_definition(name, type_def)
+    }
+
+    pub fn footer(self, footer: Versioned<SchemaFooter, V>) -> SchemaDocumentBuilder<V, HasFooter> {
+        self.change_state::<Types>().footer(footer)
+    }
+}
+
+impl<V: IslVersion> SchemaDocumentBuilder<V, Types> {
+    pub fn type_definition<S: Into<String>>(
+        mut self,
+        name: S,
+        type_def: VersionedTypeDefinition<V>,
+    ) -> Self {
+        self.items.push(SchemaItem::Type(
+            name.into(),
+            VersionedTypeDefinition::into_inner(type_def),
+        ));
+        self
+    }
+
+    pub fn footer(
+        mut self,
+        footer: Versioned<SchemaFooter, V>,
+    ) -> SchemaDocumentBuilder<V, HasFooter> {
+        self.items.push(footer.into_inner().into());
+        self.change_state()
+    }
+}
+
+impl<V: IslVersion, S> SchemaDocumentBuilder<V, S> {
+    pub fn open_content(mut self, content: Element) -> SchemaDocumentBuilder<V, S> {
+        // TODO: Check open content
+        self.items.push(content.into());
+        self
+    }
+
+    pub fn build(self) -> SchemaDocument {
+        SchemaDocument::new::<V>(self.items)
+    }
+
+    fn change_state<ToState>(self) -> SchemaDocumentBuilder<V, ToState> {
+        SchemaDocumentBuilder {
+            version: self.version,
+            state: PhantomData,
+            items: self.items,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaFooter {
+    // TODO: Add open content
+}
+impl SchemaFooter {
+    pub fn empty<V: IslVersion>() -> Versioned<SchemaFooter, V> {
+        Versioned::new(SchemaFooter {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::bag::bag;
+    use crate::model::constraints::ContainerLength;
+    use crate::model::TypeDefinitionBuilder;
+    use crate::ISL_2_0;
+
+    #[test]
+    fn test_builder() {
+        let header = SchemaHeader::builder()
+            .import(("foo.isl", "BarType"))
+            .build();
+
+        let schema = SchemaDocument::builder::<ISL_2_0>()
+            .header(header.clone())
+            .type_definition(
+                "quux",
+                TypeDefinitionBuilder::new().container_length(0..5).build(),
+            )
+            .open_content(Element::string("foo"))
+            .footer(SchemaFooter::empty())
+            .build();
+
+        assert_eq!((2, 0), schema.source_version());
+
+        assert_eq!(
+            schema.items.to_vec(),
+            vec![
+                SchemaItem::Header(header.into_inner()),
+                SchemaItem::Type(
+                    "quux".to_string(),
+                    TypeDefinition::new(bag![ContainerLength::new(0..5).into()], bag![])
+                ),
+                SchemaItem::OpenContent(Element::string("foo")),
+                SchemaItem::Footer(SchemaFooter {})
+            ]
+        )
+    }
+}

--- a/ion-schema/src/model/schema_header.rs
+++ b/ion-schema/src/model/schema_header.rs
@@ -1,0 +1,259 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::bag::Bag;
+use crate::{IslVersion, Versioned, ISL_2_0};
+use ion_rs::Element;
+use std::marker::PhantomData;
+
+/// Represents an Ion Schema document header, providing support for schema and type imports in
+/// [ISL 1.0] and [ISL 2.0], and [open content] in ISL 2.0).
+///
+/// [ISL 1.0]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#schema-definitions
+/// [ISL 2.0]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#imports
+/// [open content]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#open-content
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaHeader {
+    imports: Bag<Import>,
+    user_reserved_header_keywords: Bag<String>,
+    user_reserved_type_keywords: Bag<String>,
+    user_reserved_footer_keywords: Bag<String>,
+    open_content: Bag<(String, Element)>,
+}
+
+impl SchemaHeader {
+    pub fn builder<V: IslVersion>() -> SchemaHeaderBuilder<V> {
+        SchemaHeaderBuilder::new()
+    }
+
+    pub fn imports(&self) -> impl Iterator<Item = &Import> {
+        self.imports.iter()
+    }
+
+    pub fn open_content(&self) -> impl Iterator<Item = &(String, Element)> {
+        self.open_content.iter()
+    }
+}
+
+/// Represents an import in a [`SchemaHeader`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Import {
+    schema_id: String,
+    type_import: Option<TypeImport>,
+}
+
+/// Narrows an [`Import`] to a specific type from the source schema, with an optional alias.
+#[derive(Debug, Clone, PartialEq)]
+struct TypeImport {
+    type_name: String,
+    alias: Option<String>,
+}
+impl Import {
+    pub fn schema(schema_id: &str) -> Self {
+        Import {
+            schema_id: schema_id.to_string(),
+            type_import: None,
+        }
+    }
+    pub fn schema_type(schema_id: &str, type_name: &str, alias: Option<&str>) -> Self {
+        Import {
+            schema_id: schema_id.to_string(),
+            type_import: Some(TypeImport {
+                type_name: type_name.to_string(),
+                alias: alias.map(|s| s.to_string()),
+            }),
+        }
+    }
+}
+
+/// Builds a [`SchemaHeader`].
+///
+/// ### Example:
+/// ```
+/// # use ion_schema::model::SchemaHeaderBuilder;
+/// # use ion_schema::ISL_1_0;
+/// # use ion_schema::model::SchemaHeader;
+/// let header = SchemaHeader::builder::<ISL_1_0>()
+///     .import("foo_schema.isl")
+///     .import(("bar_schema.isl", "baz_type"))
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct SchemaHeaderBuilder<V: IslVersion> {
+    version: PhantomData<V>,
+    imports: Vec<Import>,
+    user_reserved_header_keywords: Vec<String>,
+    user_reserved_type_keywords: Vec<String>,
+    user_reserved_footer_keywords: Vec<String>,
+    open_content: Vec<(String, Element)>,
+}
+
+impl<V: IslVersion> Default for SchemaHeaderBuilder<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: IslVersion> SchemaHeaderBuilder<V> {
+    pub fn new() -> Self {
+        SchemaHeaderBuilder {
+            version: PhantomData,
+            imports: vec![],
+            user_reserved_header_keywords: vec![],
+            user_reserved_type_keywords: vec![],
+            user_reserved_footer_keywords: vec![],
+            open_content: vec![],
+        }
+    }
+
+    pub fn import<T: IntoImport>(mut self, import: T) -> Self {
+        self.imports.push(import.into_import());
+        self
+    }
+
+    pub fn build(self) -> Versioned<SchemaHeader, V> {
+        Versioned::new(SchemaHeader {
+            imports: self.imports.into(),
+            user_reserved_header_keywords: self.user_reserved_header_keywords.into(),
+            user_reserved_type_keywords: self.user_reserved_type_keywords.into(),
+            user_reserved_footer_keywords: self.user_reserved_footer_keywords.into(),
+            open_content: self.open_content.into(),
+        })
+    }
+}
+
+impl SchemaHeaderBuilder<ISL_2_0> {
+    pub fn reserve_header_keywords<S: Into<String>, I: IntoIterator<Item = S>>(
+        mut self,
+        keywords: I,
+    ) -> Self {
+        keywords
+            .into_iter()
+            .map(S::into)
+            .for_each(|s| self.user_reserved_header_keywords.push(s));
+        self
+    }
+    pub fn reserve_type_keywords<S: Into<String>, I: IntoIterator<Item = S>>(
+        mut self,
+        keywords: I,
+    ) -> Self {
+        keywords
+            .into_iter()
+            .map(S::into)
+            .for_each(|s| self.user_reserved_type_keywords.push(s));
+        self
+    }
+    pub fn reserve_footer_keywords<S: Into<String>, I: IntoIterator<Item = S>>(
+        mut self,
+        keywords: I,
+    ) -> Self {
+        keywords
+            .into_iter()
+            .map(S::into)
+            .for_each(|s| self.user_reserved_footer_keywords.push(s));
+        self
+    }
+}
+
+/// Can be converted to an [`Import`].
+pub trait IntoImport {
+    fn into_import(self) -> Import;
+}
+impl IntoImport for Import {
+    fn into_import(self) -> Import {
+        self
+    }
+}
+impl IntoImport for &str {
+    fn into_import(self) -> Import {
+        Import::schema(self)
+    }
+}
+impl IntoImport for String {
+    fn into_import(self) -> Import {
+        Import::schema(self.as_str())
+    }
+}
+impl<S: AsRef<str>> IntoImport for (S,) {
+    fn into_import(self) -> Import {
+        Import::schema(self.0.as_ref())
+    }
+}
+impl<S: AsRef<str>, T: AsRef<str>> IntoImport for (S, T) {
+    fn into_import(self) -> Import {
+        Import::schema_type(self.0.as_ref(), self.1.as_ref(), None)
+    }
+}
+impl<S: AsRef<str>, T: AsRef<str>, A: AsRef<str>> IntoImport for (S, T, A) {
+    fn into_import(self) -> Import {
+        Import::schema_type(self.0.as_ref(), self.1.as_ref(), Some(self.2.as_ref()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::bag::bag;
+    use crate::model::{Import, SchemaHeader, SchemaHeaderBuilder};
+    use crate::{ISL_1_0, ISL_2_0};
+
+    #[test]
+    fn test_builder_isl_1_0() {
+        let header = SchemaHeaderBuilder::<ISL_1_0>::new()
+            .import("widget.isl")
+            .import(("foo.isl",))
+            .import(("bar.isl", "TypeA"))
+            .import(("baz.isl", "TypeB", "AliasA"))
+            .build()
+            .into_inner();
+
+        assert_eq!(
+            header,
+            SchemaHeader {
+                imports: bag![
+                    Import::schema("widget.isl"),
+                    Import::schema("foo.isl"),
+                    Import::schema_type("bar.isl", "TypeA", None),
+                    Import::schema_type("baz.isl", "TypeB", Some("AliasA")),
+                ],
+                user_reserved_header_keywords: bag![],
+                user_reserved_type_keywords: bag![],
+                user_reserved_footer_keywords: bag![],
+                open_content: bag![],
+            }
+        )
+    }
+
+    #[test]
+    fn test_builder_isl_2_0() {
+        let header = SchemaHeaderBuilder::<ISL_2_0>::new()
+            .import("widget.isl")
+            .import(("foo.isl",))
+            .import(("bar.isl", "TypeA"))
+            .import(("baz.isl", "TypeB", "AliasA"))
+            .reserve_type_keywords(["foo", "bar"])
+            .reserve_type_keywords(["baz", "bat"])
+            .build()
+            .into_inner();
+
+        assert_eq!(
+            header,
+            SchemaHeader {
+                imports: bag![
+                    Import::schema_type("baz.isl", "TypeB", Some("AliasA")),
+                    Import::schema_type("bar.isl", "TypeA", None),
+                    Import::schema("foo.isl"),
+                    Import::schema("widget.isl"),
+                ],
+                user_reserved_header_keywords: bag![],
+                user_reserved_type_keywords: bag![
+                    "bat".to_string(),
+                    "baz".to_string(),
+                    "bar".to_string(),
+                    "foo".to_string(),
+                ],
+                user_reserved_footer_keywords: bag![],
+                open_content: bag![],
+            }
+        )
+    }
+}

--- a/ion-schema/src/model/type_argument.rs
+++ b/ion-schema/src/model/type_argument.rs
@@ -202,10 +202,10 @@ impl<const N: usize, V: IslVersion, T: Into<VersionedTypeArgument<V>>> From<[T; 
 /// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
 macro_rules! into_type_arg_list {
     ($($t:ident $i:tt),+) => {
-        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedTypeArgumentList<V>
+        impl<V: IslVersion, $($t),+> From<( $($t,)+ )> for VersionedTypeArgumentList<V>
         where $($t: Into<VersionedTypeArgument<V>>,)+
         {
-            fn from(value: ( $($t),+ )) -> Self {
+            fn from(value: ( $($t,)+ )) -> Self {
                 Versioned::new(vec![
                     $(Versioned::into_inner(value.$i.into()),)+
                 ])
@@ -214,6 +214,7 @@ macro_rules! into_type_arg_list {
     };
 }
 
+into_type_arg_list!(A 0);
 into_type_arg_list!(A 0, B 1);
 into_type_arg_list!(A 0, B 1, C 2);
 into_type_arg_list!(A 0, B 1, C 2, D 3);

--- a/ion-schema/src/model/variable_type_argument.rs
+++ b/ion-schema/src/model/variable_type_argument.rs
@@ -142,10 +142,10 @@ impl<const N: usize, V: IslVersion, T: Into<VersionedVariablyOccurringTypeArgume
 /// https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html is stable.
 macro_rules! into_var_type_arg_list {
     ($($t:ident $i:tt),+) => {
-        impl<V: IslVersion, $($t),+> From<( $($t),+ )> for VersionedVariablyOccurringTypeArgumentList<V>
+        impl<V: IslVersion, $($t),+> From<( $($t,)+ )> for VersionedVariablyOccurringTypeArgumentList<V>
         where $($t: Into<VersionedVariablyOccurringTypeArgument<V>>,)+
         {
-            fn from(value: ( $($t),+ )) -> Self {
+            fn from(value: ( $($t,)+ )) -> Self {
                 Versioned::new(vec![
                     $(Versioned::into_inner(value.$i.into()),)+
                 ])
@@ -154,6 +154,7 @@ macro_rules! into_var_type_arg_list {
     };
 }
 
+into_var_type_arg_list!(A 0);
 into_var_type_arg_list!(A 0, B 1);
 into_var_type_arg_list!(A 0, B 1, C 2);
 into_var_type_arg_list!(A 0, B 1, C 2, D 3);


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* Adds `SchemaDocument` and supporting types `SchemaItem`, `SchemaHeader`, `SchemaFooter`, and relevant builders.
* Drive-by improvements for the type argument list `Into` macros
* Make `impl Deref for Versioned` only available for test, and make `into_inner()` a method instead of just an associated function.
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
