### PR TITLE
Adds resolve function, ResolvedSchema, and ResolvedType

### DIFF
--- a/ion-schema/src/model/bag.rs
+++ b/ion-schema/src/model/bag.rs
@@ -58,6 +58,10 @@ impl<T> Bag<T> {
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.items.iter()
     }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.items.iter_mut()
+    }
 }
 
 impl<T> IntoIterator for Bag<T> {

--- a/ion-schema/src/model/constraints/annotations/mod.rs
+++ b/ion-schema/src/model/constraints/annotations/mod.rs
@@ -32,7 +32,7 @@ impl ConstraintName for Annotations {
 pub struct Annotations {
     variant: AnnotationsVariant,
 }
-impl_type_ref_walker!(Annotations, as_annotations_v2_standard());
+impl_type_ref_walker!(Annotations, as_annotations_v2_standard_mut());
 
 impl Annotations {
     pub fn as_annotations_v1(&self) -> Option<&AnnotationsV1> {
@@ -51,6 +51,14 @@ impl Annotations {
     }
     pub fn as_annotations_v2_standard(&self) -> Option<&AnnotationsV2Standard> {
         if let AnnotationsVariant::V2Standard(variant) = &self.variant {
+            Some(variant)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_annotations_v2_standard_mut(&mut self) -> Option<&mut AnnotationsV2Standard> {
+        if let AnnotationsVariant::V2Standard(ref mut variant) = &mut self.variant {
             Some(variant)
         } else {
             None

--- a/ion-schema/src/model/constraints/any_constraint.rs
+++ b/ion-schema/src/model/constraints/any_constraint.rs
@@ -39,7 +39,7 @@ macro_rules! any_constraint {
         )+
 
         impl TypeRefWalker for AnyConstraint {
-            fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+            fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
                 match self {
                     $(AnyConstraint::$name(constraint) => constraint.walk(visitor),
                     )+

--- a/ion-schema/src/model/mod.rs
+++ b/ion-schema/src/model/mod.rs
@@ -18,3 +18,4 @@ pub use schema_header::*;
 pub use type_argument::*;
 pub use type_definition::*;
 pub use type_reference::*;
+pub use variable_type_argument::*;

--- a/ion-schema/src/model/schema.rs
+++ b/ion-schema/src/model/schema.rs
@@ -84,12 +84,42 @@ impl SchemaDocument {
         self.items.iter()
     }
 
+    /// Iterate all types declared in this schema document
+    pub fn types(&self) -> impl Iterator<Item = (&str, &TypeDefinition)> {
+        self.items.iter().filter_map(|item| match item {
+            SchemaItem::Type(name, def) => Some((name.as_str(), def)),
+            _ => None,
+        })
+    }
+
+    /// Gets the [`SchemaHeader`], if this schema document has a header.
+    pub fn header(&self) -> Option<&SchemaHeader> {
+        self.items.iter().find_map(|item| {
+            if let SchemaItem::Header(header) = item {
+                Some(header)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Get a type from the schema, by name.
     pub fn get_type(&self, name: &str) -> Option<&TypeDefinition> {
         self.items.iter().find_map(|item| match item {
             SchemaItem::Type(type_name, type_def) if name == type_name => Some(type_def),
             _ => None,
         })
+    }
+
+    /// Iterate all types declared in this schema definition
+    pub(crate) fn indexed_type_names(&self) -> impl Iterator<Item = (usize, &String)> {
+        self.items
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| match item {
+                SchemaItem::Type(name, _) => Some((idx, name)),
+                _ => None,
+            })
     }
 
     pub(crate) fn get_type_idx_by_name(&self, name: &str) -> Option<usize> {

--- a/ion-schema/src/model/schema.rs
+++ b/ion-schema/src/model/schema.rs
@@ -33,7 +33,7 @@ impl From<Element> for SchemaItem {
 }
 
 impl TypeRefWalker for SchemaItem {
-    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+    fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
         if let SchemaItem::Type(_, t) = self {
             t.walk(visitor)
         }

--- a/ion-schema/src/model/schema_header.rs
+++ b/ion-schema/src/model/schema_header.rs
@@ -64,6 +64,25 @@ impl Import {
             }),
         }
     }
+
+    /// The Schema ID that this [`Import`] is targeting.
+    pub fn schema_id(&self) -> &str {
+        &self.schema_id
+    }
+
+    /// The (optional) type that this [`Import`] is targeting.
+    pub fn type_name(&self) -> Option<&str> {
+        self.type_import
+            .as_ref()
+            .map(|type_import| type_import.type_name.as_str())
+    }
+
+    /// The (optional) alias for the type that this [`Import`] is targeting.
+    pub fn type_alias(&self) -> Option<&str> {
+        self.type_import
+            .as_ref()
+            .and_then(|type_import| type_import.alias.as_deref())
+    }
 }
 
 /// Builds a [`SchemaHeader`].

--- a/ion-schema/src/model/type_argument.rs
+++ b/ion-schema/src/model/type_argument.rs
@@ -52,10 +52,10 @@ enum TypeArgumentKind {
 }
 
 impl TypeRefWalker for TypeArgument {
-    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
-        match &self.kind {
-            TypeArgumentKind::TypeReference(ref type_ref) => visitor.visit(type_ref),
-            TypeArgumentKind::InlineType(type_def) => type_def.walk(visitor),
+    fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
+        match &mut self.kind {
+            TypeArgumentKind::TypeReference(ref mut type_ref) => visitor.visit(type_ref),
+            TypeArgumentKind::InlineType(ref mut type_def) => type_def.walk(visitor),
         }
     }
 }

--- a/ion-schema/src/model/type_reference.rs
+++ b/ion-schema/src/model/type_reference.rs
@@ -18,7 +18,9 @@ pub struct TypeReference {
 }
 
 impl TypeReference {
-    fn new<S: Into<String>>(type_name: S) -> Self {
+    /// Creates a `TypeReference` for a type name that is defined in or imported to the current
+    /// [`SchemaDocument`].
+    fn local<S: Into<String>>(type_name: S) -> Self {
         TypeReference {
             schema_id: None,
             type_name: type_name.into(),
@@ -26,6 +28,7 @@ impl TypeReference {
         }
     }
 
+    /// Creates a `TypeReference` that is an inline import from another schema.
     pub fn imported<A: Into<String>, B: Into<String>>(schema_id: A, type_name: B) -> Self {
         TypeReference {
             schema_id: Some(schema_id.into()),
@@ -46,14 +49,15 @@ impl TypeReference {
         self.resolved_type_coordinates
     }
 
-    pub(crate) fn resolve_type_coordinates(&mut self, type_coordinates: Option<TypeCoordinates>) {
+    /// Sets the [`TypeCoordinates`] of this `TypeReference`.
+    pub(crate) fn set_type_coordinates(&mut self, type_coordinates: Option<TypeCoordinates>) {
         self.resolved_type_coordinates = type_coordinates
     }
 }
 
 impl<T: Into<String>> From<T> for TypeReference {
     fn from(value: T) -> Self {
-        TypeReference::new(value)
+        TypeReference::local(value)
     }
 }
 
@@ -110,7 +114,7 @@ mod tests {
     #[test]
     fn from_string() {
         let from_value = "foo";
-        let expected = TypeReference::new("foo");
+        let expected = TypeReference::local("foo");
         assert_eq!(expected, from_value.into())
     }
 
@@ -126,7 +130,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::type_name("foo", TypeReference::new("foo"))]
+    #[case::type_name("foo", TypeReference::local("foo"))]
     #[case::inline_import("{id:\"foo.isl\",type:bar}", TypeReference::imported("foo.isl", "bar"))]
     fn type_reference_try_read_ok(#[case] ion: &str, #[case] expected: TypeReference) {
         let expected = Ok(expected);

--- a/ion-schema/src/model/type_reference.rs
+++ b/ion-schema/src/model/type_reference.rs
@@ -3,7 +3,7 @@
 
 use crate::internal_traits::{LoaderContext, ReadFromIsl, WriteAsIsl, WriteContext};
 use crate::ion_extension::StructExtensions;
-use crate::model::type_definition::TypeDefinition;
+use crate::resolver::TypeCoordinates;
 use crate::result::{invalid_schema_error, IonSchemaResult};
 use crate::IslVersion;
 use ion_rs::{Element, StructWriter, Value, ValueWriter};
@@ -13,17 +13,24 @@ use ion_rs::{Element, StructWriter, Value, ValueWriter};
 pub struct TypeReference {
     schema_id: Option<String>,
     type_name: String,
-    // Not exposed in public API.
-    // Initially `None`, but changed to `Some(_)` when resolving the schemas
-    // TODO: resolved: Cell<Option<...>>,
+    // Not exposed in public API. Initially `None`, but changed to `Some(_)` when resolving the schemas
+    resolved_type_coordinates: Option<TypeCoordinates>,
 }
 
 impl TypeReference {
-    // TODO: Determine if this needs to be pub
-    pub(crate) fn imported<A: Into<String>, B: Into<String>>(schema_id: A, type_name: B) -> Self {
+    fn new<S: Into<String>>(type_name: S) -> Self {
+        TypeReference {
+            schema_id: None,
+            type_name: type_name.into(),
+            resolved_type_coordinates: None,
+        }
+    }
+
+    pub fn imported<A: Into<String>, B: Into<String>>(schema_id: A, type_name: B) -> Self {
         TypeReference {
             schema_id: Some(schema_id.into()),
             type_name: type_name.into(),
+            resolved_type_coordinates: None,
         }
     }
 
@@ -35,20 +42,18 @@ impl TypeReference {
         self.type_name.as_str()
     }
 
-    /// Returns an immutable borrow of the [TypeDefinition] to which this [TypeReference] refers.
-    pub fn get(&self) -> Option<&TypeDefinition> {
-        todo!()
+    pub(crate) fn type_coordinates(&self) -> Option<TypeCoordinates> {
+        self.resolved_type_coordinates
     }
 
-    // TODO: functions for setting the resolved type
+    pub(crate) fn resolve_type_coordinates(&mut self, type_coordinates: Option<TypeCoordinates>) {
+        self.resolved_type_coordinates = type_coordinates
+    }
 }
 
 impl<T: Into<String>> From<T> for TypeReference {
     fn from(value: T) -> Self {
-        TypeReference {
-            schema_id: None,
-            type_name: value.into(),
-        }
+        TypeReference::new(value)
     }
 }
 
@@ -105,10 +110,7 @@ mod tests {
     #[test]
     fn from_string() {
         let from_value = "foo";
-        let expected = TypeReference {
-            schema_id: None,
-            type_name: "foo".to_string(),
-        };
+        let expected = TypeReference::new("foo");
         assert_eq!(expected, from_value.into())
     }
 
@@ -118,13 +120,14 @@ mod tests {
         let expected = TypeReference {
             schema_id: Some("foo".to_string()),
             type_name: "bar".to_string(),
+            resolved_type_coordinates: None,
         };
         assert_eq!(expected, actual)
     }
 
     #[rstest]
-    #[case::type_name("foo", TypeReference { schema_id: None, type_name: "foo".to_string() })]
-    #[case::inline_import("{id:\"foo.isl\",type:bar}", TypeReference { schema_id: Some("foo.isl".to_string()), type_name: "bar".to_string() } )]
+    #[case::type_name("foo", TypeReference::new("foo"))]
+    #[case::inline_import("{id:\"foo.isl\",type:bar}", TypeReference::imported("foo.isl", "bar"))]
     fn type_reference_try_read_ok(#[case] ion: &str, #[case] expected: TypeReference) {
         let expected = Ok(expected);
         let element = Element::read_one(ion).unwrap();

--- a/ion-schema/src/resolver/mod.rs
+++ b/ion-schema/src/resolver/mod.rs
@@ -3,11 +3,39 @@
 
 use crate::model::SchemaDocument;
 
+mod resolve_fn;
+mod resolved_schema;
 mod type_ref_visitor;
 
+pub use resolve_fn::resolve;
+pub use resolve_fn::unresolve;
+pub use resolved_schema::*;
 pub(crate) use type_ref_visitor::*;
+
+/// A schema index and type index.
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub(crate) struct TypeCoordinates(usize, usize);
+impl TypeCoordinates {
+    #[cfg(test)]
+    pub(crate) fn new(s_idx: usize, t_idx: usize) -> Self {
+        TypeCoordinates(s_idx, t_idx)
+    }
+
+    fn schema_idx(&self) -> usize {
+        self.0
+    }
+    fn type_idx(&self) -> usize {
+        self.1
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct SchemaStore {
     schemas: Vec<(String, SchemaDocument)>,
+}
+
+impl SchemaStore {
+    pub(crate) fn get_schema(&self, schema_idx: usize) -> &SchemaDocument {
+        &self.schemas[schema_idx].1
+    }
 }

--- a/ion-schema/src/resolver/resolve_fn.rs
+++ b/ion-schema/src/resolver/resolve_fn.rs
@@ -11,17 +11,17 @@ use std::sync::Arc;
 
 // Private type aliases
 type Map<K, V> = HashMap<K, V>;
-type CoordinatesMap<'a> = Map<&'a str, TypeCoordinates>;
+type CoordinatesMap = Map<String, TypeCoordinates>;
 type SchemaSlice = [(String, SchemaDocument)];
 
 /// Builds a lookup table for the type coordinates of all types declared in all schemas.
-fn build_global_coordinates(schemas: &SchemaSlice) -> Map<&str, CoordinatesMap> {
+fn build_global_coordinates(schemas: &SchemaSlice) -> Map<String, CoordinatesMap> {
     schemas
         .iter()
         .enumerate()
         .map(|(schema_idx, (schema_id, _))| {
             (
-                schema_id.as_str(),
+                schema_id.to_string(),
                 build_locally_declared_coordinates(schema_idx, schemas),
             )
         })
@@ -29,24 +29,21 @@ fn build_global_coordinates(schemas: &SchemaSlice) -> Map<&str, CoordinatesMap> 
 }
 
 /// Builds a lookup table for the type coordinates of all locally declared types
-fn build_locally_declared_coordinates(
-    schema_idx: usize,
-    schemas: &SchemaSlice,
-) -> Map<&str, TypeCoordinates> {
+fn build_locally_declared_coordinates(schema_idx: usize, schemas: &SchemaSlice) -> CoordinatesMap {
     let (_, schema_doc) = &schemas[schema_idx];
     schema_doc
         .indexed_type_names()
-        .map(|(type_idx, type_name)| (type_name.as_str(), TypeCoordinates(schema_idx, type_idx)))
+        .map(|(type_idx, type_name)| (type_name.to_string(), TypeCoordinates(schema_idx, type_idx)))
         .collect()
 }
 
 /// Builds a lookup table for the type coordinates of all types that are visible _within_ the schema
 /// specified by [`schema_idx`]
-fn build_locally_available_coordinates<'a>(
-    global_coordinates: &'a Map<&'a str, CoordinatesMap<'a>>,
+fn build_locally_available_coordinates(
+    global_coordinates: &Map<String, CoordinatesMap>,
     schema_idx: usize,
-    schemas: &'a SchemaSlice,
-) -> IonSchemaResult<Map<&'a str, TypeCoordinates>> {
+    schemas: &SchemaSlice,
+) -> IonSchemaResult<CoordinatesMap> {
     let mut coordinates = build_locally_declared_coordinates(schema_idx, schemas);
     let (schema_name, schema_doc) = &schemas[schema_idx];
     let Some(header) = schema_doc.header() else {
@@ -54,7 +51,7 @@ fn build_locally_available_coordinates<'a>(
     };
 
     for import in header.imports() {
-        let imported_schema_name = import.schema_id();
+        let imported_schema_name = import.schema_id().to_string();
         if let Some(type_name) = import.type_name() {
             let tc = global_coordinates
                 .get(&imported_schema_name)
@@ -63,7 +60,7 @@ fn build_locally_available_coordinates<'a>(
                         "Cannot resolve schema '{imported_schema_name}'. Was it loaded?",
                     ))
                 })?
-                .get(type_name)
+                .get(&type_name.to_string())
                 .ok_or_else(|| {
                     invalid_schema_error_raw(format!(
                         "Type '{type_name}' in '{imported_schema_name}' does not exist."
@@ -74,7 +71,7 @@ fn build_locally_available_coordinates<'a>(
             } else {
                 type_name
             };
-            if coordinates.insert(local_name, *tc).is_some() {
+            if coordinates.insert(local_name.to_string(), *tc).is_some() {
                 invalid_schema_error(format!("name conflict for type '{local_name}' imported from '{imported_schema_name}' in schema '{schema_name}'"))?;
             }
         } else {
@@ -89,7 +86,7 @@ fn build_locally_available_coordinates<'a>(
                 })?;
 
             for (local_name, tc) in imported_types.iter() {
-                if let Some(name_conflict) = coordinates.insert(local_name, *tc) {
+                if let Some(name_conflict) = coordinates.insert(local_name.to_string(), *tc) {
                     let (conflict_schema_name, _) = &schemas[name_conflict.0];
                     invalid_schema_error(format!("name conflict in schema '{schema_name}' for type '{local_name}' declared in '{imported_schema_name}' and '{conflict_schema_name}'"))?;
                 }
@@ -103,13 +100,13 @@ fn build_locally_available_coordinates<'a>(
 /// Attempts to resolve the type references in one or more [`SchemaDocument`]s, returning an
 /// equivalent map containing [`ResolvedSchema`]s rather than [`SchemaDocument`]s.
 pub fn resolve(
-    schemas: HashMap<String, SchemaDocument>,
-) -> IonSchemaResult<HashMap<String, ResolvedSchema>> {
-    if schemas.is_empty() {
-        return Ok(HashMap::new());
-    }
-
+    schemas: impl IntoIterator<Item = (String, SchemaDocument)>,
+) -> IonSchemaResult<impl Iterator<Item = (String, ResolvedSchema)>> {
     let mut schemas: Vec<_> = schemas.into_iter().collect();
+
+    if schemas.is_empty() {
+        return Ok(vec![].into_iter());
+    }
 
     if cfg!(test) {
         // This is not necessary for correctness. It just ensures that the type coordinates are stable
@@ -127,11 +124,18 @@ pub fn resolve(
 
     let mut type_resolution_errors = vec![];
 
-    for (schema_idx, (schema_name, schema)) in schemas.iter().enumerate() {
-        let local_type_coordinates =
-            build_locally_available_coordinates(&global_type_coordinates, schema_idx, &schemas)?;
+    let locally_available_coordinates: Vec<_> = schemas
+        .iter()
+        .enumerate()
+        .map(|(schema_idx, (schema_id, schema))| {
+            build_locally_available_coordinates(&global_type_coordinates, schema_idx, &schemas)
+        })
+        .collect::<IonSchemaResult<_>>()?;
 
-        schema.walk(&mut |tr: &TypeReference| {
+    for (schema_idx, (schema_name, schema)) in schemas.iter_mut().enumerate() {
+        let local_type_coordinates = locally_available_coordinates.get(schema_idx).unwrap();
+
+        schema.walk(&mut |tr: &mut TypeReference| {
             let type_name = tr.type_name();
             let type_ref_coordinates = if let Some(imported_schema_id) = tr.schema_id() {
                 global_type_coordinates
@@ -160,29 +164,7 @@ pub fn resolve(
                     .copied()
             };
             match type_ref_coordinates {
-                Ok(tc) => {
-                    // SAFETY: This is safe because
-                    //  * All the data is fully owned within this function while this happens
-                    //  * We know there is no concurrent access to this
-                    //
-                    // we know that there is no concurrent access to the type references.
-                    //
-                    // This is necessary because
-                    //  * We can't just use `&mut TypeReference` because we run into conflicting borrows
-                    //    because the loop would have to iterate over mutable references, but the global
-                    //    and local coordinate maps require an immutable borrow at the same time in order
-                    //    to borrow the schema and type names.
-                    //  * The solution is interior mutability, but we don't want type references to use
-                    //    Cell because then they are not Sync, and we don't want to use Mutex because
-                    //    TypeReferences are in the hot path for validation.
-                    //  * Thankfully, we don't need the TypeReferences to have interior mutability all
-                    //    the time. It's only necessary for resolving (and un-resolving) the type references.
-                    //  * So instead, we just have a limited scope for treating this as immutable.
-                    //
-                    // We could also work around this by creating a "WhileBeingResolvedSchema" that
-                    // uses `Cell` to hold `TypeDefinition`s, but that's a lot of boilerplate code.
-                    unsafe { as_mutable(tr).resolve_type_coordinates(Some(tc)) }
-                }
+                Ok(tc) => tr.set_type_coordinates(Some(tc)),
                 Err(e) => type_resolution_errors.push(e),
             }
         });
@@ -193,14 +175,14 @@ pub fn resolve(
         IonSchemaResult::Err(type_resolution_errors.into_iter().next().unwrap())?;
     }
 
-    let schemas = schemas.into_iter().collect();
-
     let schema_store = Arc::new(SchemaStore { schemas });
 
-    Ok(schema_idx_by_name
+    let result: Vec<_> = schema_idx_by_name
         .into_iter()
         .map(|(name, index)| (name, ResolvedSchema::new(schema_store.clone(), index)))
-        .collect())
+        .collect();
+
+    Ok(result.into_iter())
 }
 
 /// Un-resolves the schemas and returns ownership of the underlying [`SchemaDocument`]s to the caller,
@@ -209,35 +191,27 @@ pub fn resolve(
 /// If there are any un-dropped `ResolvedSchema` or `ResolvedType` that depend on the underlying
 /// `SchemaDocument`s that are _not_ passed into this function, the function will return `None`.
 pub fn unresolve(
-    schemas: HashMap<String, ResolvedSchema>,
-) -> Option<HashMap<String, SchemaDocument>> {
+    schemas: impl IntoIterator<Item = (String, ResolvedSchema)>,
+) -> Option<impl Iterator<Item = (String, SchemaDocument)>> {
+    let schemas: Vec<_> = schemas.into_iter().collect();
     if schemas.is_empty() {
-        return Some(HashMap::new());
+        return Some(vec![].into_iter());
     }
 
-    let (_, any_resolved_schema) = schemas.iter().next().unwrap();
+    let (_, any_resolved_schema) = schemas.first().unwrap();
     let schema_store = any_resolved_schema.schema_store();
 
     drop(schemas);
 
-    let unresolved_schemas = Arc::into_inner(schema_store)?
+    let unresolved_schemas: Vec<_> = Arc::into_inner(schema_store)?
         .schemas
         .into_iter()
-        .map(|(name, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                // SAFETY: See note in [`resolve`]. Justification is the same.
-                unsafe { as_mutable(tr).resolve_type_coordinates(None) }
-            });
+        .map(|(name, mut schema)| {
+            schema.walk(&mut |tr: &mut TypeReference| tr.set_type_coordinates(None));
             (name, schema)
         })
         .collect();
-    Some(unresolved_schemas)
-}
-
-/// Cast an immutable reference to a mutable reference.
-#[allow(clippy::mut_from_ref)]
-unsafe fn as_mutable<T: ?Sized>(val: &T) -> &mut T {
-    (val as *const T as *mut T).as_mut().unwrap_unchecked()
+    Some(unresolved_schemas.into_iter())
 }
 
 #[cfg(test)]
@@ -263,10 +237,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -293,10 +270,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -311,10 +291,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -328,12 +311,12 @@ mod tests {
         let resolved_schema: ResolvedSchema = schema.try_into().unwrap();
 
         let foo = resolved_schema.get_type("foo").unwrap();
-        foo.as_ref().walk(&mut |tr: &TypeReference| {
+        foo.as_ref().clone().walk(&mut |tr: &mut TypeReference| {
             assert_eq!(Some(TypeCoordinates(0, 1)), tr.type_coordinates())
         });
 
         let bar = resolved_schema.get_type("bar").unwrap();
-        bar.as_ref().walk(&mut |tr: &TypeReference| {
+        bar.as_ref().clone().walk(&mut |tr: &mut TypeReference| {
             assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
         });
     }
@@ -362,10 +345,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(1, 1)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(1, 1)), tr.type_coordinates())
+                })
         });
     }
 
@@ -392,10 +378,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -422,10 +411,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -456,10 +448,13 @@ mod tests {
         );
 
         let resolved = resolve(schemas).unwrap();
-        resolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| {
-                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
-            })
+        resolved.into_iter().for_each(|(_, schema)| {
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| {
+                    assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+                })
         });
     }
 
@@ -469,12 +464,12 @@ mod tests {
         schemas.insert("foo.isl".to_string(), foo_schema());
         schemas.insert("bar.isl".to_string(), bar_schema());
         let original = schemas.clone();
-        let unresolved = unresolve(resolve(schemas).unwrap()).unwrap();
+        let unresolved = unresolve(resolve(schemas).unwrap()).unwrap().collect();
         assert_eq!(original, unresolved);
 
         // Check that all type coordinates have been cleared
-        unresolved.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| assert!(tr.type_coordinates().is_none()))
+        unresolved.into_iter().for_each(|(_, mut schema)| {
+            schema.walk(&mut |tr: &mut TypeReference| assert!(tr.type_coordinates().is_none()))
         });
     }
 
@@ -485,19 +480,22 @@ mod tests {
         schemas.insert("bar.isl".to_string(), bar_schema());
 
         let original = schemas.clone();
-        let resolved = resolve(schemas).unwrap();
+        let resolved: HashMap<_, _> = resolve(schemas).unwrap().collect();
 
-        let resolved_clone: HashMap<String, ResolvedSchema> = resolved.clone();
+        let resolved_clone = resolved.clone();
 
         let unresolved = unresolve(resolved);
         assert!(unresolved.is_none());
 
         // Check that type coordinates have not been cleared
         resolved_clone.iter().for_each(|(_, schema)| {
-            schema.walk(&mut |tr: &TypeReference| assert!(tr.type_coordinates().is_some()))
+            schema
+                .as_schema_document()
+                .clone()
+                .walk(&mut |tr: &mut TypeReference| assert!(tr.type_coordinates().is_some()))
         });
 
-        let unresolved = unresolve(resolved_clone).unwrap();
+        let unresolved = unresolve(resolved_clone).unwrap().collect();
         assert_eq!(original, unresolved);
     }
 

--- a/ion-schema/src/resolver/resolve_fn.rs
+++ b/ion-schema/src/resolver/resolve_fn.rs
@@ -1,0 +1,563 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) use super::*;
+use crate::model::{SchemaDocument, TypeReference};
+use crate::result::{
+    invalid_schema_error, invalid_schema_error_raw, unresolvable_schema_error_raw, IonSchemaResult,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Private type aliases
+type Map<K, V> = HashMap<K, V>;
+type CoordinatesMap<'a> = Map<&'a str, TypeCoordinates>;
+type SchemaSlice = [(String, SchemaDocument)];
+
+/// Builds a lookup table for the type coordinates of all types declared in all schemas.
+fn build_global_coordinates(schemas: &SchemaSlice) -> Map<&str, CoordinatesMap> {
+    schemas
+        .iter()
+        .enumerate()
+        .map(|(schema_idx, (schema_id, _))| {
+            (
+                schema_id.as_str(),
+                build_locally_declared_coordinates(schema_idx, schemas),
+            )
+        })
+        .collect()
+}
+
+/// Builds a lookup table for the type coordinates of all locally declared types
+fn build_locally_declared_coordinates(
+    schema_idx: usize,
+    schemas: &SchemaSlice,
+) -> Map<&str, TypeCoordinates> {
+    let (_, schema_doc) = &schemas[schema_idx];
+    schema_doc
+        .indexed_type_names()
+        .map(|(type_idx, type_name)| (type_name.as_str(), TypeCoordinates(schema_idx, type_idx)))
+        .collect()
+}
+
+/// Builds a lookup table for the type coordinates of all types that are visible _within_ the schema
+/// specified by [`schema_idx`]
+fn build_locally_available_coordinates<'a>(
+    global_coordinates: &'a Map<&'a str, CoordinatesMap<'a>>,
+    schema_idx: usize,
+    schemas: &'a SchemaSlice,
+) -> IonSchemaResult<Map<&'a str, TypeCoordinates>> {
+    let mut coordinates = build_locally_declared_coordinates(schema_idx, schemas);
+    let (schema_name, schema_doc) = &schemas[schema_idx];
+    let Some(header) = schema_doc.header() else {
+        return Ok(coordinates);
+    };
+
+    for import in header.imports() {
+        let imported_schema_name = import.schema_id();
+        if let Some(type_name) = import.type_name() {
+            let tc = global_coordinates
+                .get(&imported_schema_name)
+                .ok_or_else(|| {
+                    unresolvable_schema_error_raw(format!(
+                        "Cannot resolve schema '{imported_schema_name}'. Was it loaded?",
+                    ))
+                })?
+                .get(type_name)
+                .ok_or_else(|| {
+                    invalid_schema_error_raw(format!(
+                        "Type '{type_name}' in '{imported_schema_name}' does not exist."
+                    ))
+                })?;
+            let local_name = if let Some(alias) = import.type_alias() {
+                alias
+            } else {
+                type_name
+            };
+            if coordinates.insert(local_name, *tc).is_some() {
+                invalid_schema_error(format!("name conflict for type '{local_name}' imported from '{imported_schema_name}' in schema '{schema_name}'"))?;
+            }
+        } else {
+            let imported_types = global_coordinates
+                .get(&imported_schema_name)
+                // This can only happen if people are manually constructing schemas because the
+                // loader ensures that all imported schemas are present.
+                .ok_or_else(|| {
+                    unresolvable_schema_error_raw(format!(
+                        "Cannot resolve schema '{imported_schema_name}'. Was it loaded?"
+                    ))
+                })?;
+
+            for (local_name, tc) in imported_types.iter() {
+                if let Some(name_conflict) = coordinates.insert(local_name, *tc) {
+                    let (conflict_schema_name, _) = &schemas[name_conflict.0];
+                    invalid_schema_error(format!("name conflict in schema '{schema_name}' for type '{local_name}' declared in '{imported_schema_name}' and '{conflict_schema_name}'"))?;
+                }
+            }
+        }
+    }
+
+    Ok(coordinates)
+}
+
+/// Attempts to resolve the type references in one or more [`SchemaDocument`]s, returning an
+/// equivalent map containing [`ResolvedSchema`]s rather than [`SchemaDocument`]s.
+pub fn resolve(
+    schemas: HashMap<String, SchemaDocument>,
+) -> IonSchemaResult<HashMap<String, ResolvedSchema>> {
+    if schemas.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut schemas: Vec<_> = schemas.into_iter().collect();
+
+    if cfg!(test) {
+        // This is not necessary for correctness. It just ensures that the type coordinates are stable
+        // so that we can write tests for them.
+        schemas.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
+    }
+
+    let schema_idx_by_name: HashMap<_, _> = schemas
+        .iter()
+        .enumerate()
+        .map(|(idx, (name, _))| (name.clone(), idx))
+        .collect();
+
+    let global_type_coordinates = build_global_coordinates(schemas.as_slice());
+
+    let mut type_resolution_errors = vec![];
+
+    for (schema_idx, (schema_name, schema)) in schemas.iter().enumerate() {
+        let local_type_coordinates =
+            build_locally_available_coordinates(&global_type_coordinates, schema_idx, &schemas)?;
+
+        schema.walk(&mut |tr: &TypeReference| {
+            let type_name = tr.type_name();
+            let type_ref_coordinates = if let Some(imported_schema_id) = tr.schema_id() {
+                global_type_coordinates
+                    .get(imported_schema_id)
+                    .ok_or_else(|| {
+                        unresolvable_schema_error_raw(format!(
+                            "Cannot resolve schema '{imported_schema_id}'. Was it loaded?"
+                        ))
+                    })
+                    .and_then(|ok| {
+                        ok.get(type_name).ok_or_else(|| {
+                            invalid_schema_error_raw(format!(
+                                "No type '{type_name}' exists in '{imported_schema_id}'."
+                            ))
+                        })
+                    })
+                    .copied()
+            } else {
+                local_type_coordinates
+                    .get(type_name)
+                    .ok_or_else(|| {
+                        unresolvable_schema_error_raw(format!(
+                            "No type '{type_name}' exists in '{schema_name}'"
+                        ))
+                    })
+                    .copied()
+            };
+            match type_ref_coordinates {
+                Ok(tc) => {
+                    // SAFETY: This is safe because
+                    //  * All the data is fully owned within this function while this happens
+                    //  * We know there is no concurrent access to this
+                    //
+                    // we know that there is no concurrent access to the type references.
+                    //
+                    // This is necessary because
+                    //  * We can't just use `&mut TypeReference` because we run into conflicting borrows
+                    //    because the loop would have to iterate over mutable references, but the global
+                    //    and local coordinate maps require an immutable borrow at the same time in order
+                    //    to borrow the schema and type names.
+                    //  * The solution is interior mutability, but we don't want type references to use
+                    //    Cell because then they are not Sync, and we don't want to use Mutex because
+                    //    TypeReferences are in the hot path for validation.
+                    //  * Thankfully, we don't need the TypeReferences to have interior mutability all
+                    //    the time. It's only necessary for resolving (and un-resolving) the type references.
+                    //  * So instead, we just have a limited scope for treating this as immutable.
+                    //
+                    // We could also work around this by creating a "WhileBeingResolvedSchema" that
+                    // uses `Cell` to hold `TypeDefinition`s, but that's a lot of boilerplate code.
+                    unsafe { as_mutable(tr).resolve_type_coordinates(Some(tc)) }
+                }
+                Err(e) => type_resolution_errors.push(e),
+            }
+        });
+    }
+
+    if !type_resolution_errors.is_empty() {
+        // TODO: Report multiple errors
+        IonSchemaResult::Err(type_resolution_errors.into_iter().next().unwrap())?;
+    }
+
+    let schemas = schemas.into_iter().collect();
+
+    let schema_store = Arc::new(SchemaStore { schemas });
+
+    Ok(schema_idx_by_name
+        .into_iter()
+        .map(|(name, index)| (name, ResolvedSchema::new(schema_store.clone(), index)))
+        .collect())
+}
+
+/// Un-resolves the schemas and returns ownership of the underlying [`SchemaDocument`]s to the caller,
+/// in a map of `schema_id` to `SchemaDocument`.
+///
+/// If there are any un-dropped `ResolvedSchema` or `ResolvedType` that depend on the underlying
+/// `SchemaDocument`s that are _not_ passed into this function, the function will return `None`.
+pub fn unresolve(
+    schemas: HashMap<String, ResolvedSchema>,
+) -> Option<HashMap<String, SchemaDocument>> {
+    if schemas.is_empty() {
+        return Some(HashMap::new());
+    }
+
+    let (_, any_resolved_schema) = schemas.iter().next().unwrap();
+    let schema_store = any_resolved_schema.schema_store();
+
+    drop(schemas);
+
+    let unresolved_schemas = Arc::into_inner(schema_store)?
+        .schemas
+        .into_iter()
+        .map(|(name, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                // SAFETY: See note in [`resolve`]. Justification is the same.
+                unsafe { as_mutable(tr).resolve_type_coordinates(None) }
+            });
+            (name, schema)
+        })
+        .collect();
+    Some(unresolved_schemas)
+}
+
+/// Cast an immutable reference to a mutable reference.
+#[allow(clippy::mut_from_ref)]
+unsafe fn as_mutable<T: ?Sized>(val: &T) -> &mut T {
+    (val as *const T as *mut T).as_mut().unwrap_unchecked()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::constraints::FieldsContent;
+    use crate::model::*;
+    use crate::resolver::{resolve, unresolve, ResolvedSchema, TypeCoordinates, TypeRefWalker};
+    use crate::{ISL_1_0, ISL_2_0};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_resolve_local_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder().type_constraint("foo").build(),
+                )
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_nested_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder()
+                        .element(
+                            TypeDefinition::builder()
+                                .one_of([TypeDefinition::builder()
+                                    .fields(FieldsContent::Open, [("field", "foo".required())])
+                                    .build()])
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_self_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("foo", TypeDefinition::builder().element("foo").build())
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_circular_reference() {
+        let schema = SchemaDocument::builder::<ISL_2_0>()
+            .type_definition("foo", TypeDefinition::builder().element("bar").build())
+            .type_definition("bar", TypeDefinition::builder().element("foo").build())
+            .build();
+
+        let resolved_schema: ResolvedSchema = schema.try_into().unwrap();
+
+        let foo = resolved_schema.get_type("foo").unwrap();
+        foo.as_ref().walk(&mut |tr: &TypeReference| {
+            assert_eq!(Some(TypeCoordinates(0, 1)), tr.type_coordinates())
+        });
+
+        let bar = resolved_schema.get_type("bar").unwrap();
+        bar.as_ref().walk(&mut |tr: &TypeReference| {
+            assert_eq!(Some(TypeCoordinates(0, 0)), tr.type_coordinates())
+        });
+    }
+
+    #[test]
+    fn test_resolve_inline_import_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder()
+                        .type_constraint(TypeReference::imported("bbb.isl", "bar"))
+                        .build(),
+                )
+                .build(),
+        );
+        schemas.insert(
+            "bbb.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition("bar", TypeDefinition::builder().build())
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(1, 1)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_schema_imported_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .header(SchemaHeader::builder().import("bbb.isl").build())
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder().type_constraint("baz").build(),
+                )
+                .build(),
+        );
+        schemas.insert(
+            "bbb.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("baz", TypeDefinition::builder().build())
+                .type_definition("bat", TypeDefinition::builder().build())
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_schema_type_imported_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .header(SchemaHeader::builder().import(("bbb.isl", "baz")).build())
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder().type_constraint("baz").build(),
+                )
+                .build(),
+        );
+        schemas.insert(
+            "bbb.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("baz", TypeDefinition::builder().build())
+                .type_definition("bat", TypeDefinition::builder().build())
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_resolve_schema_type_alias_imported_reference() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "aaa.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .header(
+                    SchemaHeader::builder()
+                        .import(("bbb.isl", "baz", "pizza"))
+                        .build(),
+                )
+                .type_definition("foo", TypeDefinition::builder().build())
+                .type_definition(
+                    "bar",
+                    TypeDefinition::builder().type_constraint("pizza").build(),
+                )
+                .build(),
+        );
+        schemas.insert(
+            "bbb.isl".to_string(),
+            SchemaDocument::builder::<ISL_2_0>()
+                .type_definition("baz", TypeDefinition::builder().build())
+                .type_definition("bat", TypeDefinition::builder().build())
+                .build(),
+        );
+
+        let resolved = resolve(schemas).unwrap();
+        resolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| {
+                assert_eq!(Some(TypeCoordinates(1, 0)), tr.type_coordinates())
+            })
+        });
+    }
+
+    #[test]
+    fn test_unresolve() {
+        let mut schemas = HashMap::new();
+        schemas.insert("foo.isl".to_string(), foo_schema());
+        schemas.insert("bar.isl".to_string(), bar_schema());
+        let original = schemas.clone();
+        let unresolved = unresolve(resolve(schemas).unwrap()).unwrap();
+        assert_eq!(original, unresolved);
+
+        // Check that all type coordinates have been cleared
+        unresolved.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| assert!(tr.type_coordinates().is_none()))
+        });
+    }
+
+    #[test]
+    fn test_unresolve_does_not_return_schemas_until_all_are_unresolved() {
+        let mut schemas = HashMap::new();
+        schemas.insert("foo.isl".to_string(), foo_schema());
+        schemas.insert("bar.isl".to_string(), bar_schema());
+
+        let original = schemas.clone();
+        let resolved = resolve(schemas).unwrap();
+
+        let resolved_clone: HashMap<String, ResolvedSchema> = resolved.clone();
+
+        let unresolved = unresolve(resolved);
+        assert!(unresolved.is_none());
+
+        // Check that type coordinates have not been cleared
+        resolved_clone.iter().for_each(|(_, schema)| {
+            schema.walk(&mut |tr: &TypeReference| assert!(tr.type_coordinates().is_some()))
+        });
+
+        let unresolved = unresolve(resolved_clone).unwrap();
+        assert_eq!(original, unresolved);
+    }
+
+    // Test Fixtures
+
+    fn foo_schema() -> SchemaDocument {
+        SchemaDocument::builder::<ISL_2_0>()
+            .header(SchemaHeader::builder().import("bar.isl").build())
+            .type_definition(
+                "TypeA",
+                TypeDefinition::builder()
+                    .not("TypeB")
+                    .type_constraint("TypeC")
+                    .build(),
+            )
+            .type_definition(
+                "TypeB",
+                TypeDefinition::builder().container_length(1..10).build(),
+            )
+            .type_definition(
+                "TypeC",
+                TypeDefinition::builder()
+                    .any_of((
+                        "TypeB",
+                        TypeReference::imported("bar.isl", "TypeE"),
+                        "TypeF",
+                    ))
+                    .build(),
+            )
+            .build()
+    }
+
+    fn bar_schema() -> SchemaDocument {
+        SchemaDocument::builder::<ISL_1_0>()
+            .header(
+                SchemaHeader::builder()
+                    .import(("foo.isl", "TypeB"))
+                    .import(("foo.isl", "TypeC", "AliasC"))
+                    .import(("foo.isl", "TypeA", "TypeC"))
+                    .build(),
+            )
+            .type_definition(
+                "TypeD",
+                TypeDefinition::builder()
+                    .any_of(("TypeB", "AliasC", "TypeC"))
+                    .build(),
+            )
+            .type_definition(
+                "TypeE",
+                TypeDefinition::builder()
+                    .precision(1..10)
+                    .scale(1..10)
+                    .build(),
+            )
+            .type_definition(
+                "TypeF",
+                TypeDefinition::builder()
+                    .not(TypeReference::imported("foo.isl", "TypeA"))
+                    .build(),
+            )
+            .build()
+    }
+}

--- a/ion-schema/src/resolver/resolved_schema.rs
+++ b/ion-schema/src/resolver/resolved_schema.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::model::{SchemaDocument, TypeDefinition};
-use crate::resolver::{impl_type_ref_walker, SchemaStore};
+use crate::resolver::SchemaStore;
 use crate::resolver::{resolve, unresolve};
 use crate::result::IonSchemaError;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Represents a [`SchemaDocument`] that has had all of its type references successfully resolved
@@ -37,7 +36,6 @@ pub struct ResolvedSchema {
     schema_store: Arc<SchemaStore>,
     schema_index: usize,
 }
-impl_type_ref_walker!(ResolvedSchema, as_schema_document());
 
 impl ResolvedSchema {
     /// Constructs a [`ResolvedSchema`] backed by the given [`SchemaStore`].
@@ -76,10 +74,8 @@ impl ResolvedSchema {
     ///
     /// To get an owned copy of the [`SchemaDocument`] for just this schema, you can alternately
     /// use `self.as_schema_document().clone()`.
-    pub fn unresolve(self) -> Option<HashMap<String, SchemaDocument>> {
-        let mut map = HashMap::new();
-        map.insert("".to_string(), self);
-        unresolve(map)
+    pub fn unresolve(self) -> Option<impl Iterator<Item = (String, SchemaDocument)>> {
+        unresolve([("".to_owned(), self)])
     }
 }
 
@@ -87,11 +83,8 @@ impl ResolvedSchema {
 impl TryFrom<SchemaDocument> for ResolvedSchema {
     type Error = IonSchemaError;
     fn try_from(value: SchemaDocument) -> Result<Self, Self::Error> {
-        let key = "".to_string();
-        let mut map = HashMap::new();
-        map.insert(key.clone(), value);
-        let mut resolved = resolve(map)?;
-        Ok(resolved.remove(&key).unwrap())
+        let mut resolved = resolve([("".to_owned(), value)])?;
+        Ok(resolved.next().unwrap().1)
     }
 }
 

--- a/ion-schema/src/resolver/resolved_schema.rs
+++ b/ion-schema/src/resolver/resolved_schema.rs
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::model::{SchemaDocument, TypeDefinition};
+use crate::resolver::{impl_type_ref_walker, SchemaStore};
+use crate::resolver::{resolve, unresolve};
+use crate::result::IonSchemaError;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Represents a [`SchemaDocument`] that has had all of its type references successfully resolved
+/// and linked to their target types. From a [`ResolvedSchema`], you can get a [`ResolvedType`],
+/// which can be used to perform data validation.
+///
+/// ### Example:
+/// ```
+/// # use ion_schema::result::IonSchemaResult;
+/// use ion_schema::ISL_2_0;
+/// use ion_schema::model::{SchemaDocument, TypeDefinition};
+/// use ion_schema::resolver::ResolvedSchema;
+///
+/// # fn foo() -> IonSchemaResult<()> {
+/// let schema = SchemaDocument::builder::<ISL_2_0>()
+///     .type_definition("short_string", TypeDefinition::builder()
+///         .codepoint_length(0..10)
+///         .build())
+///     .build();
+///
+/// let resolved_schema: ResolvedSchema = schema.try_into()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// For resolving schemas with dependencies on other schemas, see [`resolve`](crate::resolve).
+#[derive(Debug, Clone)]
+pub struct ResolvedSchema {
+    schema_store: Arc<SchemaStore>,
+    schema_index: usize,
+}
+impl_type_ref_walker!(ResolvedSchema, as_schema_document());
+
+impl ResolvedSchema {
+    /// Constructs a [`ResolvedSchema`] backed by the given [`SchemaStore`].
+    pub(super) fn new(schema_store: Arc<SchemaStore>, schema_index: usize) -> Self {
+        Self {
+            schema_store,
+            schema_index,
+        }
+    }
+
+    /// Returns the [`SchemaStore`] that backs this [`ResolvedSchema`].
+    pub(super) fn schema_store(&self) -> Arc<SchemaStore> {
+        self.schema_store.clone()
+    }
+
+    /// Gets a [`ResolvedType`] from this schema.
+    pub fn get_type(&self, type_name: &str) -> Option<ResolvedType> {
+        let schema = self.schema_store.get_schema(self.schema_index);
+        let type_index = schema.get_type_idx_by_name(type_name)?;
+        Some(ResolvedType {
+            resolved_schema: self,
+            type_index,
+        })
+    }
+
+    /// Immutably borrows the [`SchemaDocument`] that backs this [`ResolvedSchema`].
+    pub fn as_schema_document(&self) -> &SchemaDocument {
+        self.schema_store.get_schema(self.schema_index)
+    }
+
+    /// Consumes this [`ResolvedSchema`], and attempts to return the [`SchemaDocument`]s for this
+    /// schema and all of its dependencies.
+    ///
+    /// If all other [`ResolvedSchema`] that were resolved in the same batch have been dropped,
+    /// returns all the schemas that were used in resolving this schema. Otherwise, returns `None`.
+    ///
+    /// To get an owned copy of the [`SchemaDocument`] for just this schema, you can alternately
+    /// use `self.as_schema_document().clone()`.
+    pub fn unresolve(self) -> Option<HashMap<String, SchemaDocument>> {
+        let mut map = HashMap::new();
+        map.insert("".to_string(), self);
+        unresolve(map)
+    }
+}
+
+// Implementation of TryFrom that wraps the `resolve` function.
+impl TryFrom<SchemaDocument> for ResolvedSchema {
+    type Error = IonSchemaError;
+    fn try_from(value: SchemaDocument) -> Result<Self, Self::Error> {
+        let key = "".to_string();
+        let mut map = HashMap::new();
+        map.insert(key.clone(), value);
+        let mut resolved = resolve(map)?;
+        Ok(resolved.remove(&key).unwrap())
+    }
+}
+
+impl AsRef<SchemaDocument> for ResolvedSchema {
+    fn as_ref(&self) -> &SchemaDocument {
+        self.as_schema_document()
+    }
+}
+
+/// A representation of a [`TypeDefinition`] that can be used for validation.
+#[derive(Clone, Copy, Debug)]
+pub struct ResolvedType<'schema> {
+    resolved_schema: &'schema ResolvedSchema,
+    type_index: usize,
+}
+
+impl ResolvedType<'_> {
+    // TODO: validate functions
+}
+
+impl AsRef<TypeDefinition> for ResolvedType<'_> {
+    fn as_ref(&self) -> &TypeDefinition {
+        self.resolved_schema
+            .as_schema_document()
+            .get_type_by_idx(self.type_index)
+            .unwrap()
+    }
+}

--- a/ion-schema/src/resolver/type_ref_visitor.rs
+++ b/ion-schema/src/resolver/type_ref_visitor.rs
@@ -8,26 +8,26 @@ use std::collections::HashMap;
 /// A visitor for [`TypeReference`]s in a [`SchemaDocument`], used for resolving schema references.
 pub(crate) trait TypeRefVisitor {
     /// Visits a single [`TypeReference`].
-    fn visit(&mut self, type_ref: &TypeReference);
+    fn visit(&mut self, type_ref: &mut TypeReference);
 }
 
-impl<F: FnMut(&TypeReference)> TypeRefVisitor for F {
-    fn visit(&mut self, type_ref: &TypeReference) {
+impl<F: FnMut(&mut TypeReference)> TypeRefVisitor for F {
+    fn visit(&mut self, type_ref: &mut TypeReference) {
         self(type_ref)
     }
 }
 
 /// A trait indicating that a type can walk a [`TypeRefVisitor`], possibly to [`TypeReferences`].
 pub(crate) trait TypeRefWalker {
-    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V);
+    fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V);
 }
 
 /// A macro that implements [`TypeRefWalker`] for container types that have an `iter()` method.
 macro_rules! has_n_type_refs {
     ($t:ident) => {
         impl<T: TypeRefWalker> TypeRefWalker for $t<T> {
-            fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
-                self.iter().for_each(|item| item.walk(visitor))
+            fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
+                self.iter_mut().for_each(|item| item.walk(visitor))
             }
         }
     };
@@ -36,15 +36,15 @@ has_n_type_refs!(Vec);
 has_n_type_refs!(Bag);
 has_n_type_refs!(Option);
 
-impl<T: TypeRefWalker> TypeRefWalker for &T {
-    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
+impl<T: TypeRefWalker> TypeRefWalker for &mut T {
+    fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
         <T as TypeRefWalker>::walk(self, visitor)
     }
 }
 
 impl<K, T: TypeRefWalker> TypeRefWalker for HashMap<K, T> {
-    fn walk<V: TypeRefVisitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|(_, item)| item.walk(visitor))
+    fn walk<V: TypeRefVisitor>(&mut self, visitor: &mut V) {
+        self.iter_mut().for_each(|(_, item)| item.walk(visitor))
     }
 }
 
@@ -54,13 +54,13 @@ impl<K, T: TypeRefWalker> TypeRefWalker for HashMap<K, T> {
 macro_rules! impl_type_ref_walker {
     ($t:ty) => {
         impl crate::resolver::TypeRefWalker for $t {
-            fn walk<V: crate::resolver::TypeRefVisitor>(&self, visitor: &mut V) {
+            fn walk<V: crate::resolver::TypeRefVisitor>(&mut self, visitor: &mut V) {
             }
         }
     };
     ($t:ty, $($accessor:tt)+) => {
         impl crate::resolver::TypeRefWalker for $t {
-            fn walk<V: crate::resolver::TypeRefVisitor>(&self, visitor: &mut V) {
+            fn walk<V: crate::resolver::TypeRefVisitor>(&mut self, visitor: &mut V) {
                 self.$($accessor)+.walk(visitor);
             }
         }

--- a/ion-schema/src/result.rs
+++ b/ion-schema/src/result.rs
@@ -17,6 +17,8 @@ pub type ValidationResult = Result<(), Violation>;
 /// Represents the different types of high-level failures that might occur when reading Ion Schema.
 #[derive(Debug, Error)]
 pub enum IonSchemaError {
+    // TODO: Add support for multiple errors (i.e. more than one resolution failure and/or invalid syntax)
+    //       Consider using Miette (https://crates.io/crates/miette) for formatting the list of errors.
     /// Indicates that an io error occurred while loading a schema
     #[error("{source:?}")]
     IoError {


### PR DESCRIPTION
### Issue #, if available:

#228 

### Description of changes:

* The key piece is the `resolve` function to resolve type references.
* Also adds `ResolvedSchema`, `ResolvedType`.
* Incidental changes to `SchemaDocument` and `Import`.

See 🪧 comments for details.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
