### PR TITLE
Update ion-rs dependency to support arbitrary-sized numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,8 @@ members = [
     "ion-schema-tests-runner",
     "wasm-schema-sandbox",
 ]
+
+resolver = "2"
+
+[workspace.dependencies]
+ion-rs = { version = "1.0.0-rc.12", features = ["experimental-reader-writer"] }

--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,8 +9,8 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.10"}
 ion-schema = { path = "../ion-schema" }
+ion-rs = { workspace = true }
 quote = "1.0.21"
 syn = "1.0.102"
 proc-macro2 = "1.0.47"

--- a/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
@@ -3,18 +3,13 @@ use ion_schema_tests_runner::ion_schema_tests;
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_1_0/",
     ignored(
-        "constraints::occurs::invalid::occurs_for_a_field_must_be_a_positive_integer_or_a_non_empty__non_negative_integer_range__0_",
-        "constraints::occurs::invalid::occurs_for_a_field_must_be_a_positive_integer_or_a_non_empty__non_negative_integer_range__1_",
         "constraints::occurs::invalid::occurs_for_a_field_must_be_a_positive_integer_or_a_non_empty__non_negative_integer_range__6_",
         "constraints::occurs::invalid::occurs_for_a_field_must_be_a_positive_integer_or_a_non_empty__non_negative_integer_range__7_",
         "constraints::occurs::invalid::occurs_must_be_a_positive_integer_or_non_empty__non_negative_integer_range__06_",
         "constraints::occurs::invalid::occurs_range_must_be_a_valid__satisfiable_range__1_",
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__04_",
-        "constraints::valid_values::all_types::value_should_be_invalid_for_type_valid_values_all_types__04_",
         "nullable::*",
         "schema::import::cycles::*",
-        "schema::import::diamond_import::should_be_a_valid_schema",
-        "schema::import::diamond_import::value_should_be_valid_for_type_diamond_import",
         "schema::import::import::value_should_be_(valid|invalid)_for_type",
         "schema::import::import_inline::.*",
         "schema::import::import_type_unknown::attempting_to_import_an_unknown_type_should_result_in_an_error",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -3,8 +3,20 @@ use ion_schema_tests_runner::ion_schema_tests;
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
     ignored(
-        // Not fully implemented yet.
-        "imports",
+        // Cycle detection not fully implemented yet.
+        "imports::cycles.*",
+        "imports::self_import.*",
+        // Error cases not fully validated yet.
+        "imports::header_imports::Importing_a_type_with_the_same_name_or_alias_as_locally_defined_type_should_result_in_an_error.*",
+        "imports::header_imports::Two_different_imported_types_with_the_same_name_or_alias_should_result_in_an_error.*",
+        "imports::invalid_imports::header_imports_may_not_have_unexpected_fields.*",
+        "imports::invalid_imports::imports_may_not_have_unexpected_annotations.*",
+        "imports::invalid_imports::imports_field_may_occur_at_most_one_time_in_the_schema_header.*",
+        "imports::invalid_imports::imports_field_must_be_a_non_null_list.*",
+        "imports::invalid_imports::imports_may_not_have_repeated_field_names.*",
+        "imports::invalid_imports::inline_imports_must_have_exactly_one_each_of__id__and__type__fields_and_nothing_else__0_",
+        "imports::invalid_imports::when_imported_schema_or_type_does_not_exist__should_be_an_invalid_schema__1_",
+        "imports::invalid_imports::when_imported_schema_or_type_does_not_exist__should_be_an_invalid_schema__3_",
         // Failing because of https://github.com/amazon-ion/ion-rust/issues/399
         "constraints::regex::value_should_be_invalid_for_type_regex_unescaped_newline__2_",
     )

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.10", features = ["experimental-reader-writer"] }
+ion-rs = { workspace = true }
 thiserror = "1.0"
 num-traits = "0.2"
 regex = "1.5.6"

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1139,7 +1139,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
         let size = if let Some(element_iter) = value.as_sequence_iter() {
             element_iter.count()
         } else if let Some(strukt) = value.as_struct() {
-            strukt.fields().map(|(k, v)| v).count()
+            strukt.fields().count()
         } else {
             return Err(Violation::new(
                 "container_length",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1986,10 +1986,8 @@ impl RegexConstraint {
         while let Some(ch) = si.next() {
             sb.push(ch);
             match ch {
-                '&' => {
-                    if si.peek() == Some(&'&') {
-                        return invalid_schema_error("'&&' is not supported in a character class");
-                    }
+                '&' if si.peek() == Some(&'&') => {
+                    return invalid_schema_error("'&&' is not supported in a character class");
                 }
                 '[' => return invalid_schema_error("'[' must be escaped within a character class"),
                 '\\' => {

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -30,7 +30,6 @@ use regex::{Regex, RegexBuilder};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::iter::Peekable;
-use std::ops::Neg;
 use std::str::Chars;
 
 /// Provides validation for schema Constraint
@@ -1740,8 +1739,7 @@ impl ConstraintValidator for ExponentConstraint {
             .expect_element_of_type(&[IonType::Decimal], "exponent", ion_path)?
             .as_decimal()
             .unwrap()
-            .scale()
-            .neg();
+            .exponent();
 
         // get isl decimal exponent as a range
         let exponent_range: &I64Range = self.exponent();

--- a/ion-schema/src/ion_extension.rs
+++ b/ion-schema/src/ion_extension.rs
@@ -1,6 +1,5 @@
 use ion_rs::Decimal;
 use ion_rs::{Element, Value};
-use num_traits::ToPrimitive;
 
 /// Trait for adding extensions to [`Element`] that are useful for implementing Ion Schema.
 pub(crate) trait ElementExtensions {

--- a/ion-schema/src/ion_extension.rs
+++ b/ion-schema/src/ion_extension.rs
@@ -24,15 +24,15 @@ impl ElementExtensions for Element {
     }
     fn as_u64(&self) -> Option<u64> {
         match self.value() {
-            Value::Int(i) => i.as_i128()?.to_u64(),
+            Value::Int(i) => i.as_u64(),
             _ => None,
         }
     }
     fn any_number_as_decimal(&self) -> Option<Decimal> {
         match self.value() {
-            Value::Int(i) => Some((*i).into()),
+            Value::Int(i) => Some(i.clone().into()),
             Value::Float(f) => (*f).try_into().ok(),
-            Value::Decimal(d) => Some(*d),
+            Value::Decimal(d) => Some(d.clone()),
             _ => None,
         }
     }

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -517,10 +517,10 @@ impl IslConstraintValue {
                         IslAnnotationsConstraint::StandardAnnotations(type_reference),
                     ))
                 } else {
-                    return invalid_schema_error(format!(
+                    invalid_schema_error(format!(
                         "annotations constraint was a {:?} instead of a list",
                         value.ion_type()
-                    ));
+                    ))
                 }
             }
             "any_of" => {

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -1,4 +1,3 @@
-use crate::ion_extension::ElementExtensions;
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslType;
 use crate::isl::ranges::{Limit, UsizeRange};

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -3,16 +3,13 @@
 //! This module consists of three submodules that help constructing ISL types/constraint:
 //!
 //! * `isl_type` module represents a schema type [IslType] which converts given ion content in the schema file
-//! into an ISL types(not-yet-resolved types). It stores `IslConstraint`s defined within the given type.
-//!
+//!   into an ISL types(not-yet-resolved types). It stores `IslConstraint`s defined within the given type.
 //! * `isl_import` module represents a schema import [IslImport] which converts given ion content in the schema file
-//! into an ISL import. It stores schema id, an optional type that needs to be imported and an optional alias to that type.
-//!
+//!   into an ISL import. It stores schema id, an optional type that needs to be imported and an optional alias to that type.
 //! * `isl_constraint` module represents schema constraints [IslConstraint]
-//! which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
-//!
+//!   which converts given ion content in the schema file into an ISL constraint(not-yet-resolved constraints).
 //! * `isl_type_reference` module provides a schema type reference.
-//! The type reference grammar is defined in the [Ion Schema Specification]
+//!   The type reference grammar is defined in the [Ion Schema Specification]
 //!
 //! [IslConstraint]: isl_constraint::IslConstraint
 //! [Ion Schema Specification]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#grammar

--- a/ion-schema/src/isl/ranges.rs
+++ b/ion-schema/src/isl/ranges.rs
@@ -163,6 +163,8 @@ impl RangeValidation<TimestampPrecision> for TimestampPrecisionRange {
                 let end_value = upper.int_value();
 
                 // Checking for e.g. range::[exclusive::1, exclusive::2] which is empty.
+                // Integer overflow is not possible here because TimestampPrecision range boundaries
+                // have an i64 range of `-4 ..= 9`.
                 let adjusted_lower = start_value + 1;
                 adjusted_lower >= end_value
             }

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -6,7 +6,6 @@ use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
 use ion_rs::TimestampPrecision as Precision;
 use ion_rs::{Element, IonResult, Value, ValueWriter, WriteAsIon};
 use ion_rs::{IonType, Timestamp};
-use num_traits::abs;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -333,8 +332,9 @@ impl Display for TimestampOffset {
             Unknown => write!(f, "-00:00"),
             Known(offset) => {
                 let sign = if offset < &0 { "-" } else { "+" };
-                let hours = abs(*offset) / 60;
-                let minutes = abs(*offset) - hours * 60;
+                let abs_offset = offset.unsigned_abs();
+                let hours = abs_offset / 60;
+                let minutes = abs_offset - hours * 60;
                 write!(f, "{sign}{hours:02}:{minutes:02}")
             }
         }
@@ -346,8 +346,9 @@ impl WriteAsIon for TimestampOffset {
         match &self {
             TimestampOffset::Known(offset) => {
                 let sign = if offset < &0 { "-" } else { "+" };
-                let hours = abs(*offset) / 60;
-                let minutes = abs(*offset) - hours * 60;
+                let abs_offset = offset.unsigned_abs();
+                let hours = abs_offset / 60;
+                let minutes = abs_offset - hours * 60;
                 writer.write_string(format!("{sign}{hours:02}:{minutes:02}"))
             }
             TimestampOffset::Unknown => writer.write_string("-00:00"),

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -278,21 +278,6 @@ pub enum TimestampOffset {
     Unknown,    // represents unknown timestamp offset "-00:00"
 }
 
-impl TimestampOffset {
-    fn to_string(&self) -> String {
-        match &self {
-            Unknown => "-00:00".to_string(),
-            Known(offset) => {
-                let sign = if offset < &0 { "-" } else { "+" };
-                let abs_offset = offset.unsigned_abs();
-                let hours = abs_offset / 60;
-                let minutes = abs_offset - hours * 60;
-                format!("{sign}{hours:02}:{minutes:02}")
-            }
-        }
-    }
-}
-
 impl TryFrom<&str> for TimestampOffset {
     type Error = IonSchemaError;
 
@@ -343,7 +328,16 @@ impl From<Option<i32>> for TimestampOffset {
 
 impl Display for TimestampOffset {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        match &self {
+            Unknown => f.write_str("-00:00"),
+            Known(offset) => {
+                let sign = if offset < &0 { "-" } else { "+" };
+                let abs_offset = offset.unsigned_abs();
+                let hours = abs_offset / 60;
+                let minutes = abs_offset - hours * 60;
+                write!(f, "{sign}{hours:02}:{minutes:02}")
+            }
+        }
     }
 }
 

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -208,7 +208,7 @@ impl ValidValue {
         if element.annotations().contains("range") {
             isl_require!(annotation.len() == 1 => "Unexpected annotation(s) on valid values argument: {element}")?;
             // Does it contain any timestamps
-            let has_timestamp = element.as_sequence().map_or(false, |s| {
+            let has_timestamp = element.as_sequence().is_some_and(|s| {
                 s.elements().any(|it| it.ion_type() == IonType::Timestamp)
             });
             let range = if has_timestamp {

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -9,6 +9,7 @@ use ion_rs::{IonType, Timestamp};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use crate::isl::util::TimestampOffset::{Known, Unknown};
 
 /// Represents an annotation for `annotations` constraint.
 /// ```ion
@@ -277,6 +278,21 @@ pub enum TimestampOffset {
     Unknown,    // represents unknown timestamp offset "-00:00"
 }
 
+impl TimestampOffset {
+    fn to_string(&self) -> String {
+        match &self {
+            Unknown => "-00:00".to_string(),
+            Known(offset) => {
+                let sign = if offset < &0 { "-" } else { "+" };
+                let abs_offset = offset.unsigned_abs();
+                let hours = abs_offset / 60;
+                let minutes = abs_offset - hours * 60;
+                format!("{sign}{hours:02}:{minutes:02}")
+            }
+        }
+    }
+}
+
 impl TryFrom<&str> for TimestampOffset {
     type Error = IonSchemaError;
 
@@ -327,32 +343,13 @@ impl From<Option<i32>> for TimestampOffset {
 
 impl Display for TimestampOffset {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use TimestampOffset::*;
-        match &self {
-            Unknown => write!(f, "-00:00"),
-            Known(offset) => {
-                let sign = if offset < &0 { "-" } else { "+" };
-                let abs_offset = offset.unsigned_abs();
-                let hours = abs_offset / 60;
-                let minutes = abs_offset - hours * 60;
-                write!(f, "{sign}{hours:02}:{minutes:02}")
-            }
-        }
+        f.write_str(&self.to_string())
     }
 }
 
 impl WriteAsIon for TimestampOffset {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
-        match &self {
-            TimestampOffset::Known(offset) => {
-                let sign = if offset < &0 { "-" } else { "+" };
-                let abs_offset = offset.unsigned_abs();
-                let hours = abs_offset / 60;
-                let minutes = abs_offset - hours * 60;
-                writer.write_string(format!("{sign}{hours:02}:{minutes:02}"))
-            }
-            TimestampOffset::Unknown => writer.write_string("-00:00"),
-        }
+        writer.write_string(self.to_string())
     }
 }
 

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -1,5 +1,6 @@
 use crate::ion_extension::ElementExtensions;
 use crate::isl::ranges::{NumberRange, TimestampRange};
+use crate::isl::util::TimestampOffset::{Known, Unknown};
 use crate::isl::IslVersion;
 use crate::isl_require;
 use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
@@ -9,7 +10,6 @@ use ion_rs::{IonType, Timestamp};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use crate::isl::util::TimestampOffset::{Known, Unknown};
 
 /// Represents an annotation for `annotations` constraint.
 /// ```ion
@@ -209,9 +209,9 @@ impl ValidValue {
         if element.annotations().contains("range") {
             isl_require!(annotation.len() == 1 => "Unexpected annotation(s) on valid values argument: {element}")?;
             // Does it contain any timestamps
-            let has_timestamp = element.as_sequence().is_some_and(|s| {
-                s.elements().any(|it| it.ion_type() == IonType::Timestamp)
-            });
+            let has_timestamp = element
+                .as_sequence()
+                .is_some_and(|s| s.elements().any(|it| it.ion_type() == IonType::Timestamp));
             let range = if has_timestamp {
                 ValidValue::TimestampRange(TimestampRange::from_ion_element(element, |e| {
                     e.as_timestamp()

--- a/ion-schema/src/ordered_elements_nfa.rs
+++ b/ion-schema/src/ordered_elements_nfa.rs
@@ -395,11 +395,11 @@ impl State {
                 }
             }
             State::Final(_) => {
-                if element.is_some() {
+                if let Some(el) = element {
                     Err(Violation::new(
                         "ordered_elements",
                         ViolationCode::ElementMismatched,
-                        format!("expected <END OF SEQUENCE>; found: {}", element.unwrap()),
+                        format!("expected <END OF SEQUENCE>; found: {}", el),
                         ion_path,
                     ))
                 } else {
@@ -422,6 +422,7 @@ impl Display for State {
 }
 
 /// The reason why a transition (or edge) in the state machine graph cannot be traversed.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 enum TraversalError {
     CannotEnterState(StateId, Violation),

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -3,6 +3,7 @@
 //!
 //! * `get_types`: This function returns an [`SchemaTypeIterator`] which can be used to iterate over the [`TypeDefinition`]s.
 //! * `get_type`: This function requires to pass the name of a type definition that you want to use for validation.
+//!
 //! It returns the [`TypeDefinition`] if it is defined in the [`Schema`] otherwise returns [`None`].
 //!
 

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 /// * A nested anonymous type definition.
 /// * A reference to type definition that is followed by current type definition. These type references
 ///   will be deferred to later check if a type definition with that name exists in the schema.
+///
 /// Because the [`SchemaSystem`] does not yet know the complete definition
 /// of these types, it cannot find them in the [`TypeStore`].
 /// An instance of [`PendingTypes`] is used to track information about types
@@ -85,13 +86,14 @@ impl PendingTypes {
     /// This method is used after a schema named type/root type is loaded entirely into [`PendingTypes`]
     /// * `type_store` - The TypeStore which will be updated with the types within this PendingType
     /// * `load_isl_import` - If this argument is Some(isl_import), then we are not within an import process of schema.
-    ///                       Based on given enum variant isl_import we will add the types to type_store.
-    ///                       Otherwise we will add all the types from this PendingTypes to TypeStore.
+    ///   Based on given enum variant isl_import we will add the types to type_store.
+    ///   Otherwise we will add all the types from this PendingTypes to TypeStore.
     /// * `isl_type_names` - The isl type names defined within the schema. This will be used to determine
-    ///                      if a type definition actually exists within the schema. If a type definition from this list
-    ///                      exists in [`PendingTypes`] it would have been added as a deferred type definition.
-    ///                      This deferred type will be loaded into [`TypeStore`] as it is and will be replaced with a type definition
-    ///                      once it is resolved.
+    ///   if a type definition actually exists within the schema. If a type definition from this list
+    ///   exists in [`PendingTypes`] it would have been added as a deferred type definition.
+    ///   This deferred type will be loaded into [`TypeStore`] as it is and will be replaced with a type definition
+    ///   once it is resolved.
+    ///
     /// Returns true, if this update is not for an isl import type or it is for an isl import type but it is added to the type_store
     /// Otherwise, returns false if this update is for an isl import type and it is not yet added to the type_store.
     pub fn update_type_store(
@@ -173,7 +175,7 @@ impl PendingTypes {
         import_type_name: &str,
         type_store: &mut TypeStore,
     ) -> Option<IonSchemaResult<TypeDefinitionImpl>> {
-        return match self.ids_by_name.get(import_type_name) {
+        match self.ids_by_name.get(import_type_name) {
             Some(id) => self.types_by_id[*id]
                 .to_owned()
                 .map(|type_def| match type_def {
@@ -211,7 +213,7 @@ impl PendingTypes {
                     None => None,
                 }
             }
-        };
+        }
     }
 
     // helper method to update type store with all the types from this PendingTypes

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -505,12 +505,8 @@ impl TypeDefinitionImpl {
 
         if let Some(type_name) = type_name {
             // update with this resolved type_def to context for type_id
-            actual_type_id = pending_types.update_named_type(
-                type_id,
-                type_name,
-                type_def,
-                type_store,
-            );
+            actual_type_id =
+                pending_types.update_named_type(type_id, type_name, type_def, type_store);
 
             // clear parent information from type_store as the type is already added in the type_store now
             pending_types.clear_parent();

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -503,11 +503,11 @@ impl TypeDefinitionImpl {
         // actual type id is the type id with respect to type store length
         let actual_type_id;
 
-        if type_name.is_some() {
+        if let Some(type_name) = type_name {
             // update with this resolved type_def to context for type_id
             actual_type_id = pending_types.update_named_type(
                 type_id,
-                type_name.as_ref().unwrap(),
+                type_name,
                 type_def,
                 type_store,
             );

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -210,10 +210,10 @@ macro_rules! assert_equivalent_violations {
     };
 }
 
-#[macro_export]
 
 /// Equivalence for `Violation`s is not supported due to its tree structure of having children violations.
 /// This macro can be used for comparing if two violations are not equal and uses `flattened_violations` for the comparison.
+#[macro_export]
 macro_rules! assert_non_equivalent_violations {
     ($left:expr, $right:expr $(,)?) => {
         let mut left_strings: Vec<String> = $left

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -210,7 +210,6 @@ macro_rules! assert_equivalent_violations {
     };
 }
 
-
 /// Equivalence for `Violation`s is not supported due to its tree structure of having children violations.
 /// This macro can be used for comparing if two violations are not equal and uses `flattened_violations` for the comparison.
 #[macro_export]

--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 js-sys = "0.3.61"
 ion-schema = { path="../ion-schema" }
-ion-rs = { version = "1.0.0-rc.10", features = ["experimental-reader-writer"] }
+ion-rs = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

Updates `ion-schema-rust` to use the latest version of `ion-rust`, which includes support for arbitrary precision integers and decimals. I've also updated the `ion-schema-tests` submodule to include tests that exercise very large numbers, and there are some drive-by code quality improvements, which are called out in the comments.




----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
