### PR TITLE
Adds TypeRefWalker to support type reference resolution

### DIFF
--- a/ion-schema/src/internal_traits.rs
+++ b/ion-schema/src/internal_traits.rs
@@ -5,7 +5,6 @@
 //       instead of being clobbered together.
 
 use crate::result::{invalid_schema_error, IonSchemaResult};
-use crate::type_reference::TypeReference;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
 use std::fmt::Debug;
@@ -29,33 +28,11 @@ pub(crate) trait ValidateInternal {
         R: ViolationRecorder<'top>;
 }
 
-/// Trait for visiting all the type references of things that could have type references.
-///
-/// This can be implemented for things with no type references, and if done so, the implementations
-/// of each function should be a no-op.
-trait HasTypeReferences {
-    /// Recursively visit each [TypeReference] held by self or by members of self.
-    ///
-    /// Used for:
-    ///   - Identifying references to other schemas that may need to be loaded
-    ///   - Ensuring that all references are resolvable
-    fn visit_type_references<F: FnMut(&TypeReference)>(&self, visitor: F);
-
-    /// Recursively visit each [TypeReference] held by self or by members of self.
-    ///
-    /// Used for resolving the type references.
-    fn visit_mut_type_references<F: FnMut(&mut TypeReference)>(&mut self, visitor: F);
-}
-
 // TODO: fields/functions to support
 //  - looking up references in the InvisibleSchemaStore
 //  - any other state or needed for validation
 //  - "validate" configuration options
 pub(crate) struct ValidationContext {}
-
-pub(crate) struct SchemaStore {
-    // TODO: This is a placeholder
-}
 
 /// For internal implementation of serialization.
 ///

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -41,10 +41,11 @@ mod internal_traits;
 mod ion_schema_version;
 mod violation_recorder;
 
-pub mod model;
-
 #[cfg(test)]
 mod test_harness;
+
+pub mod model;
+pub mod resolver;
 
 pub use ion_schema_element::*;
 pub use ion_schema_version::*;

--- a/ion-schema/src/model/constraints/all_of.rs
+++ b/ion-schema/src/model/constraints/all_of.rs
@@ -9,6 +9,7 @@ use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
+use crate::resolver::impl_type_ref_walker;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -26,6 +27,7 @@ impl ConstraintName for AllOf {
 pub struct AllOf {
     type_arguments: Bag<TypeArgument>,
 }
+impl_type_ref_walker!(AllOf, type_arguments);
 
 impl AllOf {
     fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {

--- a/ion-schema/src/model/constraints/annotations/mod.rs
+++ b/ion-schema/src/model/constraints/annotations/mod.rs
@@ -14,6 +14,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, IonType, ValueWriter};
@@ -30,6 +31,31 @@ impl ConstraintName for Annotations {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Annotations {
     variant: AnnotationsVariant,
+}
+impl_type_ref_walker!(Annotations, as_annotations_v2_standard());
+
+impl Annotations {
+    pub fn as_annotations_v1(&self) -> Option<&AnnotationsV1> {
+        if let AnnotationsVariant::V1(variant) = &self.variant {
+            Some(variant)
+        } else {
+            None
+        }
+    }
+    pub fn as_annotations_v2_simple(&self) -> Option<&AnnotationsV2Simple> {
+        if let AnnotationsVariant::V2Simple(variant) = &self.variant {
+            Some(variant)
+        } else {
+            None
+        }
+    }
+    pub fn as_annotations_v2_standard(&self) -> Option<&AnnotationsV2Standard> {
+        if let AnnotationsVariant::V2Standard(variant) = &self.variant {
+            Some(variant)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/ion-schema/src/model/constraints/annotations/v2_standard.rs
+++ b/ion-schema/src/model/constraints/annotations/v2_standard.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::*;
 use crate::model::constraints::annotations::AnnotationsVariant;
 use crate::model::constraints::{Annotations, ReadConstraint};
 use crate::model::{TypeArgument, TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, Versioned, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -17,6 +18,7 @@ use std::ops::ControlFlow;
 pub struct AnnotationsV2Standard {
     annotations_type: TypeArgument,
 }
+impl_type_ref_walker!(AnnotationsV2Standard, annotations_type);
 
 impl AnnotationsV2Standard {
     pub fn annotations_type(&self) -> &TypeArgument {
@@ -38,9 +40,12 @@ impl AnnotationsV2Standard {
 
 impl TypeDefinitionBuilder<ISL_2_0> {
     /// Adds an Ion Schema 2.0 `annotations` constraint using the standard syntax.
-    pub fn annotations_type(self, annotations_type: VersionedTypeArgument<ISL_2_0>) -> Self {
+    pub fn annotations_type<T: Into<VersionedTypeArgument<ISL_2_0>>>(
+        self,
+        annotations_type: T,
+    ) -> Self {
         let constraint = AnnotationsV2Standard {
-            annotations_type: Versioned::into_inner(annotations_type),
+            annotations_type: Versioned::into_inner(annotations_type.into()),
         };
         self.with_constraint(
             Annotations {

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::internal_traits::{ValidateInternal, ValidationContext, WriteAsIsl, WriteContext};
+use crate::internal_traits::{
+    LoaderContext, ValidateInternal, ValidationContext, WriteAsIsl, WriteContext,
+};
 use crate::model::constraints::valid_values::ValidValues;
 use crate::model::constraints::*;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::ValueWriter;
@@ -34,6 +37,15 @@ macro_rules! any_constraint {
             fn from(value: $name) -> Self { AnyConstraint::$name(value) }
         }
         )+
+
+        impl TypeRefWalker for AnyConstraint {
+            fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+                match self {
+                    $(AnyConstraint::$name(constraint) => constraint.walk(visitor),
+                    )+
+                }
+            }
+        }
 
         // Any traits that should be implemented by delegating to the enum variants can be added here.
         impl ValidateInternal for AnyConstraint {

--- a/ion-schema/src/model/constraints/any_of.rs
+++ b/ion-schema/src/model/constraints/any_of.rs
@@ -9,6 +9,7 @@ use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -26,6 +27,7 @@ impl ConstraintName for AnyOf {
 pub struct AnyOf {
     type_arguments: Bag<TypeArgument>,
 }
+impl_type_ref_walker!(AnyOf, type_arguments);
 
 impl AnyOf {
     fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {

--- a/ion-schema/src/model/constraints/byte_length.rs
+++ b/ion-schema/src/model/constraints/byte_length.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -23,6 +24,7 @@ impl ConstraintName for ByteLength {
 pub struct ByteLength {
     range: IonSchemaRange<usize>,
 }
+impl_type_ref_walker!(ByteLength);
 
 impl ByteLength {
     pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/codepoint_length.rs
+++ b/ion-schema/src/model/constraints/codepoint_length.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -23,6 +24,7 @@ impl ConstraintName for CodepointLength {
 pub struct CodepointLength {
     range: IonSchemaRange<usize>,
 }
+impl_type_ref_walker!(CodepointLength);
 
 impl CodepointLength {
     pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/container_length.rs
+++ b/ion-schema/src/model/constraints/container_length.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -23,6 +24,7 @@ impl ConstraintName for ContainerLength {
 pub struct ContainerLength {
     range: IonSchemaRange<usize>,
 }
+impl_type_ref_walker!(ContainerLength);
 
 impl ContainerLength {
     pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/contains.rs
+++ b/ion-schema/src/model/constraints/contains.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, IonData, ValueWriter};
@@ -24,6 +25,7 @@ impl ConstraintName for Contains {
 pub struct Contains {
     values: HashSet<IonData<Element>>,
 }
+impl_type_ref_walker!(Contains);
 
 impl Contains {
     pub(crate) fn new<T: IntoIterator<Item = Element>>(values: T) -> Self {

--- a/ion-schema/src/model/constraints/element.rs
+++ b/ion-schema/src/model/constraints/element.rs
@@ -6,6 +6,7 @@ use crate::ion_schema_version::Versioned;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -26,6 +27,7 @@ pub struct ElementType {
     type_argument: TypeArgument,
     distinct: bool,
 }
+impl_type_ref_walker!(ElementType, type_argument);
 
 impl ElementType {
     pub(crate) fn new<T: Into<TypeArgument>>(distinct: bool, type_argument: T) -> Self {
@@ -45,24 +47,24 @@ impl ElementType {
 }
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
-    pub fn element(self, type_argument: VersionedTypeArgument<V>) -> Self {
+    pub fn element<T: Into<VersionedTypeArgument<V>>>(self, type_argument: T) -> Self {
         let constraint = ElementType {
             distinct: false,
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }
 }
 
 impl TypeDefinitionBuilder<ISL_2_0> {
-    pub fn element_distinct(
+    pub fn element_distinct<T: Into<VersionedTypeArgument<ISL_2_0>>>(
         self,
         distinct: bool,
-        type_argument: VersionedTypeArgument<ISL_2_0>,
+        type_argument: T,
     ) -> Self {
         let constraint = ElementType {
             distinct,
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }

--- a/ion-schema/src/model/constraints/exponent.rs
+++ b/ion-schema/src/model/constraints/exponent.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -22,6 +23,7 @@ impl ConstraintName for Exponent {
 pub struct Exponent {
     range: IonSchemaRange<isize>,
 }
+impl_type_ref_walker!(Exponent);
 
 impl Exponent {
     pub(crate) fn new<T: Into<IonSchemaRange<isize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/field_names.rs
+++ b/ion-schema/src/model/constraints/field_names.rs
@@ -6,6 +6,7 @@ use crate::ion_schema_version::Versioned;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -23,6 +24,7 @@ pub struct FieldNames {
     type_argument: TypeArgument,
     distinct: bool,
 }
+impl_type_ref_walker!(FieldNames, type_argument);
 
 impl FieldNames {
     pub(crate) fn new<T: Into<TypeArgument>>(distinct: bool, type_argument: T) -> Self {
@@ -42,22 +44,22 @@ impl FieldNames {
 }
 
 impl TypeDefinitionBuilder<ISL_2_0> {
-    pub fn field_names(self, type_argument: VersionedTypeArgument<ISL_2_0>) -> Self {
+    pub fn field_names<T: Into<VersionedTypeArgument<ISL_2_0>>>(self, type_argument: T) -> Self {
         let constraint = FieldNames {
             distinct: false,
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }
 
-    pub fn field_names_distinct(
+    pub fn field_names_distinct<T: Into<VersionedTypeArgument<ISL_2_0>>>(
         self,
         distinct: bool,
-        type_argument: VersionedTypeArgument<ISL_2_0>,
+        type_argument: T,
     ) -> Self {
         let constraint = FieldNames {
             distinct,
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }

--- a/ion-schema/src/model/constraints/fields.rs
+++ b/ion-schema/src/model/constraints/fields.rs
@@ -11,6 +11,7 @@ use crate::model::variable_type_argument::{
     VariablyOccurringTypeArgument, VersionedVariablyOccurringTypeArgument,
 };
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -30,6 +31,7 @@ pub struct Fields {
     fields: HashMap<String, VariablyOccurringTypeArgument>,
     is_closed: bool,
 }
+impl_type_ref_walker!(Fields, fields);
 
 impl Fields {
     pub fn fields(&self) -> impl Iterator<Item = (&str, &VariablyOccurringTypeArgument)> {

--- a/ion-schema/src/model/constraints/ieee754_float.rs
+++ b/ion-schema/src/model/constraints/ieee754_float.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, Value, ValueWriter};
@@ -22,6 +23,7 @@ impl ConstraintName for Ieee754Float {
 pub struct Ieee754Float {
     value: FloatingPointNumberFormat,
 }
+impl_type_ref_walker!(Ieee754Float);
 
 impl Ieee754Float {
     pub fn value(&self) -> FloatingPointNumberFormat {

--- a/ion-schema/src/model/constraints/not.rs
+++ b/ion-schema/src/model/constraints/not.rs
@@ -8,6 +8,7 @@ use crate::ion_schema_version::Versioned;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -25,6 +26,7 @@ impl ConstraintName for Not {
 pub struct Not {
     type_argument: TypeArgument,
 }
+impl_type_ref_walker!(Not, type_argument);
 
 impl Not {
     pub(crate) fn new<T: Into<TypeArgument>>(type_argument: T) -> Self {
@@ -39,9 +41,9 @@ impl Not {
 }
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
-    pub fn not(self, type_argument: VersionedTypeArgument<V>) -> Self {
+    pub fn not<T: Into<VersionedTypeArgument<V>>>(self, type_argument: T) -> Self {
         let constraint = Not {
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }

--- a/ion-schema/src/model/constraints/one_of.rs
+++ b/ion-schema/src/model/constraints/one_of.rs
@@ -9,6 +9,7 @@ use crate::model::bag::Bag;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinitionBuilder, VersionedTypeArgumentList};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -26,6 +27,7 @@ impl ConstraintName for OneOf {
 pub struct OneOf {
     type_arguments: Bag<TypeArgument>,
 }
+impl_type_ref_walker!(OneOf, type_arguments);
 
 impl OneOf {
     fn new<T: Into<Bag<TypeArgument>>>(type_arguments: T) -> Self {

--- a/ion-schema/src/model/constraints/ordered_elements.rs
+++ b/ion-schema/src/model/constraints/ordered_elements.rs
@@ -11,6 +11,7 @@ use crate::model::variable_type_argument::{
     VariablyOccurringTypeArgument, VersionedVariablyOccurringTypeArgumentList,
 };
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -28,6 +29,7 @@ impl ConstraintName for OrderedElements {
 pub struct OrderedElements {
     type_arguments: Vec<VariablyOccurringTypeArgument>,
 }
+impl_type_ref_walker!(OrderedElements, type_arguments);
 
 impl OrderedElements {
     pub fn elements(&self) -> impl Iterator<Item = &VariablyOccurringTypeArgument> {

--- a/ion-schema/src/model/constraints/precision.rs
+++ b/ion-schema/src/model/constraints/precision.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -23,6 +24,7 @@ impl ConstraintName for Precision {
 pub struct Precision {
     range: IonSchemaRange<usize>,
 }
+impl_type_ref_walker!(Precision);
 
 impl Precision {
     pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/regex.rs
+++ b/ion-schema/src/model/constraints/regex.rs
@@ -8,6 +8,7 @@ use crate::internal_traits::{
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error_raw, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, Versioned, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -135,6 +136,7 @@ pub struct Regex {
     multiline: bool,
     case_insensitive: bool,
 }
+impl_type_ref_walker!(Regex);
 
 impl PartialEq for Regex {
     fn eq(&self, other: &Self) -> bool {

--- a/ion-schema/src/model/constraints/scale.rs
+++ b/ion-schema/src/model/constraints/scale.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::{IonSchemaRange, TypeDefinitionBuilder};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, ValueWriter};
@@ -22,6 +23,7 @@ impl ConstraintName for Scale {
 pub struct Scale {
     range: IonSchemaRange<isize>,
 }
+impl_type_ref_walker!(Scale);
 
 impl Scale {
     pub(crate) fn new<T: Into<IonSchemaRange<isize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/timestamp_offset.rs
+++ b/ion-schema/src/model/constraints/timestamp_offset.rs
@@ -6,6 +6,7 @@ use crate::internal_traits::{
 };
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -24,6 +25,7 @@ impl ConstraintName for TimestampOffset {
 pub struct TimestampOffset {
     values: HashSet<TimestampOffsetValue>,
 }
+impl_type_ref_walker!(TimestampOffset);
 
 impl TimestampOffset {
     fn new(values: Vec<TimestampOffsetValue>) -> Self {

--- a/ion-schema/src/model/constraints/timestamp_precision.rs
+++ b/ion-schema/src/model/constraints/timestamp_precision.rs
@@ -8,6 +8,7 @@ use crate::ion_extension::ElementExtensions;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder};
 use ion_rs::{Element, IonResult, TimestampPrecision as TSPrecision, ValueWriter, WriteAsIon};
@@ -108,6 +109,7 @@ impl WriteAsIon for TimestampPrecisionValue {
 pub struct TimestampPrecision {
     range: IonSchemaRange<i64>,
 }
+impl_type_ref_walker!(TimestampPrecision);
 
 impl TimestampPrecision {
     pub(crate) fn new<T: Into<IonSchemaRange<TimestampPrecisionValue>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/type_constraint.rs
+++ b/ion-schema/src/model/constraints/type_constraint.rs
@@ -8,6 +8,7 @@ use crate::ion_schema_version::Versioned;
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::type_argument::TypeArgument;
 use crate::model::{TypeDefinition, TypeDefinitionBuilder, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -25,6 +26,7 @@ use std::ops::ControlFlow;
 pub struct TypeConstraint {
     type_argument: TypeArgument,
 }
+impl_type_ref_walker!(TypeConstraint, type_argument);
 
 impl TypeConstraint {
     pub(crate) fn new<T: Into<TypeArgument>>(type_argument: T) -> Self {
@@ -43,9 +45,9 @@ impl ConstraintName for TypeConstraint {
 }
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
-    pub fn type_constraint(self, type_argument: VersionedTypeArgument<V>) -> Self {
+    pub fn type_constraint<T: Into<VersionedTypeArgument<V>>>(self, type_argument: T) -> Self {
         let constraint = TypeConstraint {
-            type_argument: Versioned::into_inner(type_argument),
+            type_argument: Versioned::into_inner(type_argument.into()),
         };
         self.with_constraint(constraint.into())
     }

--- a/ion-schema/src/model/constraints/utf8_byte_length.rs
+++ b/ion-schema/src/model/constraints/utf8_byte_length.rs
@@ -7,6 +7,7 @@ use crate::internal_traits::{
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationInfo, ViolationRecorder};
 use ion_rs::{Element, ValueWriter};
@@ -20,6 +21,7 @@ use std::ops::ControlFlow;
 pub struct Utf8ByteLength {
     range: IonSchemaRange<usize>,
 }
+impl_type_ref_walker!(Utf8ByteLength);
 
 impl Utf8ByteLength {
     pub(crate) fn new<T: Into<IonSchemaRange<usize>>>(range: T) -> Self {

--- a/ion-schema/src/model/constraints/valid_values.rs
+++ b/ion-schema/src/model/constraints/valid_values.rs
@@ -6,6 +6,7 @@ use crate::model::bag::{bag, Bag};
 use crate::model::constraints::{ConstraintName, ReadConstraint};
 use crate::model::ranges::IonSchemaRange;
 use crate::model::TypeDefinitionBuilder;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaResult};
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder};
 use ion_rs::{Decimal, Element, SequenceWriter, Timestamp, ValueWriter};
@@ -26,6 +27,7 @@ pub struct ValidValues {
     // TODO: Use a Set once Timestamp and Decimal implement Hash
     values: Bag<ValidValuesArgument>,
 }
+impl_type_ref_walker!(ValidValues);
 
 impl ValidValues {
     pub fn values(&self) -> impl Iterator<Item = &ValidValuesArgument> {

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -11,7 +11,7 @@ mod type_definition;
 mod type_reference;
 mod variable_type_argument;
 
-use bag::*;
+pub(crate) use bag::*;
 pub use ranges::*;
 pub use schema::*;
 pub use schema_header::*;

--- a/ion-schema/src/model/schema.rs
+++ b/ion-schema/src/model/schema.rs
@@ -3,6 +3,7 @@
 
 use crate::model::schema::schema_doc_builder_state::{BeforeHeader, HasFooter, Types};
 use crate::model::{SchemaHeader, TypeDefinition, VersionedTypeDefinition};
+use crate::resolver::*;
 use crate::{IslVersion, Versioned};
 use ion_rs::Element;
 use std::collections::HashMap;
@@ -31,6 +32,14 @@ impl From<Element> for SchemaItem {
     }
 }
 
+impl TypeRefWalker for SchemaItem {
+    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+        if let SchemaItem::Type(_, t) = self {
+            t.walk(visitor)
+        }
+    }
+}
+
 /// Represents an Ion Schema document.
 ///
 /// A schema is a collection of types that can be used to constrain the Ion data model.
@@ -41,6 +50,7 @@ pub struct SchemaDocument {
     items: Vec<SchemaItem>,
     types_by_name: HashMap<String, usize>,
 }
+impl_type_ref_walker!(SchemaDocument, items);
 
 impl SchemaDocument {
     pub fn builder<V: IslVersion>() -> SchemaDocumentBuilder<V, BeforeHeader> {
@@ -129,9 +139,9 @@ impl<V: IslVersion> SchemaDocumentBuilder<V, BeforeHeader> {
         self.change_state()
     }
 
-    pub fn type_definition(
+    pub fn type_definition<S: Into<String>>(
         self,
-        name: String,
+        name: S,
         type_def: VersionedTypeDefinition<V>,
     ) -> SchemaDocumentBuilder<V, Types> {
         self.change_state::<Types>().type_definition(name, type_def)

--- a/ion-schema/src/model/type_argument.rs
+++ b/ion-schema/src/model/type_argument.rs
@@ -7,6 +7,7 @@ use crate::isl::isl_type_reference::NullabilityModifier;
 use crate::model::type_definition::TypeDefinition;
 use crate::model::type_reference::TypeReference;
 use crate::model::VersionedTypeDefinition;
+use crate::resolver::*;
 use crate::result::{invalid_schema_error, IonSchemaResult};
 use crate::{IslVersion, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, Value, ValueWriter};
@@ -48,6 +49,15 @@ impl TypeArgument {
 enum TypeArgumentKind {
     TypeReference(TypeReference),
     InlineType(TypeDefinition),
+}
+
+impl TypeRefWalker for TypeArgument {
+    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+        match &self.kind {
+            TypeArgumentKind::TypeReference(ref type_ref) => visitor.visit(type_ref),
+            TypeArgumentKind::InlineType(type_def) => type_def.walk(visitor),
+        }
+    }
 }
 
 impl<V: IslVersion> WriteAsIsl<V> for TypeArgument

--- a/ion-schema/src/model/type_definition.rs
+++ b/ion-schema/src/model/type_definition.rs
@@ -7,6 +7,7 @@ use crate::internal_traits::{
 use crate::ion_schema_version::Versioned;
 use crate::model::bag::Bag;
 use crate::model::constraints::*;
+use crate::resolver::impl_type_ref_walker;
 use crate::result::IonSchemaResult;
 use crate::{IonSchemaElement, IslVersion, ViolationRecorder, ISL_1_0, ISL_2_0};
 use ion_rs::{Element, IonData, StructWriter, Symbol, ValueWriter};
@@ -57,6 +58,7 @@ pub struct TypeDefinitionBuilder<V: IslVersion> {
     open_content: Vec<(Symbol, IonData<Element>)>,
     isl_version: PhantomData<V>,
 }
+impl_type_ref_walker!(TypeDefinition, constraints);
 
 impl<V: IslVersion> TypeDefinitionBuilder<V> {
     pub(crate) fn new() -> Self {

--- a/ion-schema/src/model/variable_type_argument.rs
+++ b/ion-schema/src/model/variable_type_argument.rs
@@ -5,6 +5,7 @@ use crate::internal_traits::{WriteAsIsl, WriteContext};
 use crate::ion_schema_version::Versioned;
 use crate::model::type_definition::TypeDefinition;
 use crate::model::{IonSchemaRange, TypeArgument, VersionedTypeArgument};
+use crate::resolver::*;
 use crate::result::IonSchemaResult;
 use crate::IslVersion;
 use ion_rs::ValueWriter;
@@ -15,6 +16,7 @@ pub struct VariablyOccurringTypeArgument {
     occurs: IonSchemaRange<usize>,
     type_argument: TypeArgument,
 }
+impl_type_ref_walker!(VariablyOccurringTypeArgument, type_argument);
 
 impl VariablyOccurringTypeArgument {
     pub fn occurs<R: Into<IonSchemaRange<usize>>>(

--- a/ion-schema/src/resolver/mod.rs
+++ b/ion-schema/src/resolver/mod.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::SchemaDocument;
+
+mod type_ref_visitor;
+
+pub(crate) use type_ref_visitor::*;
+
+#[derive(Debug)]
+pub(crate) struct SchemaStore {
+    schemas: Vec<(String, SchemaDocument)>,
+}

--- a/ion-schema/src/resolver/type_ref_visitor.rs
+++ b/ion-schema/src/resolver/type_ref_visitor.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::Bag;
+use crate::model::TypeReference;
+use std::collections::HashMap;
+
+/// A visitor for [`TypeReference`]s in a [`SchemaDocument`], used for resolving schema references.
+pub(crate) trait TypeRefVisitor {
+    /// Visits a single [`TypeReference`].
+    fn visit(&mut self, type_ref: &TypeReference);
+}
+
+impl<F: FnMut(&TypeReference)> TypeRefVisitor for F {
+    fn visit(&mut self, type_ref: &TypeReference) {
+        self(type_ref)
+    }
+}
+
+/// A trait indicating that a type can walk a [`TypeRefVisitor`], possibly to [`TypeReferences`].
+pub(crate) trait TypeRefWalker {
+    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V);
+}
+
+/// A macro that implements [`TypeRefWalker`] for container types that have an `iter()` method.
+macro_rules! has_n_type_refs {
+    ($t:ident) => {
+        impl<T: TypeRefWalker> TypeRefWalker for $t<T> {
+            fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+                self.iter().for_each(|item| item.walk(visitor))
+            }
+        }
+    };
+}
+has_n_type_refs!(Vec);
+has_n_type_refs!(Bag);
+has_n_type_refs!(Option);
+
+impl<T: TypeRefWalker> TypeRefWalker for &T {
+    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+        <T as TypeRefWalker>::walk(self, visitor)
+    }
+}
+
+impl<K, T: TypeRefWalker> TypeRefWalker for HashMap<K, T> {
+    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+        self.iter().for_each(|(_, item)| item.walk(visitor))
+    }
+}
+
+/// A macro that implements [`TypeRefWalker`]. The first argument is the type for which to implement
+/// the trait. The second argument is an expression (relative to `self`) that accesses a single
+/// field that _indirectly_ contains type references.
+macro_rules! impl_type_ref_walker {
+    ($t:ty) => {
+        impl crate::resolver::TypeRefWalker for $t {
+            fn walk<V: crate::resolver::TypeRefVisitor>(&self, visitor: &mut V) {
+            }
+        }
+    };
+    ($t:ty, $($accessor:tt)+) => {
+        impl crate::resolver::TypeRefWalker for $t {
+            fn walk<V: crate::resolver::TypeRefVisitor>(&self, visitor: &mut V) {
+                self.$($accessor)+.walk(visitor);
+            }
+        }
+    };
+}
+pub(crate) use impl_type_ref_walker;

--- a/ion-schema/src/violation_recorder.rs
+++ b/ion-schema/src/violation_recorder.rs
@@ -14,7 +14,7 @@ use std::ops::ControlFlow;
 /// The `accept` method returns [`ControlFlow`] to allow implementations to determine whether
 /// validation should continue after each violation.
 ///
-/// This crate provides implementations for [Option<ViolationInfo>] and [Vec<ViolationInfo>].
+/// This crate provides implementations for [`Option<ViolationInfo>`] and [`Vec<ViolationInfo>`].
 ///
 /// # Example
 ///


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* Creates a `resolver` module
* Moves `SchemaStore` to the resolver module
* Moves/refactors `HasTypeReferences` into `TypeRefVisitor` and `TypeRefWalker`
* Add `TypeRefWalker` implementations for the whole model
* Updates a few builder methods that had ugly signatures—e.g. they were using a specific type `Something` instead of `T: Into<Something>`.
* Minor fix in `violation_recorder.rs` to get `cargo doc` to stop complaining about unclosed HTML tags.


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
